### PR TITLE
chore: Update enforce ordering on converted values for `karpenter-convert`

### DIFF
--- a/pkg/utils/nodeclass/nodeclass.go
+++ b/pkg/utils/nodeclass/nodeclass.go
@@ -16,6 +16,7 @@ package nodeclass
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/samber/lo"
@@ -69,12 +70,14 @@ func NewSubnetSelectorTerms(subnetSelector map[string]string) (terms []v1beta1.S
 	// Each of these slices needs to be pre-populated with the "0" element so that we can properly generate permutations
 	ids := []string{""}
 	tagSet := []map[string]string{make(map[string]string)}
-	for k, v := range subnetSelector {
+	selectorTagKeys := lo.Keys(subnetSelector)
+	sort.Strings(selectorTagKeys)
+	for _, k := range selectorTagKeys {
 		switch k {
 		case "aws-ids", "aws::ids":
-			ids = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
+			ids = lo.Map(strings.Split(subnetSelector[k], ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		default:
-			tagSet = createSelectorTags(k, v, tagSet)
+			tagSet = createSelectorTags(k, subnetSelector[k], tagSet)
 		}
 	}
 	// If there are some "special" keys used, we have to represent the old selector as multiple terms
@@ -96,12 +99,14 @@ func NewSecurityGroupSelectorTerms(securityGroupSelector map[string]string) (ter
 	// Each of these slices needs to be pre-populated with the "0" element so that we can properly generate permutations
 	ids := []string{""}
 	tagSet := []map[string]string{make(map[string]string)}
-	for k, v := range securityGroupSelector {
+	selectorTagKeys := lo.Keys(securityGroupSelector)
+	sort.Strings(selectorTagKeys)
+	for _, k := range selectorTagKeys {
 		switch k {
 		case "aws-ids", "aws::ids":
-			ids = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
+			ids = lo.Map(strings.Split(securityGroupSelector[k], ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		default:
-			tagSet = createSelectorTags(k, v, tagSet)
+			tagSet = createSelectorTags(k, securityGroupSelector[k], tagSet)
 		}
 	}
 	// If there are some "special" keys used, we have to represent the old selector as multiple terms
@@ -125,16 +130,18 @@ func NewAMISelectorTerms(amiSelector map[string]string) (terms []v1beta1.AMISele
 	names := []string{""}
 	owners := []string{""}
 	tagSet := []map[string]string{make(map[string]string)}
-	for k, v := range amiSelector {
+	selectorTagKeys := lo.Keys(amiSelector)
+	sort.Strings(selectorTagKeys)
+	for _, k := range selectorTagKeys {
 		switch k {
 		case "aws-ids", "aws::ids":
-			ids = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
+			ids = lo.Map(strings.Split(amiSelector[k], ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		case "aws::name":
-			names = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
+			names = lo.Map(strings.Split(amiSelector[k], ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		case "aws::owners":
-			owners = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
+			owners = lo.Map(strings.Split(amiSelector[k], ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		default:
-			tagSet = createSelectorTags(k, v, tagSet)
+			tagSet = createSelectorTags(k, amiSelector[k], tagSet)
 		}
 	}
 	// If there are some "special" keys used, we have to represent the old selector as multiple terms


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- To ensure that values are properly converted, we will enforce ordering on converted tags

**How was this change tested?**
- `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.