### PR TITLE
Informer improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ IMG ?= ${KO_DOCKER_REPO}/karpenter:latest
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+all: generate verify test ## Run all steps in the developer loop
+
 ci: generate verify battletest ## Run all steps used by continuous integration
 
 test: ## Run tests
@@ -59,4 +61,4 @@ release: ## Build and release a container image to $KO_DOCKER_REPO/karpenter
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh
 
-.PHONY: help all test release run apply delete verify generate toolchain
+.PHONY: help all ci test release run apply delete verify generate toolchain

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,8 +25,6 @@ spec:
       containers:
       - name: manager
         image: controller:latest
-        args:
-        - "--enable-leader-election"
         resources:
           limits:
             cpu: 100m

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/google/ko v0.6.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.10.0
 	go.uber.org/multierr v1.6.0

--- a/karpenter/main.go
+++ b/karpenter/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"time"
+	"fmt"
 
 	"github.com/ellistarn/karpenter/pkg/apis"
 	"github.com/ellistarn/karpenter/pkg/cloudprovider/nodegroup"
@@ -12,35 +12,23 @@ import (
 	horizontalautoscalerv1alpha1 "github.com/ellistarn/karpenter/pkg/controllers/horizontalautoscaler/v1alpha1"
 	metricsproducerv1alpha1 "github.com/ellistarn/karpenter/pkg/controllers/metricsproducer/v1alpha1"
 	scalablenodegroupv1alpha1 "github.com/ellistarn/karpenter/pkg/controllers/scalablenodegroup/v1alpha1"
-	"github.com/ellistarn/karpenter/pkg/metrics/clients"
 	metricsclients "github.com/ellistarn/karpenter/pkg/metrics/clients"
 	"github.com/ellistarn/karpenter/pkg/metrics/producers"
-	metricsproducers "github.com/ellistarn/karpenter/pkg/metrics/producers"
-	"github.com/prometheus/client_golang/api"
 
 	"github.com/ellistarn/karpenter/pkg/utils/log"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/scale"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	controllerruntimezap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	// +kubebuilder:scaffold:imports
 )
 
 var (
-	scheme       = runtime.NewScheme()
-	options      = Options{}
-	dependencies = Dependencies{}
+	scheme  = runtime.NewScheme()
+	options = Options{}
 )
 
 func init() {
@@ -50,141 +38,43 @@ func init() {
 
 // Options for running this binary
 type Options struct {
-	EnableLeaderElection bool
 	EnableVerboseLogging bool
-	MetricsAddr          string
+	MetricsPort          int
+	WebhookPort          int
 	PrometheusURI        string
 }
 
-// Dependencies to be injected
-type Dependencies struct {
-	Manager                manager.Manager
-	InformerFactory        informers.SharedInformerFactory
-	Controllers            []controllers.Controller
-	MetricsProducerFactory metricsproducers.Factory
-	MetricsClientFactory   metricsclients.Factory
-	AutoscalerFactory      autoscaler.Factory
-	NodeGroupFactory       nodegroup.Factory
-}
-
 func main() {
-	setupFlags()
+	flag.BoolVar(&options.EnableVerboseLogging, "verbose", true, "Enable verbose logging.")
+	flag.StringVar(&options.PrometheusURI, "prometheus-uri", "http://prometheus-operated:9090", "The Prometheus Metrics Server URI for retrieving metrics")
+	flag.IntVar(&options.WebhookPort, "webhook-port", 9443, "The port the webhook endpoint binds to for validation and mutation of resources.")
+	flag.IntVar(&options.MetricsPort, "metrics-port", 8080, "The port the metric endpoint binds to for operating metrics about the controller itself.")
+	flag.Parse()
+
 	log.Setup(controllerruntimezap.UseDevMode(options.EnableVerboseLogging))
 
-	dependencies.Manager = managerOrDie()
-	dependencies.InformerFactory = informerFactoryOrDie()
-	dependencies.MetricsProducerFactory = metricsProducerFactoryOrDie()
-	dependencies.MetricsClientFactory = metricsClientFactoryOrDie()
-	dependencies.AutoscalerFactory = autoscalerFactoryOrDie()
-	dependencies.Controllers = controllersOrDie()
-
-	if err := dependencies.Manager.Start(controllerruntime.SetupSignalHandler()); err != nil {
-		zap.S().Fatalf("Unable to start manager, %v", err)
-	}
-}
-
-func setupFlags() {
-	// Controller
-	flag.BoolVar(&options.EnableLeaderElection, "enable-leader-election", true, "Enable leader election.")
-	flag.BoolVar(&options.EnableVerboseLogging, "verbose", true, "Enable verbose logging.")
-
-	// Metrics
-	flag.StringVar(&options.PrometheusURI, "prometheus-uri", "http://prometheus-operated:9090", "The Prometheus Metrics Server URI for retrieving metrics")
-	flag.StringVar(&options.MetricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to for operating metrics about the controller itself.")
-	flag.Parse()
-}
-
-func managerOrDie() manager.Manager {
-	mgr, err := controllerruntime.NewManager(controllerruntime.GetConfigOrDie(), controllerruntime.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: options.MetricsAddr,
-		Port:               9443,
-		LeaderElection:     options.EnableLeaderElection,
+	manager := controllers.NewManagerOrDie(controllerruntime.GetConfigOrDie(), controllerruntime.Options{
+		LeaderElection:     true,
 		LeaderElectionID:   "karpenter-leader-election",
+		Scheme:             scheme,
+		MetricsBindAddress: fmt.Sprintf(":%d", options.MetricsPort),
+		Port:               options.WebhookPort,
 	})
-	if err != nil {
-		zap.S().Fatalf("Unable to start controller manager, %v", err)
-	}
-	return mgr
-}
 
-func informerFactoryOrDie() informers.SharedInformerFactory {
-	factory := informers.NewSharedInformerFactory(
-		kubernetes.NewForConfigOrDie(dependencies.Manager.GetConfig()),
-		time.Minute*30,
+	metricsProducerFactory := &producers.Factory{Client: manager.GetClient()}
+	metricsClientFactory := metricsclients.NewFactoryOrDie(options.PrometheusURI)
+	autoscalerFactory := autoscaler.NewFactoryOrDie(metricsClientFactory, manager.GetRESTMapper(), manager.GetConfig())
+
+	horizontalAutoscalerController := &horizontalautoscalerv1alpha1.Controller{AutoscalerFactory: autoscalerFactory}
+	scalableNodeGroupController := &scalablenodegroupv1alpha1.Controller{NodeGroupFactory: &nodegroup.Factory{}}
+	metricsProducerController := &metricsproducerv1alpha1.Controller{ProducerFactory: metricsProducerFactory}
+
+	manager.Register(
+		horizontalAutoscalerController,
+		scalableNodeGroupController,
+		metricsProducerController,
 	)
-
-	if err := dependencies.Manager.Add(manager.RunnableFunc(func(stopChannel <-chan struct{}) error {
-		factory.Start(stopChannel)
-		if synced := cache.WaitForCacheSync(stopChannel,
-			factory.Core().V1().Pods().Informer().HasSynced,
-			factory.Core().V1().Nodes().Informer().HasSynced,
-		); !synced {
-			zap.S().Fatal("Unable to sync informer cache")
-		}
-		<-stopChannel
-		return nil
-	})); err != nil {
-		zap.S().Fatalf("Unable to register informer factory, %v", err)
+	if err := manager.Start(controllerruntime.SetupSignalHandler()); err != nil {
+		zap.S().Fatalf("Unable to start manager, %w", err)
 	}
-
-	return factory
-}
-
-func metricsProducerFactoryOrDie() producers.Factory {
-	return producers.Factory{
-		NodeLister: dependencies.InformerFactory.Core().V1().Nodes().Lister(),
-		PodLister:  dependencies.InformerFactory.Core().V1().Pods().Lister(),
-	}
-}
-
-func metricsClientFactoryOrDie() clients.Factory {
-	client, err := api.NewClient(api.Config{Address: options.PrometheusURI})
-	if err != nil {
-		zap.S().Fatalf("Unable to create prometheus client, %v", err)
-	}
-	return clients.Factory{
-		PrometheusClient: prometheusv1.NewAPI(client),
-	}
-}
-
-func autoscalerFactoryOrDie() autoscaler.Factory {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(dependencies.Manager.GetConfig())
-	if err != nil {
-		zap.S().Fatalf("Unable to create discovery client, %v", err)
-	}
-	scale, err := scale.NewForConfig(
-		dependencies.Manager.GetConfig(),
-		dependencies.Manager.GetRESTMapper(),
-		dynamic.LegacyAPIPathResolverFunc,
-		scale.NewDiscoveryScaleKindResolver(discoveryClient),
-	)
-	if err != nil {
-		zap.S().Fatalf("Unable to create scale client, %v", err)
-	}
-	return autoscaler.Factory{
-		MetricsClientFactory: dependencies.MetricsClientFactory,
-		Mapper:               dependencies.Manager.GetRESTMapper(),
-		ScaleNamespacer:      scale,
-	}
-}
-
-func controllersOrDie() []controllers.Controller {
-	cs := []controllers.Controller{
-		&horizontalautoscalerv1alpha1.Controller{
-			AutoscalerFactory: dependencies.AutoscalerFactory,
-		},
-		&scalablenodegroupv1alpha1.Controller{
-			NodeGroupFactory: dependencies.NodeGroupFactory,
-		},
-		&metricsproducerv1alpha1.Controller{
-			ProducerFactory: dependencies.MetricsProducerFactory,
-		},
-	}
-	for _, c := range cs {
-		if err := controllers.Register(dependencies.Manager, c); err != nil {
-			zap.S().Fatalf("Failed to register controller for resource %v: %v", c.For(), err)
-		}
-	}
-	return cs
 }

--- a/pkg/apis/autoscaling/v1alpha1/scalablenodegroup_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/scalablenodegroup_validation.go
@@ -15,7 +15,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 // +kubebuilder:object:generate=false
@@ -30,10 +30,10 @@ func RegisterScalableNodeGroupValidator(nodeGroupType NodeGroupType, validator S
 func (sng *ScalableNodeGroup) Validate() error {
 	validator, ok := scalableNodeGroupValidators[sng.Spec.Type]
 	if !ok {
-		return errors.Errorf("Unexpected type %v", sng.Spec.Type)
+		return fmt.Errorf("Unexpected type %v", sng.Spec.Type)
 	}
 	if err := validator(&sng.Spec); err != nil {
-		return errors.Wrap(err, "Invalid ScalableNodeGroup")
+		return fmt.Errorf("Invalid ScalableNodeGroup, %w", err)
 	}
 	return nil
 }

--- a/pkg/cloudprovider/nodegroup/aws/autoscalinggroup.go
+++ b/pkg/cloudprovider/nodegroup/aws/autoscalinggroup.go
@@ -15,11 +15,12 @@ limitations under the License.
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
-	"github.com/pkg/errors"
 )
 
 // AutoScalingGroup implements the NodeGroup CloudProvider for AWS EC2 AutoScalingGroups
@@ -45,7 +46,7 @@ func (asg *AutoScalingGroup) GetReplicas() (int32, error) {
 		return 0, err
 	}
 	if len(out.AutoScalingGroups) != 1 {
-		return 0, errors.Errorf("autoscaling group has no instances: %s", asg.ID)
+		return 0, fmt.Errorf("autoscaling group has no instances: %s", asg.ID)
 	}
 	return int32(len(out.AutoScalingGroups[0].Instances)), nil
 }

--- a/pkg/cloudprovider/nodegroup/aws/managednodegroup.go
+++ b/pkg/cloudprovider/nodegroup/aws/managednodegroup.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
-	"github.com/pkg/errors"
 )
 
 func Validate(sng *v1alpha1.ScalableNodeGroupSpec) (err error) {
@@ -63,9 +62,9 @@ func NewManagedNodeGroup(id string) *ManagedNodeGroup {
 // parseId extracts the cluster and nodegroup from an ARN. This is
 // needed for Managed Node Group APIs that don't take an ARN directly.
 func parseId(fromArn string) (cluster string, nodegroup string, err error) {
-	nodeGroupArn, parseErr := arn.Parse(fromArn)
-	if parseErr != nil {
-		return "", "", errors.Wrapf(parseErr, "invalid managed node group id %s", fromArn)
+	nodeGroupArn, err := arn.Parse(fromArn)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid managed node group id %s, %w", fromArn, err)
 	}
 	// Example node group ARN:
 	// arn:aws:eks:us-west-2:741206201142:nodegroup/ridiculous-sculpture-1594766004/ng-0b663e8a/aeb9a7fe-69d6-21f0-cb41-fb9b03d3aaa9

--- a/pkg/controllers/horizontalautoscaler/v1alpha1/controller.go
+++ b/pkg/controllers/horizontalautoscaler/v1alpha1/controller.go
@@ -29,7 +29,7 @@ import (
 // Controller reconciles a HorizontalAutoscaler object
 type Controller struct {
 	client.Client
-	AutoscalerFactory autoscaler.Factory
+	AutoscalerFactory *autoscaler.Factory
 }
 
 // For returns the resource this controller is for.

--- a/pkg/controllers/horizontalautoscaler/v1alpha1/suite_test.go
+++ b/pkg/controllers/horizontalautoscaler/v1alpha1/suite_test.go
@@ -22,17 +22,11 @@ import (
 
 	v1alpha1 "github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
 	"github.com/ellistarn/karpenter/pkg/autoscaler"
-	"github.com/ellistarn/karpenter/pkg/controllers"
 	scalablenodegroupv1alpha1 "github.com/ellistarn/karpenter/pkg/controllers/scalablenodegroup/v1alpha1"
 	"github.com/ellistarn/karpenter/pkg/metrics/clients"
 	"github.com/ellistarn/karpenter/pkg/test/environment"
 	. "github.com/ellistarn/karpenter/pkg/test/expectations"
 	"github.com/ellistarn/karpenter/pkg/utils/log"
-	"github.com/prometheus/client_golang/api"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/scale"
 	"knative.dev/pkg/ptr"
 
 	. "github.com/onsi/ginkgo"
@@ -55,26 +49,12 @@ func injectFakeServer(environment *environment.Local) {
 }
 
 func injectHorizontalAutoscalerController(environment *environment.Local) {
-	scale, err := scale.NewForConfig(
-		environment.Manager.GetConfig(),
-		environment.Manager.GetRESTMapper(),
-		dynamic.LegacyAPIPathResolverFunc,
-		scale.NewDiscoveryScaleKindResolver(discovery.NewDiscoveryClientForConfigOrDie(environment.Manager.GetConfig())),
+	metricsClientFactory := clients.NewFactoryOrDie(environment.Server.URL())
+	autoscalerFactory := autoscaler.NewFactoryOrDie(metricsClientFactory, environment.Manager.GetRESTMapper(), environment.Config)
+	environment.Manager.Register(
+		&Controller{Client: environment.Manager.GetClient(), AutoscalerFactory: autoscalerFactory},
+		&scalablenodegroupv1alpha1.Controller{},
 	)
-	Expect(err).ToNot(HaveOccurred(), "Failed to create scale client")
-	prometheusClient, err := api.NewClient(api.Config{Address: environment.Server.URL()})
-	Expect(err).ToNot(HaveOccurred(), "Unable to create prometheus client")
-	Expect(controllers.Register(environment.Manager, &Controller{
-		Client: environment.Manager.GetClient(),
-		AutoscalerFactory: autoscaler.Factory{
-			MetricsClientFactory: clients.Factory{
-				PrometheusClient: prometheusv1.NewAPI(prometheusClient),
-			},
-			Mapper:          environment.Manager.GetRESTMapper(),
-			ScaleNamespacer: scale,
-		},
-	}), "Failed to register controller")
-	Expect(controllers.Register(environment.Manager, &scalablenodegroupv1alpha1.Controller{})).To(Succeed(), "Failed to register controller")
 }
 
 var env environment.Environment = environment.NewLocal(injectFakeServer, injectHorizontalAutoscalerController)

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -1,0 +1,59 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/ellistarn/karpenter/pkg/apis"
+	"github.com/ellistarn/karpenter/pkg/utils/log"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	log.PanicIfError(clientgoscheme.AddToScheme(scheme), "adding clientgo to scheme")
+	log.PanicIfError(apis.AddToScheme(scheme), "adding apis to scheme")
+}
+
+type Manager struct {
+	manager.Manager
+}
+
+// NewManager instantiates a controller manager or panics
+func NewManagerOrDie(config *rest.Config, options controllerruntime.Options) Manager {
+	options.Scheme = scheme
+	manager, err := controllerruntime.NewManager(config, options)
+	log.PanicIfError(err, "Failed to create controller manager")
+	log.PanicIfError(manager.GetFieldIndexer().
+		IndexField(context.Background(), &v1.Pod{}, "spec.nodeName", podSchedulingIndex),
+		"Failed to setup pod indexer")
+	return Manager{Manager: manager}
+}
+
+func (m *Manager) Register(controllers ...Controller) {
+	for _, controller := range controllers {
+		var builder = controllerruntime.NewControllerManagedBy(m).For(controller.For())
+		for _, resource := range controller.Owns() {
+			builder = builder.Owns(resource)
+		}
+		log.PanicIfError(builder.Complete(&GenericController{Controller: controller, Client: m.GetClient()}),
+			"Failed to register controller to manager for %s", controller.For())
+		log.PanicIfError(controllerruntime.NewWebhookManagedBy(m).For(controller.For()).Complete(),
+			"Failed to register controller to manager for %s", controller.For())
+	}
+}
+
+func podSchedulingIndex(object runtime.Object) []string {
+	pod, ok := object.(*v1.Pod)
+	if !ok {
+		return nil
+	}
+	return []string{pod.Spec.NodeName}
+}

--- a/pkg/controllers/metricsproducer/v1alpha1/controller.go
+++ b/pkg/controllers/metricsproducer/v1alpha1/controller.go
@@ -23,13 +23,11 @@ import (
 	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
 	"github.com/ellistarn/karpenter/pkg/controllers"
 	"github.com/ellistarn/karpenter/pkg/metrics/producers"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Controller for the resource
 type Controller struct {
-	client.Client
-	ProducerFactory producers.Factory
+	ProducerFactory *producers.Factory
 }
 
 // For returns the resource this controller is for.

--- a/pkg/controllers/scalablenodegroup/v1alpha1/suite_test.go
+++ b/pkg/controllers/scalablenodegroup/v1alpha1/suite_test.go
@@ -20,7 +20,6 @@ import (
 	v1alpha1 "github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
 
 	"github.com/ellistarn/karpenter/pkg/cloudprovider/nodegroup"
-	"github.com/ellistarn/karpenter/pkg/controllers"
 	"github.com/ellistarn/karpenter/pkg/test/environment"
 	. "github.com/ellistarn/karpenter/pkg/test/expectations"
 	"knative.dev/pkg/ptr"
@@ -37,13 +36,9 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-func injectScalableNodeGroupController(environment *environment.Local) {
-	Expect(controllers.Register(environment.Manager, &Controller{
-		NodeGroupFactory: nodegroup.Factory{},
-	}), "Failed to register controller")
-}
-
-var env environment.Environment = environment.NewLocal(injectScalableNodeGroupController)
+var env environment.Environment = environment.NewLocal(func(e *environment.Local) {
+	e.Manager.Register(&Controller{NodeGroupFactory: &nodegroup.Factory{}})
+})
 
 var _ = BeforeSuite(func() {
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")

--- a/pkg/metrics/clients/client.go
+++ b/pkg/metrics/clients/client.go
@@ -18,8 +18,18 @@ import (
 	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
 	"github.com/ellistarn/karpenter/pkg/metrics"
 	"github.com/ellistarn/karpenter/pkg/utils/log"
+
+	"github.com/prometheus/client_golang/api"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
+
+func NewFactoryOrDie(prometheusURI string) *Factory {
+	client, err := api.NewClient(api.Config{Address: prometheusURI})
+	log.PanicIfError(err, "Failed to instantiate metrics client factory")
+	return &Factory{
+		PrometheusClient: prometheusv1.NewAPI(client),
+	}
+}
 
 // Factory instantiates metrics clients
 type Factory struct {

--- a/pkg/metrics/clients/prometheus.go
+++ b/pkg/metrics/clients/prometheus.go
@@ -16,12 +16,12 @@ package clients
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
 	"github.com/ellistarn/karpenter/pkg/metrics"
 	"github.com/ellistarn/karpenter/pkg/utils/log"
-	"github.com/pkg/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
@@ -35,10 +35,10 @@ type PrometheusMetricsClient struct {
 func (c *PrometheusMetricsClient) GetCurrentValue(metric v1alpha1.Metric) (metrics.Metric, error) {
 	value, _, err := c.Client.Query(context.Background(), metric.Prometheus.Query, time.Now().Round(time.Hour))
 	if err != nil {
-		return metrics.Metric{}, errors.Wrapf(err, "request failed for query %s", metric.Prometheus.Query)
+		return metrics.Metric{}, fmt.Errorf("request failed for query %s, %w", metric.Prometheus.Query, err)
 	}
 	if err := c.validateResponseType(value); err != nil {
-		return metrics.Metric{}, errors.Wrapf(err, "invalid response for query %s", metric.Prometheus.Query)
+		return metrics.Metric{}, fmt.Errorf("invalid response for query %s, %w", metric.Prometheus.Query, err)
 	}
 	return metrics.Metric{Value: float64(value.(model.Vector)[0].Value)}, nil
 }
@@ -46,10 +46,10 @@ func (c *PrometheusMetricsClient) GetCurrentValue(metric v1alpha1.Metric) (metri
 func (c *PrometheusMetricsClient) validateResponseType(value model.Value) error {
 	vector, ok := value.(model.Vector)
 	if !ok {
-		return errors.Errorf("expected %s and got %s", model.ValVector, value.Type())
+		return fmt.Errorf("expected %s and got %s", model.ValVector, value.Type())
 	}
 	if vector.Len() != 1 {
-		return errors.Errorf("expected instant vector and got vector: %s", log.Pretty(value))
+		return fmt.Errorf("expected instant vector and got vector: %s", log.Pretty(value))
 	}
 	return nil
 }

--- a/pkg/metrics/producers/factory.go
+++ b/pkg/metrics/producers/factory.go
@@ -9,13 +9,12 @@ import (
 	"github.com/ellistarn/karpenter/pkg/metrics/producers/reservedcapacity"
 	"github.com/ellistarn/karpenter/pkg/metrics/producers/scheduledcapacity"
 	"github.com/ellistarn/karpenter/pkg/utils/log"
-	v1 "k8s.io/client-go/listers/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Factory instantiates metrics producers
 type Factory struct {
-	NodeLister   v1.NodeLister
-	PodLister    v1.PodLister
+	Client       client.Client
 	QueueFactory cloudproviderqueue.Factory
 }
 
@@ -23,8 +22,7 @@ func (f *Factory) For(mp *v1alpha1.MetricsProducer) metrics.Producer {
 	if mp.Spec.PendingCapacity != nil {
 		return &pendingcapacity.Producer{
 			MetricsProducer: mp,
-			Nodes:           f.NodeLister,
-			Pods:            f.PodLister,
+			Client:          f.Client,
 		}
 	}
 	if mp.Spec.Queue != nil {
@@ -36,14 +34,12 @@ func (f *Factory) For(mp *v1alpha1.MetricsProducer) metrics.Producer {
 	if mp.Spec.ReservedCapacity != nil {
 		return &reservedcapacity.Producer{
 			MetricsProducer: mp,
-			Nodes:           f.NodeLister,
-			Pods:            f.PodLister,
+			Client:          f.Client,
 		}
 	}
 	if mp.Spec.ScheduledCapacity != nil {
 		return &scheduledcapacity.Producer{
 			MetricsProducer: mp,
-			Nodes:           f.NodeLister,
 		}
 	}
 	log.InvariantViolated("Failed to instantiate metrics producer, no spec defined")

--- a/pkg/metrics/producers/pendingcapacity/producer.go
+++ b/pkg/metrics/producers/pendingcapacity/producer.go
@@ -16,14 +16,13 @@ package pendingcapacity
 
 import (
 	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
-	listersv1 "k8s.io/client-go/listers/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Producer implements a Pending Capacity metric
 type Producer struct {
 	*v1alpha1.MetricsProducer
-	Nodes listersv1.NodeLister
-	Pods  listersv1.PodLister
+	Client client.Client
 }
 
 // GetCurrentValues of the metrics

--- a/pkg/metrics/producers/reservedcapacity/producer.go
+++ b/pkg/metrics/producers/reservedcapacity/producer.go
@@ -1,74 +1,53 @@
 package reservedcapacity
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	listersv1 "k8s.io/client-go/listers/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Producer implements a Reserved Capacity metric
 type Producer struct {
 	*v1alpha1.MetricsProducer
-	Nodes listersv1.NodeLister
-	Pods  listersv1.PodLister
+	Client client.Client
 }
 
 // Reconcile of the metrics
 func (p *Producer) Reconcile() error {
-	// 1. List Pods and Nodes
-	nodes, err := p.Nodes.List(labels.Set(p.Spec.ReservedCapacity.NodeSelector).AsSelector())
-	if err != nil {
-		return errors.Wrapf(err, "Listing nodes for %s", p.Spec.ReservedCapacity.NodeSelector)
-	}
-	pods, err := p.Pods.Pods(metav1.NamespaceAll).List(labels.Everything())
-	if err != nil {
-		return errors.Wrap(err, "Listing pods")
+	// 1. List nodes
+	nodes := &v1.NodeList{}
+	if err := p.Client.List(context.Background(), nodes, client.MatchingLabels(p.Spec.ReservedCapacity.NodeSelector)); err != nil {
+		return fmt.Errorf("Listing nodes for %s, %w", p.Spec.ReservedCapacity.NodeSelector, err)
 	}
 
-	// 2. Calculate Pod Assignments,
-	// TODO Make this an index for increased performance
-	assignments := p.getAssignments(nodes, pods)
+	// 2. Compute reservations
+	reservations := NewReservations(p.MetricsProducer)
+	for _, node := range nodes.Items {
+		pods := &v1.PodList{}
+		if err := p.Client.List(context.Background(), pods, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
+			return fmt.Errorf("Listing pods for %s, %w", node.Name, err)
+		}
+		reservations.Add(&node, pods)
+	}
 
-	// 3. Compute reservations
-	reservations := p.getReservations(nodes, assignments)
-
-	// 4. Record reservations and update status
+	// 3. Record reservations and update status
 	p.record(reservations)
 	return nil
-}
-
-func (p *Producer) getAssignments(nodes []*v1.Node, pods []*v1.Pod) map[string][]*v1.Pod {
-	assignments := map[string][]*v1.Pod{}
-	for _, pod := range pods {
-		assignments[pod.Spec.NodeName] = append(assignments[pod.Spec.NodeName], pod)
-	}
-	return assignments
-}
-
-func (p *Producer) getReservations(nodes []*v1.Node, assignments map[string][]*v1.Pod) *Reservations {
-	reservations := NewReservations(p.MetricsProducer)
-	for _, node := range nodes {
-		reservations.Add(node, assignments[node.Name])
-	}
-	return reservations
 }
 
 func (p *Producer) record(reservations *Reservations) {
 	if p.Status.ReservedCapacity == nil {
 		p.Status.ReservedCapacity = map[v1.ResourceName]string{}
 	}
-
 	var errs error
 	for resource, reservation := range reservations.Resources {
 		utilization, err := reservation.Utilization()
 		if err != nil {
-			errs = multierr.Append(errs, errors.Wrapf(err, "unable to compute utilization for %s", resource))
+			errs = multierr.Append(errs, fmt.Errorf("unable to compute utilization for %s, %w", resource, err))
 		} else {
 			reservation.Gauge.Set(utilization)
 			p.Status.ReservedCapacity[resource] = fmt.Sprintf(

--- a/pkg/metrics/producers/scheduledcapacity/producer.go
+++ b/pkg/metrics/producers/scheduledcapacity/producer.go
@@ -2,13 +2,11 @@ package scheduledcapacity
 
 import (
 	"github.com/ellistarn/karpenter/pkg/apis/autoscaling/v1alpha1"
-	v1 "k8s.io/client-go/listers/core/v1"
 )
 
 // Producer implements the ScheduledCapacity metric
 type Producer struct {
 	*v1alpha1.MetricsProducer
-	Nodes v1.NodeLister
 }
 
 // Reconcile of the metrics

--- a/pkg/test/environment/namespace.go
+++ b/pkg/test/environment/namespace.go
@@ -1,13 +1,13 @@
 package environment
 
 import (
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"regexp"
 	"strings"
 
 	"github.com/Pallinder/go-randomdata"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,10 +52,10 @@ func (n *Namespace) ParseResources(path string, objects ...runtime.Object) error
 func (n *Namespace) ParseResource(path string, object runtime.Object) error {
 	data, err := ioutil.ReadFile(project.RelativeToRoot(path))
 	if err != nil {
-		return errors.Wrapf(err, "reading file %s", path)
+		return fmt.Errorf("reading file %s, %w", path, err)
 	}
 	if err := parseFromYaml(data, object); err != nil {
-		return errors.Wrapf(err, "parsing yaml")
+		return fmt.Errorf("parsing yaml, %w", err)
 	}
 
 	if field := reflect.ValueOf(object).Elem().FieldByName("Namespace"); field.IsValid() {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ellistarn/karpenter/pkg/test"
 	"github.com/ellistarn/karpenter/pkg/utils/log"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -54,6 +54,6 @@ func ExpectEventuallyDeleted(client client.Client, resource test.Resource) {
 	nn := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
 	Expect(client.Delete(context.Background(), resource)).To(Succeed())
 	Eventually(func() bool {
-		return apierrors.IsNotFound(client.Get(context.Background(), nn, resource))
+		return errors.IsNotFound(client.Get(context.Background(), nn, resource))
 	}, APIServerPropagationTime, RequestInterval).Should(BeTrue(), "resource was never deleted %s", nn)
 }

--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"fmt"
+
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -15,4 +17,10 @@ func Setup(opts ...controllerruntimezap.Opts) {
 
 func InvariantViolated(reason string) {
 	zap.S().Errorf("Invariant violated: %s. Is the validation webhook installed?", reason)
+}
+
+func PanicIfError(err error, formatter string, arguments ...interface{}) {
+	if err != nil {
+		zap.S().Panicf("%s, %w", fmt.Sprintf(formatter, arguments...), err)
+	}
 }

--- a/pkg/utils/log/pretty.go
+++ b/pkg/utils/log/pretty.go
@@ -2,8 +2,8 @@ package log
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -30,7 +30,7 @@ func PrettyInfof(formatter string, args ...interface{}) {
 
 func Pretty(object interface{}) string {
 	if data, err := json.MarshalIndent(object, LinePrefix, IndentSize); err != nil {
-		return errors.Wrap(err, "failed to print pretty string for object").Error()
+		return fmt.Sprintf("failed to print pretty string for object, %v", err)
 	} else {
 		return string(data)
 	}


### PR DESCRIPTION
- Removes outdates `build` target
- Switches from sharedinformerfactory to use controller-runtime's delegatingclientinformers 
- Adds a client side index for pod.spec.nodeName for more efficient queries.
- Simplifies capacity reservation logic

I'm seeing continued duplication of setup code in local.go and main.go. I'll address this consolidation in a followup.