### PR TITLE
Fixed an issue with default values on ScalingRules

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/horizontalautoscaler.go
+++ b/pkg/apis/autoscaling/v1alpha1/horizontalautoscaler.go
@@ -244,9 +244,7 @@ func (b *Behavior) ScaleUpRules() ScalingRules {
 		StabilizationWindowSeconds: ptr.Int32(0),
 		SelectPolicy:               &MaxPolicySelect,
 	}
-	if b.ScaleUp != nil {
-		b.ScaleUp.DeepCopyInto(&rules)
-	}
+	f.MergeInto(&rules, b.ScaleUp)
 	return rules
 }
 
@@ -255,9 +253,7 @@ func (b *Behavior) ScaleDownRules() ScalingRules {
 		StabilizationWindowSeconds: ptr.Int32(300),
 		SelectPolicy:               &MaxPolicySelect,
 	}
-	if b.ScaleDown != nil {
-		b.ScaleDown.DeepCopyInto(&rules)
-	}
+	f.MergeInto(&rules, b.ScaleDown)
 	return rules
 }
 

--- a/pkg/utils/functional/functional.go
+++ b/pkg/utils/functional/functional.go
@@ -15,7 +15,10 @@ limitations under the License.
 package f
 
 import (
+	"encoding/json"
 	"math"
+
+	"github.com/ellistarn/karpenter/pkg/utils/log"
 )
 
 // GreaterThanInt32 returns values greater than the target value
@@ -63,4 +66,26 @@ func SelectInt32(values []int32, selector func(int32, int32) int32) int32 {
 		selected = selector(selected, int32(value))
 	}
 	return selected
+}
+
+/* MergeInto overlays multiple srcs onto a dest struct. Srcs are applied in
+order, so srcs[1] will override any fields set from srcs[2]
+
+For example,
+
+dest {a: 1 b: 2}
+srcs[0] {a: 2 c: 3}
+
+result {a: 2 b: 2 c: 3}
+
+*/
+func MergeInto(dest interface{}, srcs ...interface{}) {
+	for _, src := range srcs {
+		if src != nil {
+			bytes, err := json.Marshal(src)
+			log.PanicIfError(err, "Failed to marshall json from %v", src)
+			err = json.Unmarshal(bytes, dest)
+			log.PanicIfError(err, "Failed to unmarshall json %s into %v", string(bytes), dest)
+		}
+	}
 }

--- a/pkg/utils/log/log.go
+++ b/pkg/utils/log/log.go
@@ -35,6 +35,6 @@ func InvariantViolated(reason string) {
 
 func PanicIfError(err error, formatter string, arguments ...interface{}) {
 	if err != nil {
-		zap.S().Panicf("%s, %w", fmt.Sprintf(formatter, arguments...), err)
+		zap.S().Panicf("%s, %v", fmt.Sprintf(formatter, arguments...), err)
 	}
 }


### PR DESCRIPTION
DeepCopyInto didn't behave as expected. It fully replaces the object rather than merging.
Test coming soon. I'm releasing this first to avoid a huge PR.