### PR TITLE
re-add on pull_request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
It looks like we still need the on pull_request here.
I removed it in https://github.com/aws/karpenter/pull/1373 because it was double running the tests. It looks like when you add both it will each test twice and when you don't do pull_request it will not be triggered on pull request. 

 This seems to be the best of two words where it 1) Does run tests after merge 2) It runs on pull requests

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
