### PR TITLE
chore: Convert CDL values on tags for SelectorTerms 

### DIFF
--- a/pkg/utils/nodeclass/suite_test.go
+++ b/pkg/utils/nodeclass/suite_test.go
@@ -399,7 +399,7 @@ var _ = Describe("NodeClassUtils", func() {
 			"aws::name":   "ami-name1,ami-name2",
 			"aws::owners": "self,amazon",
 			"aws::ids":    "ami-1234,ami-5678",
-			"custom-tag":  "custom-value",
+			"custom-tag":  "custom-value1,custom-value2",
 			"custom-tag2": "custom-value2",
 		}
 		nodeClass := nodeclassutil.New(nodeTemplate)
@@ -417,14 +417,23 @@ var _ = Describe("NodeClassUtils", func() {
 
 		// Expect AMISelectorTerms to be exactly what we would expect from the filtering above
 		// This should include all permutations of the filters that could be used by this selector mechanism
-		Expect(nodeClass.Spec.AMISelectorTerms).To(HaveLen(8))
+		Expect(nodeClass.Spec.AMISelectorTerms).To(HaveLen(16))
 		Expect(nodeClass.Spec.AMISelectorTerms).To(ConsistOf(
 			v1beta1.AMISelectorTerm{
 				Name:  "ami-name1",
 				Owner: "self",
 				ID:    "ami-1234",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
+					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name1",
+				Owner: "self",
+				ID:    "ami-1234",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
 					"custom-tag2": "custom-value2",
 				},
 			},
@@ -433,7 +442,16 @@ var _ = Describe("NodeClassUtils", func() {
 				Owner: "self",
 				ID:    "ami-5678",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
+					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name1",
+				Owner: "self",
+				ID:    "ami-5678",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
 					"custom-tag2": "custom-value2",
 				},
 			},
@@ -442,7 +460,16 @@ var _ = Describe("NodeClassUtils", func() {
 				Owner: "amazon",
 				ID:    "ami-1234",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
+					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name1",
+				Owner: "amazon",
+				ID:    "ami-1234",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
 					"custom-tag2": "custom-value2",
 				},
 			},
@@ -451,7 +478,16 @@ var _ = Describe("NodeClassUtils", func() {
 				Owner: "amazon",
 				ID:    "ami-5678",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
+					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name1",
+				Owner: "amazon",
+				ID:    "ami-5678",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
 					"custom-tag2": "custom-value2",
 				},
 			},
@@ -460,7 +496,16 @@ var _ = Describe("NodeClassUtils", func() {
 				Owner: "self",
 				ID:    "ami-1234",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
+					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name2",
+				Owner: "self",
+				ID:    "ami-1234",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
 					"custom-tag2": "custom-value2",
 				},
 			},
@@ -469,7 +514,16 @@ var _ = Describe("NodeClassUtils", func() {
 				Owner: "self",
 				ID:    "ami-5678",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
+					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name2",
+				Owner: "self",
+				ID:    "ami-5678",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
 					"custom-tag2": "custom-value2",
 				},
 			},
@@ -478,7 +532,16 @@ var _ = Describe("NodeClassUtils", func() {
 				Owner: "amazon",
 				ID:    "ami-1234",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
+					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name2",
+				Owner: "amazon",
+				ID:    "ami-1234",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
 					"custom-tag2": "custom-value2",
 				},
 			},
@@ -487,8 +550,136 @@ var _ = Describe("NodeClassUtils", func() {
 				Owner: "amazon",
 				ID:    "ami-5678",
 				Tags: map[string]string{
-					"custom-tag":  "custom-value",
+					"custom-tag":  "custom-value1",
 					"custom-tag2": "custom-value2",
+				},
+			},
+			v1beta1.AMISelectorTerm{
+				Name:  "ami-name2",
+				Owner: "amazon",
+				ID:    "ami-5678",
+				Tags: map[string]string{
+					"custom-tag":  "custom-value2",
+					"custom-tag2": "custom-value2",
+				},
+			},
+		))
+
+		Expect(nodeClass.Spec.AMIFamily).To(Equal(nodeTemplate.Spec.AMIFamily))
+		Expect(nodeClass.Spec.UserData).To(Equal(nodeTemplate.Spec.UserData))
+		Expect(nodeClass.Spec.Role).To(BeEmpty())
+		Expect(nodeClass.Spec.Tags).To(Equal(nodeTemplate.Spec.Tags))
+		ExpectBlockDeviceMappingsEqual(nodeTemplate.Spec.BlockDeviceMappings, nodeClass.Spec.BlockDeviceMappings)
+		Expect(nodeClass.Spec.DetailedMonitoring).To(Equal(nodeTemplate.Spec.DetailedMonitoring))
+		ExpectMetadataOptionsEqual(nodeTemplate.Spec.MetadataOptions, nodeClass.Spec.MetadataOptions)
+		Expect(nodeClass.Spec.Context).To(Equal(nodeTemplate.Spec.Context))
+		Expect(nodeClass.Spec.LaunchTemplateName).To(Equal(nodeTemplate.Spec.LaunchTemplateName))
+		Expect(nodeClass.Spec.InstanceProfile).To(Equal(nodeTemplate.Spec.InstanceProfile))
+
+		ExpectSubnetStatusEqual(nodeTemplate.Status.Subnets, nodeClass.Status.Subnets)
+		ExpectSecurityGroupStatusEqual(nodeTemplate.Status.SecurityGroups, nodeClass.Status.SecurityGroups)
+		ExpectAMIStatusEqual(nodeTemplate.Status.AMIs, nodeClass.Status.AMIs)
+	})
+	It("should convert a AWSNodeTemplate to a EC2NodeClass (with comma delineated list on SubnetSelector)", func() {
+		nodeTemplate.Spec.SubnetSelector = map[string]string{
+			"test-key-1": "test-value-1,test-value-2,test-value-3",
+			"test-key-2": "test-value-1,test-value-2",
+		}
+
+		nodeClass := nodeclassutil.New(nodeTemplate)
+
+		for k, v := range nodeTemplate.Annotations {
+			Expect(nodeClass.Annotations).To(HaveKeyWithValue(k, v))
+		}
+		for k, v := range nodeTemplate.Labels {
+			Expect(nodeClass.Labels).To(HaveKeyWithValue(k, v))
+		}
+		Expect(nodeClass.Spec.SubnetSelectorTerms).To(HaveLen(6))
+		Expect(nodeClass.Spec.SubnetSelectorTerms).To(ConsistOf(
+			v1beta1.SubnetSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-1",
+				},
+			},
+			v1beta1.SubnetSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-2",
+					"test-key-2": "test-value-1",
+				},
+			},
+			v1beta1.SubnetSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-3",
+					"test-key-2": "test-value-1",
+				},
+			},
+			v1beta1.SubnetSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+				},
+			},
+			v1beta1.SubnetSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-2",
+					"test-key-2": "test-value-2",
+				},
+			},
+			v1beta1.SubnetSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-3",
+					"test-key-2": "test-value-2",
+				},
+			},
+		))
+
+		Expect(nodeClass.Spec.SecurityGroupSelectorTerms).To(HaveLen(1))
+		Expect(nodeClass.Spec.SecurityGroupSelectorTerms[0].Tags).To(Equal(nodeTemplate.Spec.SecurityGroupSelector))
+
+		Expect(nodeClass.Spec.AMIFamily).To(Equal(nodeTemplate.Spec.AMIFamily))
+		Expect(nodeClass.Spec.UserData).To(Equal(nodeTemplate.Spec.UserData))
+		Expect(nodeClass.Spec.Role).To(BeEmpty())
+		Expect(nodeClass.Spec.Tags).To(Equal(nodeTemplate.Spec.Tags))
+		ExpectBlockDeviceMappingsEqual(nodeTemplate.Spec.BlockDeviceMappings, nodeClass.Spec.BlockDeviceMappings)
+		Expect(nodeClass.Spec.DetailedMonitoring).To(Equal(nodeTemplate.Spec.DetailedMonitoring))
+		ExpectMetadataOptionsEqual(nodeTemplate.Spec.MetadataOptions, nodeClass.Spec.MetadataOptions)
+		Expect(nodeClass.Spec.Context).To(Equal(nodeTemplate.Spec.Context))
+		Expect(nodeClass.Spec.LaunchTemplateName).To(Equal(nodeTemplate.Spec.LaunchTemplateName))
+		Expect(nodeClass.Spec.InstanceProfile).To(Equal(nodeTemplate.Spec.InstanceProfile))
+
+		ExpectSubnetStatusEqual(nodeTemplate.Status.Subnets, nodeClass.Status.Subnets)
+		ExpectSecurityGroupStatusEqual(nodeTemplate.Status.SecurityGroups, nodeClass.Status.SecurityGroups)
+		ExpectAMIStatusEqual(nodeTemplate.Status.AMIs, nodeClass.Status.AMIs)
+	})
+	It("should convert a AWSNodeTemplate to a EC2NodeClass (with comma delineated list on SecurityGroupSelector)", func() {
+		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{
+			"test-key-1": "test-value-1,test-value-2",
+			"test-key-2": "test-value-1",
+		}
+
+		nodeClass := nodeclassutil.New(nodeTemplate)
+
+		for k, v := range nodeTemplate.Annotations {
+			Expect(nodeClass.Annotations).To(HaveKeyWithValue(k, v))
+		}
+		for k, v := range nodeTemplate.Labels {
+			Expect(nodeClass.Labels).To(HaveKeyWithValue(k, v))
+		}
+		Expect(nodeClass.Spec.SubnetSelectorTerms).To(HaveLen(1))
+		Expect(nodeClass.Spec.SubnetSelectorTerms[0].Tags).To(Equal(nodeTemplate.Spec.SubnetSelector))
+		Expect(nodeClass.Spec.SecurityGroupSelectorTerms).To(HaveLen(2))
+		Expect(nodeClass.Spec.SecurityGroupSelectorTerms).To(ConsistOf(
+			v1beta1.SecurityGroupSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-1",
+				},
+			},
+			v1beta1.SecurityGroupSelectorTerm{
+				Tags: map[string]string{
+					"test-key-1": "test-value-2",
+					"test-key-2": "test-value-1",
 				},
 			},
 		))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Convert CDL values on tags into multiple selectors
- This will affect subnet, security group, and AMI selectors

**How was this change tested?**
- `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.