### PR TITLE
ci: Pin e2e-upgrade for deploying karpenter to kube-system

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -83,10 +83,9 @@ jobs:
       statuses: write # ./.github/actions/commit-status/start
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      # This version matches the steps of the newest version that contains the additional step
-      # of deploying the instance profile so that the pre-upgrade and post-upgrade create-cluster
-      # actions have the same number of steps and don't fail during post-cleanup
-      from_git_ref: 62c25a3ea85c7d00165e60a913fff1ec7c1f29fd
+      # This version matches the newest version that contains karpenter deployed
+      # to the kube-system namespace so that karpenter upgrade succeeds
+      from_git_ref: 3522382660f15d678406c7aafdc5aac14ac5cec2
       to_git_ref: ${{ inputs.git_ref }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change pins the version that is used for the pre-upgrade step to contain the change that involves Karpenter being deployed to the kube-system namespace (#5192)

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.