### PR TITLE
ci: Notify slack of `codegen` failures

### DIFF
--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -4,8 +4,6 @@ inputs:
   suite:
     description: "Suite that's running"
     required: true
-  k8s_version:
-    description: "Kubernetes version that this test ran against"
   url:
     description: "Webhook URL to send the Slack notification to"
     required: true

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -52,3 +52,9 @@ jobs:
               issue_number: result.data.number,
               labels: ['aws', 'dependencies']
             });
+      - name: notify slack of success or failure
+        uses: ./.github/actions/e2e/slack/notify
+        if: (success() || failure())
+        with:
+          url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          suite: codegen

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -132,7 +132,6 @@ jobs:
         with:
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
           suite: Upgrade
-          k8s_version: ${{ inputs.k8s_version }}
           git_ref: ${{ inputs.to_git_ref }}
       - name: dump logs on failure
         uses: ./.github/actions/e2e/dump-logs

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -133,7 +133,6 @@ jobs:
         with:
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
           suite: ${{ inputs.suite }}
-          k8s_version: ${{ inputs.k8s_version }}
           git_ref: ${{ inputs.git_ref }}
       - name: dump logs on failure
         uses: ./.github/actions/e2e/dump-logs


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds handling to send slack messages over to the notification channel when the codegen for Karpenter fails

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.