### PR TITLE
ci: Fix dump logs action to refer to the `kube-system` namespace

### DIFF
--- a/.github/actions/e2e/dump-logs/action.yaml
+++ b/.github/actions/e2e/dump-logs/action.yaml
@@ -26,14 +26,14 @@ runs:
       shell: bash
       run: |
         aws eks update-kubeconfig --name ${{ inputs.cluster_name }}
-        POD_NAME=$(kubectl get pods -n karpenter --no-headers -o custom-columns=":metadata.name" | tail -n 1)
+        POD_NAME=$(kubectl get pods -n kube-system --no-headers -o custom-columns=":metadata.name" | tail -n 1)
         echo "logs from pod ${POD_NAME}"
-        kubectl logs "${POD_NAME}" -n karpenter -c controller
+        kubectl logs "${POD_NAME}" -n kube-system -c controller
     - name: describe-karpenter-pods
       shell: bash
       run: |
         aws eks update-kubeconfig --name ${{ inputs.cluster_name }}
-        kubectl describe pods -n karpenter
+        kubectl describe pods -n kube-system
     - name: describe-nodes
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates the `dump-logs` action to refer to the `kube-system` namespace rather than the `karpenter` namespace since the E2E tests are now deploying Karpenter to the `kube-system` namespace since #5192

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.