### PR TITLE
chore: Rename `karpenter-provider-aws` in tools

### DIFF
--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -27,8 +27,8 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
-	"github.com/aws/karpenter/test/hack/resource/pkg/metrics"
-	"github.com/aws/karpenter/test/hack/resource/pkg/resourcetypes"
+	"github.com/aws/karpenter-provider-aws/test/hack/resource/pkg/metrics"
+	"github.com/aws/karpenter-provider-aws/test/hack/resource/pkg/resourcetypes"
 )
 
 const expirationTTL = time.Hour * 12

--- a/test/hack/resource/count/main.go
+++ b/test/hack/resource/count/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
-	"github.com/aws/karpenter/test/hack/resource/pkg/metrics"
-	"github.com/aws/karpenter/test/hack/resource/pkg/resourcetypes"
+	"github.com/aws/karpenter-provider-aws/test/hack/resource/pkg/metrics"
+	"github.com/aws/karpenter-provider-aws/test/hack/resource/pkg/resourcetypes"
 )
 
 const resourceCountTableName = "resourceCount"

--- a/test/hack/resource/go.mod
+++ b/test/hack/resource/go.mod
@@ -1,4 +1,4 @@
-module github.com/aws/karpenter/test/hack/resource
+module github.com/aws/karpenter-provider-aws/test/hack/resource
 
 go 1.21
 

--- a/tools/allocatable-diff/go.mod
+++ b/tools/allocatable-diff/go.mod
@@ -3,19 +3,18 @@ module github.com/aws/karpenter/tools/allocatable-diff
 go 1.21
 
 require (
-	github.com/aws/karpenter v0.32.2-0.20231205002141-fbdb621104b4
+	github.com/aws/karpenter-provider-aws v0.33.1-0.20231206223517-f73ccfa65419
 	github.com/samber/lo v1.39.0
 	k8s.io/api v0.28.4
-	k8s.io/apimachinery v0.28.4
 	k8s.io/client-go v0.28.4
 	sigs.k8s.io/controller-runtime v0.16.3
-	sigs.k8s.io/karpenter v0.32.2-0.20231205004259-6a5c00a354b3
+	sigs.k8s.io/karpenter v0.33.0
 )
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
-	github.com/aws/aws-sdk-go v1.48.11 // indirect
+	github.com/aws/aws-sdk-go v1.48.13 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
@@ -87,6 +86,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.4 // indirect
+	k8s.io/apimachinery v0.28.4 // indirect
 	k8s.io/cloud-provider v0.28.4 // indirect
 	k8s.io/component-base v0.28.4 // indirect
 	k8s.io/csi-translation-lib v0.28.4 // indirect

--- a/tools/allocatable-diff/go.sum
+++ b/tools/allocatable-diff/go.sum
@@ -48,10 +48,10 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/aws/aws-sdk-go v1.48.11 h1:9YbiSbaF/jWi+qLRl+J5dEhr2mcbDYHmKg2V7RBcD5M=
-github.com/aws/aws-sdk-go v1.48.11/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
-github.com/aws/karpenter v0.32.2-0.20231205002141-fbdb621104b4 h1:GbFqWkP2rUNKEtzAqJ8HJTCLQAVdlUdyu8XZrEpjEFU=
-github.com/aws/karpenter v0.32.2-0.20231205002141-fbdb621104b4/go.mod h1:7tIW1X81+Q+b177/BnypK6Ir7GiL5KKtR6pU6GphnAo=
+github.com/aws/aws-sdk-go v1.48.13 h1:6N4GTme6MpxfCisWf5pql8k3TBORiKTmbeutZCDXlG8=
+github.com/aws/aws-sdk-go v1.48.13/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/karpenter-provider-aws v0.33.1-0.20231206223517-f73ccfa65419 h1:zejIHIPkRwfw1VFHFqtM1YHYcxH3vcBkQIQbydw6YjI=
+github.com/aws/karpenter-provider-aws v0.33.1-0.20231206223517-f73ccfa65419/go.mod h1:PYMJm2lX/ppJjEfQg3OEeMb8UyYXW762mlmbJ7WueEg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -729,8 +729,8 @@ sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigw
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.32.2-0.20231205004259-6a5c00a354b3 h1:iTCm2GfvpG+x8GedLc2NIr5DtV6AbDf5V5NgV9CtcA0=
-sigs.k8s.io/karpenter v0.32.2-0.20231205004259-6a5c00a354b3/go.mod h1:7hPB7kdImFHAFp7pqPUqgBDOrh8GEcRnHT5uIlsXMKA=
+sigs.k8s.io/karpenter v0.33.0 h1:FvFzhYMwFackafImFeFz/ti/z/55NiZtr8HXiS+z9lU=
+sigs.k8s.io/karpenter v0.33.0/go.mod h1:7hPB7kdImFHAFp7pqPUqgBDOrh8GEcRnHT5uIlsXMKA=
 sigs.k8s.io/structured-merge-diff/v4 v4.3.0 h1:UZbZAZfX0wV2zr7YZorDz6GXROfDFj6LvqCRm4VUVKk=
 sigs.k8s.io/structured-merge-diff/v4 v4.3.0/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/tools/allocatable-diff/main.go
+++ b/tools/allocatable-diff/main.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -35,10 +33,9 @@ import (
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 	coreoperator "sigs.k8s.io/karpenter/pkg/operator"
 
-	"github.com/aws/karpenter/pkg/apis/v1alpha1"
-	"github.com/aws/karpenter/pkg/cloudprovider"
-	"github.com/aws/karpenter/pkg/operator"
-	"github.com/aws/karpenter/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider"
+	"github.com/aws/karpenter-provider-aws/pkg/operator"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 )
 
 var clusterName string
@@ -83,12 +80,6 @@ func main() {
 		op.SecurityGroupProvider,
 		op.SubnetProvider,
 	)
-	raw := &runtime.RawExtension{}
-	lo.Must0(raw.UnmarshalJSON(lo.Must(json.Marshal(&v1alpha1.AWS{
-		SubnetSelector: map[string]string{
-			"karpenter.sh/discovery": clusterName,
-		},
-	}))))
 	instanceTypes := lo.Must(cloudProvider.GetInstanceTypes(ctx, nil))
 
 	// Write the header information into the CSV

--- a/tools/kompat/cmd/kompat/main.go
+++ b/tools/kompat/cmd/kompat/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
-	"github.com/aws/karpenter/tools/kompat/pkg/kompat"
+	"github.com/aws/karpenter-provider-aws/tools/kompat/pkg/kompat"
 )
 
 const (

--- a/tools/kompat/go.mod
+++ b/tools/kompat/go.mod
@@ -1,4 +1,4 @@
-module github.com/aws/karpenter/tools/kompat
+module github.com/aws/karpenter-provider-aws/tools/kompat
 
 go 1.20
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the tools directory to use the correct naming for `karpenter-provider-aws`

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.