### PR TITLE
fix: report an error when the node template is not found

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -177,7 +177,10 @@ func (c *CloudProvider) GetInstanceTypes(ctx context.Context, nodePool *corev1be
 		if errors.IsNotFound(err) {
 			c.recorder.Publish(cloudproviderevents.NodePoolFailedToResolveNodeClass(nodePool))
 		}
-		return nil, client.IgnoreNotFound(fmt.Errorf("resolving node class, %w", err))
+		// We must return an error here in the event of the node class not being found. Otherwise users just get
+		// no instance types and a failure to schedule with no indicator pointing to a bad configuration
+		// as the cause.
+		return nil, fmt.Errorf("resolving node class, %w", err)
 	}
 	// TODO, break this coupling
 	instanceTypes, err := c.instanceTypeProvider.List(ctx, nodePool.Spec.Template.Spec.Kubelet, nodeClass)

--- a/pkg/cloudprovider/machine_test.go
+++ b/pkg/cloudprovider/machine_test.go
@@ -666,12 +666,12 @@ var _ = Describe("Machine/CloudProvider", func() {
 				// select nothing!
 				AMISelector: map[string]string{"Name": "nothing"},
 			})
+			misconfiguredNodeTemplate.Name = "misconfigured"
 			prov2 := test.Provisioner(coretest.ProvisionerOptions{
 				ProviderRef: &v1alpha5.MachineTemplateRef{
 					APIVersion: misconfiguredNodeTemplate.APIVersion,
 					Kind:       misconfiguredNodeTemplate.Kind,
-					// select nothing!
-					Name: "nothing",
+					Name:       "misconfigured",
 				},
 			})
 			ExpectApplied(ctx, env.Client, provisioner, prov2, nodeTemplate, misconfiguredNodeTemplate)


### PR DESCRIPTION
Fixes #4698

**Description**

Without this change, no instance types are found and the resulting behavior is a generic error regarding not finding instance types.


**How was this change tested?**

Deployed to EKS with no node template.

Previous error message:

```
INFO	controller.provisioner	provisioning/provisioner.go:238	skipping, no resolved instance types found	
ERROR	controller.provisioner	scheduling/scheduler.go:190	Could not schedule pod, all available instance types exceed limits for provisioner: "default"	
```

New Error Message
```
karpenter-5cd78bcc87-jlwnp controller 2023-09-28T12:49:09.907Z	ERROR	controller.provisioner	creating scheduler, getting instance types, resolving node class, resolving node template, getting providerRef, AWSNodeTemplate.karpenter.k8s.aws "defaultFake" not found	{"commit": "d71c265-dirty"
```

https://github.com/aws/karpenter-core/pull/547 modifies karpenter-core to log the instance type failure, but continue on to the next provisioner, changing the error into:

```
karpenter-d7887b4d7-wx64q controller 2023-09-28T13:04:14.064Z	ERROR	controller.provisioner	skipping, unable to resolve instance types, resolving node class, resolving node template, getting providerRef, AWSNodeTemplate.karpenter.k8s.aws "defaultFake" not found	{"commit": "ff540d0", "provisioner": "default"}
karpenter-d7887b4d7-wx64q controller 2023-09-28T13:04:14.066Z	ERROR	controller.provisioner	Could not schedule pod, all available instance types exceed limits for provisioner: "default"	{"commit": "ff540d0", "pod": "default/inflate-54b8bcf56d-fq8kk"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.