### PR TITLE
ci: Fix codegen failure when the branch exists

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,5 +1,6 @@
-name: "APICodeGen"
+name: "CodeGenCI"
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 13 * * MON'
 jobs:

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -83,13 +83,14 @@ checkForUpdates() {
 
 gitOpenAndPullBranch() {
   git fetch origin
-  git checkout codegen || git checkout -b codegen || true
+  git checkout -b codegen
 }
 
 gitCommitAndPush() {
   UPDATE_SUBJECT=$1
   git commit -m "CodeGen updates from AWS API for ${UPDATE_SUBJECT}"
-  git push --set-upstream origin codegen
+  # Force push the branch since we might have left the branch around from the last codegen
+  git push --set-upstream origin codegen --force
 }
 
 noUpdates() {
@@ -101,7 +102,12 @@ if [[ $ENABLE_GIT_PUSH == true ]]; then
   gitOpenAndPullBranch
 fi
 
+echo "Updating bandwidth..."
 bandwidth
+echo "Updating pricing..."
 pricing
+echo "Updating VPC limits..."
 vpcLimits
+echo "Updating instance type data..."
 instanceTypeTestData
+echo "Finished codegen"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates CodeGen so that it won't fail when the branch is left around after a merge.

This change also allows you to manually trigger the CodeGen by running a `workflow_dispatch` operation against the action.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.