### PR TITLE
ci: Dump pod logs and describe pods based on karpenter pod labels

### DIFF
--- a/.github/actions/e2e/dump-logs/action.yaml
+++ b/.github/actions/e2e/dump-logs/action.yaml
@@ -22,20 +22,19 @@ runs:
         role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.role }}
         aws-region: ${{ inputs.region }}
         role-duration-seconds: 21600
+    - name: update cluster context
+      shell: bash
+      run: |
+        aws eks update-kubeconfig --name ${{ inputs.cluster_name }}
     - name: controller-logs
       shell: bash
       run: |
-        aws eks update-kubeconfig --name ${{ inputs.cluster_name }}
-        POD_NAME=$(kubectl get pods -n kube-system --no-headers -o custom-columns=":metadata.name" | tail -n 1)
-        echo "logs from pod ${POD_NAME}"
-        kubectl logs "${POD_NAME}" -n kube-system -c controller
-    - name: describe-karpenter-pods
+        kubectl logs -n kube-system -l app.kubernetes.io/name=karpenter --all-containers --ignore-errors
+    - name: describe karpenter pods
       shell: bash
       run: |
-        aws eks update-kubeconfig --name ${{ inputs.cluster_name }}
-        kubectl describe pods -n kube-system
-    - name: describe-nodes
+        kubectl describe pods -n kube-system -l app.kubernetes.io/name=karpenter
+    - name: describe nodes
       shell: bash
       run: |
-        aws eks update-kubeconfig --name ${{ inputs.cluster_name }}
         kubectl describe nodes


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the failure output of the Karpenter testing run to print out details only from pods that contains the `app.kubernetes.io/name` equal to `karpenter`

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.