### PR TITLE
fix: remove data field from Secret

### DIFF
--- a/charts/karpenter/templates/secret-webhook-cert.yaml
+++ b/charts/karpenter/templates/secret-webhook-cert.yaml
@@ -9,4 +9,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data: {} # Injected by karpenter-webhook
+# data: {} # Injected by karpenter-webhook


### PR DESCRIPTION
fix: remove data field from Secret (chart)

**Description**
When deploying karpenter with ArgoCD as a Helm chart, ArgoCD will complain about sync-error for the Secret object. This occurs as the helm chart sets the `data` field to `null`. This happens since karpenter-webhook will set this field, and ArgoCD expects it to be `null`. 


**How was this change tested?**
Our current workaround with Kustomization and ArgoCD:
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

helmCharts: 
  - name: karpenter
    version: v0.27.5
    valuesFile: karpenter.values.yaml
    namespace: karpenter
    releaseName: karpenter

    patch: |-
      - op: remove
        path: /data
```

If the PR is accepted, one would no longer require to patch the helm chart with Kustomize
*

**Does this change impact docs?**
- [X] No

**Release Note**
```release-note
fix: remove data field from Secret chart template

This avoids syncing errors with ArgoCD
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
