### PR TITLE
Switch AWS Auto Scaling Group support to match MNG style

### DIFF
--- a/pkg/cloudprovider/nodegroup/aws/autoscalinggroup_test.go
+++ b/pkg/cloudprovider/nodegroup/aws/autoscalinggroup_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
 )
 
 type mockedUpdateAutoScalingGroup struct {
@@ -37,8 +38,12 @@ func TestUpdateAutoScalingGroupSuccess(t *testing.T) {
 		Error: nil,
 	}
 	asg := &AutoScalingGroup{
-		Client:    client,
-		GroupName: "spatula",
+		Client: client,
+		ScalableNodeGroup: &v1alpha1.ScalableNodeGroup{
+			Spec: v1alpha1.ScalableNodeGroupSpec{
+				ID: "spatula",
+			},
+		},
 	}
 	err := asg.SetReplicas(23)
 	if err != nil {

--- a/pkg/cloudprovider/nodegroup/factory.go
+++ b/pkg/cloudprovider/nodegroup/factory.go
@@ -17,7 +17,7 @@ type Factory struct {
 func (f *Factory) For(sng *v1alpha1.ScalableNodeGroup) cloudprovider.NodeGroup {
 	switch sng.Spec.Type {
 	case v1alpha1.AWSEC2AutoScalingGroup:
-		return aws.NewDefaultAutoScalingGroup(sng.Spec.ID)
+		return aws.NewDefaultAutoScalingGroup(sng)
 	case v1alpha1.AWSEKSNodeGroup:
 		return aws.NewNodeGroup(sng)
 	}


### PR DESCRIPTION
This is just a quick check-in to bring about parity between ASG/MNG, before larger changes.