### PR TITLE
Expose Total and Reserved as prometheus metrics for ReservedCapacity MetricsProducer

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/metricsproducer_status.go
+++ b/pkg/apis/autoscaling/v1alpha1/metricsproducer_status.go
@@ -36,16 +36,9 @@ type MetricsProducerStatus struct {
 	Conditions apis.Conditions `json:"conditions,omitempty"`
 }
 
-const (
-	// Calculable is a condition that refers to whether or not the Metrics
-	// Producer is able to calculate a metric given the available data. This
-	// will be false if no data is available, or if a mathematical operation
-	// desired by the producer results in an undefined value (i.e. div by 0).
-	Calculable apis.ConditionType = "Calculable"
-)
-
 type PendingCapacityStatus struct {
 }
+
 type QueueStatus struct {
 	// Length of the Queue
 	Length int64 `json:"length"`
@@ -64,7 +57,6 @@ type ScheduledCapacityStatus struct {
 func (m *MetricsProducer) StatusConditions() apis.ConditionManager {
 	return apis.NewLivingConditionSet(
 		Active,
-		Calculable,
 	).Manage(m)
 }
 

--- a/pkg/controllers/metricsproducer/v1alpha1/suite_test.go
+++ b/pkg/controllers/metricsproducer/v1alpha1/suite_test.go
@@ -97,12 +97,24 @@ var _ = Describe("Test Samples", func() {
 
 			ExpectEventuallyHappy(ns.Client, mp)
 			Expect(mp.Status.ReservedCapacity[v1.ResourceCPU]).To(BeEquivalentTo("14%, 7/48"))
-			Expect(mp.Status.ReservedCapacity[v1.ResourceMemory]).To(BeEquivalentTo("20%, 77Gi/384Gi"))
+			Expect(mp.Status.ReservedCapacity[v1.ResourceMemory]).To(BeEquivalentTo("20%, 82678120448/412316860416"))
 			Expect(mp.Status.ReservedCapacity[v1.ResourcePods]).To(BeEquivalentTo("2%, 4/150"))
 
 			ExpectDeleted(ns.Client, mp)
 			ExpectDeleted(ns.Client, nodes...)
 			ExpectDeleted(ns.Client, pods...)
+		})
+		It("should produce reservation metrics for an empty node group", func() {
+			Expect(ns.ParseResources("docs/samples/reserved-capacity/resources.yaml", mp)).To(Succeed())
+
+			ExpectCreated(ns.Client, mp)
+
+			ExpectEventuallyHappy(ns.Client, mp)
+			Expect(mp.Status.ReservedCapacity[v1.ResourceCPU]).To(BeEquivalentTo("NaN%, 0/0"))
+			Expect(mp.Status.ReservedCapacity[v1.ResourceMemory]).To(BeEquivalentTo("NaN%, 0/0"))
+			Expect(mp.Status.ReservedCapacity[v1.ResourcePods]).To(BeEquivalentTo("NaN%, 0/0"))
+
+			ExpectDeleted(ns.Client, mp)
 		})
 	})
 })


### PR DESCRIPTION
- Removed Calculable Status Condition in favor of NaN
- Displays quantities (like memory) in raw values instead of 40Ki. This removes difficult to read scenarios where the numerator and denominator weren't in the same units. We may explore normalizing these values (or displaying in MB) in the future.
```
karpenter_metrics_producer_reserved_capacity_cpu_capacity{endpoint="http",exported_namespace="default",instance="192.168.63.90:8080",job="karpenter-metrics-service",name="demo",namespace="karpenter",pod="karpenter-66cd456f64-7mf8d",service="karpenter-metrics-service"}
```


```
apiVersion: v1
items:
- apiVersion: autoscaling.karpenter.sh/v1alpha1
  kind: MetricsProducer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"autoscaling.karpenter.sh/v1alpha1","kind":"MetricsProducer","metadata":{"annotations":{},"name":"demo","namespace":"default"},"spec":{"reservedCapacity":{"nodeSelector":{"eks.amazonaws.com/nodegroup":"default"}}}}
    creationTimestamp: "2020-11-03T18:29:41Z"
    generation: 2
    name: demo
    namespace: default
    resourceVersion: "372547"
    selfLink: /apis/autoscaling.karpenter.sh/v1alpha1/namespaces/default/metricsproducers/demo
    uid: b14f6248-febc-4f3d-9041-5361f7abe4d7
  spec:
    reservedCapacity:
      nodeSelector:
        eks.amazonaws.com/nodegroup: defaul
  status:
    conditions:
    - lastTransitionTime: "2020-11-03T18:29:41Z"
      status: "True"
      type: Active
    - lastTransitionTime: "2020-11-03T18:29:41Z"
      status: "True"
      type: Calculable
    - lastTransitionTime: "2020-11-03T18:29:41Z"
      status: "True"
      type: Ready
    reservedCapacity:
      cpu: NaN%, 0/0
      memory: NaN%, 0/0
      pods: NaN%, 0/0
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
```
- apiVersion: autoscaling.karpenter.sh/v1alpha1
  kind: MetricsProducer
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"autoscaling.karpenter.sh/v1alpha1","kind":"MetricsProducer","metadata":{"annotations":{},"name":"demo","namespace":"default"},"spec":{"reservedCapacity":{"nodeSelector":{"eks.amazonaws.com/nodegroup":"default"}}}}
    creationTimestamp: "2020-11-03T18:29:41Z"
    generation: 3
    name: demo
    namespace: default
    resourceVersion: "372866"
    selfLink: /apis/autoscaling.karpenter.sh/v1alpha1/namespaces/default/metricsproducers/demo
    uid: b14f6248-febc-4f3d-9041-5361f7abe4d7
  spec:
    reservedCapacity:
      nodeSelector:
        eks.amazonaws.com/nodegroup: default
  status:
    conditions:
    - lastTransitionTime: "2020-11-03T18:29:41Z"
      status: "True"
      type: Active
    - lastTransitionTime: "2020-11-03T18:29:41Z"
      status: "True"
      type: Calculable
    - lastTransitionTime: "2020-11-03T18:29:41Z"
      status: "True"
      type: Ready
    reservedCapacity:
      cpu: 100%, 8/8
      memory: 23%, 7736393728/32891342848
      pods: 29%, 17/58
```
