### PR TITLE
Fixes a bug in stablization window status condition

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -172,8 +172,12 @@ func (a *Autoscaler) applyTransientLimits(replicas int32, recommendation int32) 
 	// 1. Don't scale if within stabilization window. Check after determining
 	// scale up vs down, as scale up window doesn't prevent scale down.
 	if rules.WithinStabilizationWindow(a.Status.LastScaleTime) {
-		a.StatusConditions().MarkFalse(v1alpha1.AbleToScale, "", fmt.Sprintf("within stabilization window %d/%d seconds",
-			time.Since(a.Status.LastScaleTime.Inner.Time), rules.StabilizationWindowSeconds))
+		a.StatusConditions().MarkFalse(v1alpha1.AbleToScale, "",
+			fmt.Sprintf("within stabilization window %f/%d seconds",
+				time.Since(a.Status.LastScaleTime.Inner.Time).Seconds(),
+				*rules.StabilizationWindowSeconds,
+			),
+		)
 		return recommendation
 	}
 


### PR DESCRIPTION
- Stop printing pointer address and instead use the actual data (oops)
- Print the duration in seconds rather than microseconds.