### PR TITLE
Fixing the type on nodegroup Karpenter is running on

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -76,7 +76,7 @@ EOF
 eksctl create cluster -f cluster.yaml
 ```
 
-This guide uses a self-managed node group to host Karpenter.
+This guide uses a managed node group to host Karpenter.
 
 Karpenter itself can run anywhere, including on [self-managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/worker.html), [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), or [AWS Fargate](https://aws.amazon.com/fargate/).
 


### PR DESCRIPTION
As per the eksctl cluster spec, it's create the cluster with a  `managedNodeGroup`

**1. Issue, if available:**


**2. Description of changes:**


**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
