### PR TITLE
feat: Adding capacityType discount as a percentage

### DIFF
--- a/designs/discount-pricing.md
+++ b/designs/discount-pricing.md
@@ -1,0 +1,55 @@
+# Discounted Pricing Support
+
+## Overview
+
+Karpenter is currently unaware of any discounted pricing, such as volume discounts or reserved instances/savings plans, which can lead to more expensive instances being chosen. For example an on demand instance with a savings plan discount may cost less than a spot instance of the same type. This pricing is apparently only available from the "payer" account, not any other child account API's for pricing.
+
+This was made explicit recently - the price of spot instances rose sharply at the beginning of Q2 2023. For users on default pricing this may not be noticeable, however if there is any discount for on-demand instances in an account, it could begin to become cheaper to use on-demand instances instead of spot.
+
+## User Stories
+
+* Karpenter will automatically prioritise the cheapest node capacity type in an account based on personal modifications to EC2 pricing
+* Karpenter will allow me to configure discounted pricing at the account level
+
+## Background
+
+[Conversation on Slack](https://kubernetes.slack.com/archives/C02SFFZSA2K/p1684246928553159)
+
+## How Will Karpenter Handle Discounted Pricing
+
+A multiplier will be applied to the price to allow any discounts to be applied and determine the real cost of an EC2 instance.
+For example, a multiplier of 0.9 would apply a 10% discount
+
+Separate multiplier values for Spot and On Demand pricing will be allowed to allow for accounts which have different pricing discounts for each type.
+
+The multiplier will default to a value of 1 so no discount will be applied unless explicitly enabled. 
+
+### Spot pricing
+
+The Spot price will be multiplied with the SpotPriceMultiplier to determine the real cost for Spot instances.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karpenter-global-settings
+  namespace: karpenter
+data:
+  # Spot Price Multiplier for including volume discounts etc. for spot prices. The spot price will be multiplied with the spotPriceMultiplier to determine the real cost
+  aws.spotPriceMultiplier: "0.95"
+```
+
+### On Demand pricing
+
+The On Demand price will be multiplied with the OnDemandPriceMultiplier to determine the real cost for On Demand instances.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karpenter-global-settings
+  namespace: karpenter
+data:
+  # On Demand Multiplier for including volume discounts etc. to ensure choosing the cheapest available instance. The ondemand price will be multiplied with the onDemandPriceMultiplier to determine the real cost
+  aws.onDemandPriceMultiplier: "0.60"
+```

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -42,6 +42,8 @@ var defaultSettings = &Settings{
 	InterruptionQueueName:      "",
 	Tags:                       map[string]string{},
 	ReservedENIs:               0,
+	SpotPriceMultiplier:        1,
+	OnDemandPriceMultiplier:    1,
 }
 
 // +k8s:deepcopy-gen=true
@@ -59,6 +61,8 @@ type Settings struct {
 	InterruptionQueueName      string
 	Tags                       map[string]string
 	ReservedENIs               int
+	SpotPriceMultiplier        float64
+	OnDemandPriceMultiplier    float64
 }
 
 func (*Settings) ConfigMap() string {
@@ -83,6 +87,8 @@ func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context,
 		configmap.AsString("aws.interruptionQueueName", &s.InterruptionQueueName),
 		AsStringMap("aws.tags", &s.Tags),
 		configmap.AsInt("aws.reservedENIs", &s.ReservedENIs),
+		configmap.AsFloat64("aws.spotPriceMultiplier", &s.SpotPriceMultiplier),
+		configmap.AsFloat64("aws.onDemandPriceMultiplier", &s.OnDemandPriceMultiplier),
 	); err != nil {
 		return ctx, fmt.Errorf("parsing settings, %w", err)
 	}

--- a/pkg/apis/settings/settings_validation.go
+++ b/pkg/apis/settings/settings_validation.go
@@ -32,6 +32,7 @@ func (s Settings) Validate() (errs *apis.FieldError) {
 		s.validateVMMemoryOverheadPercent(),
 		s.validateReservedENIs(),
 		s.validateAssumeRoleDuration(),
+		s.validatePriceMultiplier(),
 	).ViaField("aws")
 }
 
@@ -83,6 +84,16 @@ func (s Settings) validateVMMemoryOverheadPercent() (errs *apis.FieldError) {
 func (s Settings) validateReservedENIs() (errs *apis.FieldError) {
 	if s.ReservedENIs < 0 {
 		return errs.Also(apis.ErrInvalidValue("cannot be negative", "reservedENIs"))
+	}
+	return nil
+}
+
+func (s Settings) validatePriceMultiplier() (errs *apis.FieldError) {
+	if s.SpotPriceMultiplier <= 0 {
+		return errs.Also(apis.ErrInvalidValue("cannot be zero or negative", "SpotPriceMultiplier"))
+	}
+	if s.OnDemandPriceMultiplier <= 0 {
+		return errs.Also(apis.ErrInvalidValue("cannot be zero or negative", "OnDemandPriceMultiplier"))
 	}
 	return nil
 }

--- a/pkg/test/settings.go
+++ b/pkg/test/settings.go
@@ -34,6 +34,8 @@ type SettingOptions struct {
 	InterruptionQueueName      *string
 	Tags                       map[string]string
 	ReservedENIs               *int
+	SpotPriceMultiplier        *float64
+	OnDemandPriceMultiplier    *float64
 }
 
 func Settings(overrides ...SettingOptions) *awssettings.Settings {
@@ -54,5 +56,7 @@ func Settings(overrides ...SettingOptions) *awssettings.Settings {
 		InterruptionQueueName:      lo.FromPtrOr(options.InterruptionQueueName, ""),
 		Tags:                       options.Tags,
 		ReservedENIs:               lo.FromPtrOr(options.ReservedENIs, 0),
+		SpotPriceMultiplier:        lo.FromPtrOr(options.SpotPriceMultiplier, 1.0),
+		OnDemandPriceMultiplier:    lo.FromPtrOr(options.OnDemandPriceMultiplier, 1.0),
 	}
 }

--- a/website/content/en/preview/concepts/settings.md
+++ b/website/content/en/preview/concepts/settings.md
@@ -75,6 +75,10 @@ data:
   # Reserved ENIs are not included in the calculations for max-pods or kube-reserved
   # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
   aws.reservedENIs: "1"
+  # Spot Price Multiplier for including volume discounts etc. for spot prices. The spot price will be multiplied with the spotPriceMultiplier to determine the real cost
+  aws.spotPriceMultiplier: "0.95"
+  # On Demand Multiplier for including volume discounts etc. to ensure choosing the cheapest available instance. The ondemand price will be multiplied with the onDemandPriceMultiplier to determine the real cost
+  aws.onDemandPriceMultiplier: "0.60"
 ```
 
 ### Feature Gates


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Reimplementation of this PR: https://github.com/aws/karpenter/pull/3896

Added code to allow a custom multiplier to be applied to on-demand and spot pricing.
This allows you to add a multiplier to prices that will be taken into consideration on which instance to use.
This take's the same approach as [autospotting](https://github.com/LeanerCloud/AutoSpotting/blob/master/START.md#configuration-of-autospotting).

For Enterprise customers, instance prices can come from the Payer account which is not accessible outside of this account - this leads to a problem as we cannot get the accurate price data in AWS accounts running the Kubernetes clusters where it may be that running on-demand instance types would be cheaper than spot instance types.

When Karpenter retrieves the up-to-date pricing from AWS, the multiplier will be applied to the returned data.
The instance `getCapacityType` function has been updated so that it will be price aware - only if
 `offering.CapacityType == corev1beta1.CapacityTypeSpot && offering.Price == cheapestOffering` will the capacityType be set to Spot

**How was this change tested?**

- [x] Tests written around the settings change
- [x] Tests written around the multiplier being applied
- [ ] Tested in a Kubernetes cluster:
    - [x] Verify multiplier set to default value does not modify prices and karpenter launched expected capacity
    - [x] Verify when multiplier set prices were correctly modified and karpenter launched expected capacity
    - [x] Verify when multiplier set prices were correctly modified and karpenter launched on-demand capacity type when cheaper than spot pricing
    - [ ] Verify spot instances are consolidated to cheaper on-demand
    - [x] Verify on-demand instances are consolidated to cheaper spot

**Does this change impact docs?**
* [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
* [ ] Yes, issue opened: # <!-- issue number -->
* [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.