### PR TITLE
Switches presubmits to track main.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -11,7 +11,7 @@ jobs:
       with:
         go-version: 1.15.3
     - run: make toolchain
-    - run: echo ::add-path::/usr/local/kubebuilder/bin
+    - run: echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
     - run: make ci
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
