### PR TITLE
Fixed a race condition in the custom labels test

### DIFF
--- a/pkg/controllers/allocation/scheduling/suite_test.go
+++ b/pkg/controllers/allocation/scheduling/suite_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Combining Constraints", func() {
 		})
 		It("should generate custom labels", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
-			provisioner.Spec.Requirements = v1alpha5.Requirements{{Key: "test-key-2", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value-2", "not this one"}}}
+			provisioner.Spec.Requirements = v1alpha5.Requirements{{Key: "test-key-2", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value-2"}}}
 			ExpectCreated(env.Client, provisioner)
 			pods := ExpectProvisioningSucceeded(ctx, env.Client, controller, provisioner, test.UnschedulablePod(test.PodOptions{
 				NodeSelector: map[string]string{"another-key": "another-value"},
@@ -146,7 +146,7 @@ var _ = Describe("Combining Constraints", func() {
 			ExpectCreated(env.Client, provisioner)
 			pods := ExpectProvisioningSucceeded(ctx, env.Client, controller, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodePreferences: []v1.NodeSelectorRequirement{
-					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value", "another-value"}},
+					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"another-value", "test-value"}},
 				}},
 			))
 			node := ExpectNodeExists(env.Client, pods[0].Spec.NodeName)


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Order is not guaranteed for requirement values, causing this test to race. Any custom label can be selected. In the future, we may implement validation to allow only one value.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
