### PR TITLE
chore: added rules to a chart which dynamicly appear

### DIFF
--- a/charts/karpenter/templates/webhooks.yaml
+++ b/charts/karpenter/templates/webhooks.yaml
@@ -20,6 +20,18 @@ webhooks:
     sideEffects: None
     rules:
       - apiGroups:
+          - karpenter.k8s.aws
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - awsnodetemplates
+          - awsnodetemplates/status
+        scope: '*'
+      - apiGroups:
           - karpenter.sh
         apiVersions:
           - v1alpha5
@@ -47,6 +59,18 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     rules:
+      - apiGroups:
+          - karpenter.k8s.aws
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - awsnodetemplates
+          - awsnodetemplates/status
+        scope: '*'
       - apiGroups:
           - karpenter.sh
         apiVersions:


### PR DESCRIPTION
**Description**
When using ArgoCD both `defaulting.webhook.provisioners.karpenter.sh` and `validation.webhook.provisioners.karpenter.sh` are always in outofsync state because awsnodetemplates rules appear dynamicly after helm chart deployment

**How was this change tested?**
Just need to deploy a helm chart

**Release Note**
```release-note

```
