### PR TITLE
test: add disruption budget e2es

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,4 +117,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231211181207-02c1f174f9be
+replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231212190935-05fbe2e611d2

--- a/go.mod
+++ b/go.mod
@@ -117,4 +117,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231213081543-700e0aff1142
+// replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231214021004-67edadf4afdf
+
+replace sigs.k8s.io/karpenter => /Users/nichotr/workplace/go/src/github.com/kubernetes-sigs/karpenter

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-// replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231214021004-67edadf4afdf
-
-replace sigs.k8s.io/karpenter => /Users/nichotr/workplace/go/src/github.com/kubernetes-sigs/karpenter

--- a/go.mod
+++ b/go.mod
@@ -117,4 +117,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231212190935-05fbe2e611d2
+replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231213081543-700e0aff1142

--- a/go.mod
+++ b/go.mod
@@ -116,3 +116,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace sigs.k8s.io/karpenter => github.com/njtran/karpenter v0.0.0-20231211181207-02c1f174f9be

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.16.3
-	sigs.k8s.io/karpenter v0.33.1-0.20231220195037-f7d63158162f
+	sigs.k8s.io/karpenter v0.33.1-0.20231224205745-0b25de76d2ad
 )
 
 require (
@@ -49,7 +49,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
-	github.com/go-logr/logr v1.3.0 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-openapi/jsonpointer v0.20.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,9 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
-github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
 github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR8/Gg=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
@@ -762,8 +763,8 @@ sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigw
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.33.1-0.20231220195037-f7d63158162f h1:Wp4uWmsPwnGQMlU/dKV+DrbanybV6/kt+72KhADsj+g=
-sigs.k8s.io/karpenter v0.33.1-0.20231220195037-f7d63158162f/go.mod h1:k1819wVloDPI/TUTEYWII7LgbC6paTSIgYgbywM0r/k=
+sigs.k8s.io/karpenter v0.33.1-0.20231224205745-0b25de76d2ad h1:C3zHs4PswQC3tCtQBFI2hXSj9SEfJNQ5Jcs8giTec8c=
+sigs.k8s.io/karpenter v0.33.1-0.20231224205745-0b25de76d2ad/go.mod h1:k1819wVloDPI/TUTEYWII7LgbC6paTSIgYgbywM0r/k=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/njtran/karpenter v0.0.0-20231211181207-02c1f174f9be h1:RCX/jOJohXzXO9zcBhnjJXfAlptjFfWH3f+My5ls6pY=
+github.com/njtran/karpenter v0.0.0-20231211181207-02c1f174f9be/go.mod h1:J/nUafEcmZrz34hS0B8H51hqgoAd5LhGeS63kMauOjs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.13.2 h1:Bi2gGVkfn6gQcjNjZJVO8Gf0FHzMPf2phUei9tejVMs=

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/njtran/karpenter v0.0.0-20231211181207-02c1f174f9be h1:RCX/jOJohXzXO9zcBhnjJXfAlptjFfWH3f+My5ls6pY=
-github.com/njtran/karpenter v0.0.0-20231211181207-02c1f174f9be/go.mod h1:J/nUafEcmZrz34hS0B8H51hqgoAd5LhGeS63kMauOjs=
+github.com/njtran/karpenter v0.0.0-20231212190935-05fbe2e611d2 h1:9iQPcRj7wn7DIL5TrU4Sgi7t8y3gZON6HX6Onfg5z78=
+github.com/njtran/karpenter v0.0.0-20231212190935-05fbe2e611d2/go.mod h1:J/nUafEcmZrz34hS0B8H51hqgoAd5LhGeS63kMauOjs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.13.2 h1:Bi2gGVkfn6gQcjNjZJVO8Gf0FHzMPf2phUei9tejVMs=

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/njtran/karpenter v0.0.0-20231213081543-700e0aff1142 h1:gWNbShaeJiVr2o11ap7o5nHipmzXcHaxoo3Jh0W8Vmc=
-github.com/njtran/karpenter v0.0.0-20231213081543-700e0aff1142/go.mod h1:J/nUafEcmZrz34hS0B8H51hqgoAd5LhGeS63kMauOjs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.13.2 h1:Bi2gGVkfn6gQcjNjZJVO8Gf0FHzMPf2phUei9tejVMs=

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/njtran/karpenter v0.0.0-20231212190935-05fbe2e611d2 h1:9iQPcRj7wn7DIL5TrU4Sgi7t8y3gZON6HX6Onfg5z78=
-github.com/njtran/karpenter v0.0.0-20231212190935-05fbe2e611d2/go.mod h1:J/nUafEcmZrz34hS0B8H51hqgoAd5LhGeS63kMauOjs=
+github.com/njtran/karpenter v0.0.0-20231213081543-700e0aff1142 h1:gWNbShaeJiVr2o11ap7o5nHipmzXcHaxoo3Jh0W8Vmc=
+github.com/njtran/karpenter v0.0.0-20231213081543-700e0aff1142/go.mod h1:J/nUafEcmZrz34hS0B8H51hqgoAd5LhGeS63kMauOjs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.13.2 h1:Bi2gGVkfn6gQcjNjZJVO8Gf0FHzMPf2phUei9tejVMs=

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -38,6 +38,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
@@ -79,7 +80,7 @@ func (env *Environment) ExpectUpdated(objects ...client.Object) {
 			current := o.DeepCopyObject().(client.Object)
 			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(current), current)).To(Succeed())
 			if current.GetResourceVersion() != o.GetResourceVersion() {
-				logging.FromContext(env).Infof("detected an update to an object with an outdated resource version, did you get the latest version of the object before patching?")
+				logging.FromContext(env).Infof("detected an update to an object (%s) with an outdated resource version, did you get the latest version of the object before patching?", lo.Must(apiutil.GVKForObject(o, env.Client.Scheme())))
 			}
 			o.SetResourceVersion(current.GetResourceVersion())
 			g.Expect(env.Client.Update(env.Context, o)).To(Succeed())

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -150,7 +150,7 @@ func (env *Environment) ExpectTestingFinalizerRemoved(obj client.Object) error {
 	})
 
 	if !equality.Semantic.DeepEqual(metaObj, deepCopy) {
-		return env.Client.Patch(env, metaObj, client.MergeFrom(deepCopy))
+		return client.IgnoreNotFound(env.Client.Patch(env, metaObj, client.MergeFrom(deepCopy)))
 	}
 	return nil
 }

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -96,15 +96,16 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 	})
-	Context("Budgets", func() {
-		It("should respect budgets for empty drift", func() {
-			coretest.ReplaceRequirements(nodePool,
+	FContext("Budgets", func() {
+		FIt("should respect budgets for empty drift", func() {
+			nodePool = coretest.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
 					Key:      v1beta1.LabelInstanceSize,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{"2xlarge"},
 				},
 			)
+			// We're expecting to create 3 nodes, so we'll expect to see 2 nodes deleting at one time.
 			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
 				Nodes: "50%",
 			}}
@@ -130,7 +131,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.ExpectCreated(nodeClass, nodePool, dep)
 
 			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
-			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectCreatedNodeCount("==", 3)
 			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
 			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
 
@@ -148,16 +149,22 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				})
 			}).Should(Succeed())
 
+			// List nodes so that we get any updated information on the nodes. If we don't
+			// we have the potential to over-write any changes Karpenter makes to the nodes.
+			nodes := env.EventuallyExpectNodeCountWithSelector("==", 3, labels.SelectorFromSet(map[string]string{corev1beta1.NodePoolLabelKey: nodePool.Name}))
+
 			// Add a finalizer to each node so that we can stop termination disruptions
+			By("adding finalizers to the nodes to prevent full termination")
 			for _, node := range nodes {
 				node.Finalizers = append(node.Finalizers, "test/finalizer")
 				env.ExpectUpdated(node)
 			}
 
+			By("making the nodes empty")
 			// Delete the deployment to make all nodes empty.
 			env.ExpectDeleted(dep)
 
-			env.EventuallyExpectTaintedNodeCount("==", 2)
+			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
 			// Set the expireAfter to "Never" to make sure new node isn't deleted
 			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
@@ -165,12 +172,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
 			env.ExpectUpdated(nodePool)
 
-			// Expect that only one node is tainted, even considering the new node that was just created.
-			var nodeList *v1.NodeList
-			Expect(env.Client.List(env, nodeList, client.MatchingFields{"spec.taints[*].karpenter.sh/disruption": "disrupting"})).To(Succeed())
-			Expect(len(nodeList.Items)).To(BeNumerically("==", 2))
-
-			// Add a finalizer to each node so that we can stop termination disruptions
+			// Remove the finalizer from each node so that we can terminate
 			for _, node := range nodes {
 				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
 					return finalizer == "test/finalizer"
@@ -180,18 +182,22 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone
-			env.EventuallyExpectNotFound(&nodeList.Items[0], &nodeList.Items[1])
+			env.EventuallyExpectNotFound(nodes[0], nodes[1])
+
+			nodes = env.EventuallyExpectTaintedNodeCount("==", 1)
+			env.EventuallyExpectNotFound(nodes[0])
 		})
-		It("should respect budgets for non-empty delete expiration", func() {
-			coretest.ReplaceRequirements(nodePool,
+		It("should respect budgets for non-empty delete drift", func() {
+			nodePool = coretest.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
 					Key:      v1beta1.LabelInstanceSize,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{"2xlarge"},
 				},
 			)
+			// We're expecting to create 3 nodes, so we'll expect to see 2 nodes deleting at one time.
 			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
-				Nodes: "30%",
+				Nodes: "50%",
 			}}
 			var numPods int32 = 6
 			dep = coretest.Deployment(coretest.DeploymentOptions{
@@ -215,7 +221,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.ExpectCreated(nodeClass, nodePool, dep)
 
 			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
-			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectCreatedNodeCount("==", 3)
 			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
 			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
 
@@ -233,23 +239,23 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				})
 			}).Should(Succeed())
 
+			// List nodes so that we get any updated information on the nodes. If we don't
+			// we have the potential to over-write any changes Karpenter makes to the nodes.
+			nodes := env.EventuallyExpectNodeCountWithSelector("==", 3, labels.SelectorFromSet(map[string]string{corev1beta1.NodePoolLabelKey: nodePool.Name}))
+
 			// Add a finalizer to each node so that we can stop termination disruptions
+			By("adding finalizers to the nodes to prevent full termination")
 			for _, node := range nodes {
 				node.Finalizers = append(node.Finalizers, "test/finalizer")
 				env.ExpectUpdated(node)
 			}
 
-			// Half the number of replicas so that all pods can fit on one node.
-			dep.Spec.Replicas = lo.ToPtr(int32(3))
+			By("making the nodes empty")
+			// Update the deployment to half the replicas.
+			dep.Spec.Replicas = lo.ToPtr[int32](3)
 			env.ExpectUpdated(dep)
 
-			// Remove the do-not-disrupt annotation so that the nodes are now deprovisionable
-			for _, pod := range env.ExpectPodsMatchingSelector(selector) {
-				delete(pod.Annotations, corev1beta1.DoNotDisruptAnnotationKey)
-				env.ExpectUpdated(pod)
-			}
-
-			env.EventuallyExpectTaintedNodeCount("==", 1)
+			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
 			// Set the expireAfter to "Never" to make sure new node isn't deleted
 			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
@@ -257,12 +263,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
 			env.ExpectUpdated(nodePool)
 
-			// Expect that only one node is tainted, even considering the new node that was just created.
-			var nodeList *v1.NodeList
-			Expect(env.Client.List(env, nodeList, client.MatchingFields{"spec.taints[*].karpenter.sh/disruption": "disrupting"})).To(Succeed())
-			Expect(len(nodeList.Items)).To(BeNumerically("==", 1))
-
-			// Add a finalizer to each node so that we can stop termination disruptions
+			// Remove the finalizer from each node so that we can terminate
 			for _, node := range nodes {
 				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
 					return finalizer == "test/finalizer"
@@ -272,10 +273,13 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone
-			env.EventuallyExpectNotFound(&nodeList.Items[0])
+			env.EventuallyExpectNotFound(nodes[0], nodes[1])
+
+			nodes = env.EventuallyExpectTaintedNodeCount("==", 1)
+			env.EventuallyExpectNotFound(nodes[0])
 		})
-		It("should respect budgets for non-empty replace expiration", func() {
-			coretest.ReplaceRequirements(nodePool,
+		It("should respect budgets for non-empty replace drift", func() {
+			nodePool = coretest.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
 					Key:      v1beta1.LabelInstanceSize,
 					Operator: v1.NodeSelectorOpIn,
@@ -307,13 +311,13 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.ExpectCreated(nodeClass, nodePool, dep)
 
 			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
-			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectCreatedNodeCount("==", 3)
 			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
 			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
 
 			// Drift the nodeclaims
 			nodePool.Spec.Template.Annotations = map[string]string{"test": "annotation"}
-			env.ExpectUpdated(nodePool)
+			env.ExpectCreatedOrUpdated(nodePool)
 
 			// Expect that the NodeClaims will all be marked expired
 			Eventually(func(g Gomega) {
@@ -324,6 +328,10 @@ var _ = Describe("Drift", Label("AWS"), func() {
 					g.Expect(nc.StatusConditions().GetCondition(corev1beta1.Drifted).IsTrue()).To(BeTrue())
 				})
 			}).Should(Succeed())
+
+			// List nodes so that we get any updated information on the nodes. If we don't
+			// we have the potential to over-write any changes Karpenter makes to the nodes.
+			nodes := env.EventuallyExpectNodeCountWithSelector("==", 3, labels.SelectorFromSet(map[string]string{corev1beta1.NodePoolLabelKey: nodePool.Name}))
 
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range nodes {
@@ -358,7 +366,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			Expect(env.Client.List(env, nodeList, client.MatchingFields{"spec.taints[*].karpenter.sh/disruption": "disrupting"})).To(Succeed())
 			Expect(len(nodeList.Items)).To(BeNumerically("==", 1))
 
-			// Add a finalizer to each node so that we can stop termination disruptions
+			// Remove the finalizer from each node so that we can terminate
 			for _, node := range nodes {
 				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
 					return finalizer == "test/finalizer"

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -224,8 +224,8 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.ExpectUpdated(dep)
 
 			By("spreading the pods to each of the nodes")
-			pods := env.EventuallyExpectHealthyPodCount(selector, 3)
-			nodes := []*v1.Node{}
+			env.EventuallyExpectHealthyPodCount(selector, 3)
+			var nodes []*v1.Node
 			// Delete pods from the deployment until each node has one pod.
 			nodePods := []*v1.Pod{}
 			for {
@@ -275,7 +275,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			}).Should(Succeed())
 
 			By("enabling disruption by removing the do not disrupt annotation")
-			pods = env.EventuallyExpectHealthyPodCount(selector, 3)
+			pods := env.EventuallyExpectHealthyPodCount(selector, 3)
 			// Remove the do-not-disrupt annotation so that the nodes are now disruptable
 			for _, pod := range pods {
 				delete(pod.Annotations, corev1beta1.DoNotDisruptAnnotationKey)
@@ -293,8 +293,8 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
 			By("removing the finalizer from the nodes")
-			env.ExpectTestingFinalizerRemoved(nodes[0])
-			env.ExpectTestingFinalizerRemoved(nodes[1])
+			Expect(env.ExpectTestingFinalizerRemoved(nodes[0])).To(Succeed())
+			Expect(env.ExpectTestingFinalizerRemoved(nodes[1])).To(Succeed())
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone
@@ -375,8 +375,8 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			tainted := env.EventuallyExpectTaintedNodeCount("==", 2)
 			env.EventuallyExpectCreatedNodeCount("==", 2)
 
-			env.ExpectTestingFinalizerRemoved(tainted[0])
-			env.ExpectTestingFinalizerRemoved(tainted[1])
+			Expect(env.ExpectTestingFinalizerRemoved(tainted[0])).To(Succeed())
+			Expect(env.ExpectTestingFinalizerRemoved(tainted[1])).To(Succeed())
 
 			env.EventuallyExpectNotFound(tainted[0], tainted[1])
 
@@ -384,7 +384,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			tainted = env.EventuallyExpectTaintedNodeCount("==", 1)
 			env.EventuallyExpectCreatedNodeCount("==", 3)
 
-			env.ExpectTestingFinalizerRemoved(tainted[0])
+			Expect(env.ExpectTestingFinalizerRemoved(tainted[0])).To(Succeed())
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -167,12 +167,6 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
-			// Set the expireAfter to "Never" to make sure new node isn't deleted
-			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
-			// racing at the end of the E2E test, leaking node resources into subsequent tests
-			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
-			env.ExpectUpdated(nodePool)
-
 			// Remove the finalizer from each node so that we can terminate
 			for _, node := range nodes {
 				env.ExpectTestingFinalizerRemoved(node)
@@ -183,6 +177,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.EventuallyExpectNotFound(nodes[0], nodes[1])
 
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 1)
+			env.ExpectTestingFinalizerRemoved(nodes[0])
 			env.EventuallyExpectNotFound(nodes[0])
 		})
 		It("should respect budgets for non-empty delete drift", func() {
@@ -193,11 +188,11 @@ var _ = Describe("Drift", Label("AWS"), func() {
 					Values:   []string{"2xlarge"},
 				},
 			)
-			// We're expecting to create 3 nodes, so we'll expect to see 2 nodes deleting at one time.
+			// We're expecting to create 3 nodes, so we'll expect to see at most 2 nodes deleting at one time.
 			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
 				Nodes: "50%",
 			}}
-			var numPods int32 = 6
+			var numPods int32 = 9
 			dep = coretest.Deployment(coretest.DeploymentOptions{
 				Replicas: numPods,
 				PodOptions: coretest.PodOptions{
@@ -207,10 +202,10 @@ var _ = Describe("Drift", Label("AWS"), func() {
 						},
 						Labels: map[string]string{"app": "large-app"},
 					},
-					// Each 2xlarge has 8 cpu, so each node should fit 2 pods.
+					// Each 2xlarge has 8 cpu, so each node should fit no more than 3 pods.
 					ResourceRequirements: v1.ResourceRequirements{
 						Requests: v1.ResourceList{
-							v1.ResourceCPU: resource.MustParse("3"),
+							v1.ResourceCPU: resource.MustParse("2100m"),
 						},
 					},
 				},
@@ -221,13 +216,55 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
 			env.EventuallyExpectCreatedNodeCount("==", 3)
 			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
-			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
+			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after drift
 
+			By("scaling down the deployment")
+			// Update the deployment to a third of the replicas.
+			dep.Spec.Replicas = lo.ToPtr[int32](3)
+			env.ExpectUpdated(dep)
+
+			By("spreading the pods to each of the nodes")
+			pods := env.EventuallyExpectHealthyPodCount(selector, 3)
+			nodes := []*v1.Node{}
+			// Delete pods from the deployment until each node has one pod.
+			nodePods := []*v1.Pod{}
+			for {
+				nodes = env.EventuallyExpectNodeCount("==", 3)
+				node, found := lo.Find(nodes, func(n *v1.Node) bool {
+					nodePods = env.ExpectHealthyPodsForNode(n.Name)
+					return len(nodePods) > 1
+				})
+				if !found {
+					break
+				}
+				// Set the nodes to unschedulable so that the pods won't reschedule.
+				node.Spec.Unschedulable = true
+				env.ExpectUpdated(node)
+				for _, pod := range nodePods[1:] {
+					env.ExpectDeleted(pod)
+				}
+				Eventually(func(g Gomega) {
+					g.Expect(len(env.ExpectHealthyPodsForNode(node.Name))).To(Equal(1))
+				}).WithTimeout(5 * time.Second).Should(Succeed())
+			}
+			env.EventuallyExpectHealthyPodCount(selector, 3)
+
+			By("cordoning and adding finalizer to the nodes")
+			nodes = env.EventuallyExpectNodeCount("==", 3)
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = append(node.Finalizers, common.TestingFinalizer)
+				// Set nodes as unschedulable so that pod nomination doesn't delay disruption for the second disruption action
+				node.Spec.Unschedulable = true
+				env.ExpectUpdated(node)
+			}
+
+			By("drifting the nodes")
 			// Drift the nodeclaims
 			nodePool.Spec.Template.Annotations = map[string]string{"test": "annotation"}
 			env.ExpectUpdated(nodePool)
 
-			// Expect that the NodeClaims will all be marked expired
+			// Expect that the NodeClaims will all be marked drifted
 			Eventually(func(g Gomega) {
 				nodeClaimList := &corev1beta1.NodeClaimList{}
 				err := env.Client.List(env.Context, nodeClaimList)
@@ -237,43 +274,33 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				})
 			}).Should(Succeed())
 
+			By("enabling disruption by removing the do not disrupt annotation")
+			pods = env.EventuallyExpectHealthyPodCount(selector, 3)
+			// Remove the do-not-disrupt annotation so that the nodes are now disruptable
+			for _, pod := range pods {
+				delete(pod.Annotations, corev1beta1.DoNotDisruptAnnotationKey)
+				env.ExpectUpdated(pod)
+			}
+
 			// List nodes so that we get any updated information on the nodes. If we don't
 			// we have the potential to over-write any changes Karpenter makes to the nodes.
-			nodes := env.EventuallyExpectNodeCountWithSelector("==", 3, labels.SelectorFromSet(map[string]string{corev1beta1.NodePoolLabelKey: nodePool.Name}))
+			nodes = env.EventuallyExpectNodeCount("==", 3)
 
-			// Add a finalizer to each node so that we can stop termination disruptions
-			By("adding finalizers to the nodes to prevent full termination")
-			for _, node := range nodes {
-				node.Finalizers = append(node.Finalizers, common.TestingFinalizer)
-				env.ExpectUpdated(node)
-			}
-
-			By("making the nodes empty")
-			// Update the deployment to half the replicas.
-			dep.Spec.Replicas = lo.ToPtr[int32](3)
-			env.ExpectUpdated(dep)
-
+			nodes[0].Spec.Unschedulable = false
+			nodes[1].Spec.Unschedulable = false
+			env.ExpectUpdated(nodes[0])
+			env.ExpectUpdated(nodes[1])
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
-			// Set the expireAfter to "Never" to make sure new node isn't deleted
-			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
-			// racing at the end of the E2E test, leaking node resources into subsequent tests
-			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
-			env.ExpectUpdated(nodePool)
-
-			// Remove the finalizer from each node so that we can terminate
-			for _, node := range nodes {
-				env.ExpectTestingFinalizerRemoved(node)
-			}
+			By("removing the finalizer from the nodes")
+			env.ExpectTestingFinalizerRemoved(nodes[0])
+			env.ExpectTestingFinalizerRemoved(nodes[1])
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone
 			env.EventuallyExpectNotFound(nodes[0], nodes[1])
-
-			nodes = env.EventuallyExpectTaintedNodeCount("==", 1)
-			env.EventuallyExpectNotFound(nodes[0])
 		})
-		It("should respect budgets for non-empty replace drift", func() {
+		FIt("should respect budgets for non-empty replace drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
 					Key:      v1beta1.LabelInstanceSize,
@@ -281,10 +308,11 @@ var _ = Describe("Drift", Label("AWS"), func() {
 					Values:   []string{"2xlarge"},
 				},
 			)
+			// We're expecting to create 3 nodes, so we'll expect to see at most 2 nodes deleting at one time.
 			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
-				Nodes: "25%",
+				Nodes: "50%",
 			}}
-			var numPods int32 = 6
+			var numPods int32 = 3
 			dep = coretest.Deployment(coretest.DeploymentOptions{
 				Replicas: numPods,
 				PodOptions: coretest.PodOptions{
@@ -294,10 +322,10 @@ var _ = Describe("Drift", Label("AWS"), func() {
 						},
 						Labels: map[string]string{"app": "large-app"},
 					},
-					// Each 2xlarge has 8 cpu, so each node should fit 2 pods.
+					// Each 2xlarge has 8 cpu, so each node should fit no more than 3 pods.
 					ResourceRequirements: v1.ResourceRequirements{
 						Requests: v1.ResourceList{
-							v1.ResourceCPU: resource.MustParse("3"),
+							v1.ResourceCPU: resource.MustParse("5"),
 						},
 					},
 				},
@@ -308,13 +336,23 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
 			env.EventuallyExpectCreatedNodeCount("==", 3)
 			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
-			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
+			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after drift
 
+			By("cordoning and adding finalizer to the nodes")
+			nodes := env.EventuallyExpectNodeCount("==", 3)
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = append(node.Finalizers, common.TestingFinalizer)
+				// Set nodes as unschedulable so that pod nomination doesn't delay disruption for the second disruption action
+				env.ExpectUpdated(node)
+			}
+
+			By("drifting the nodes")
 			// Drift the nodeclaims
 			nodePool.Spec.Template.Annotations = map[string]string{"test": "annotation"}
-			env.ExpectCreatedOrUpdated(nodePool)
+			env.ExpectUpdated(nodePool)
 
-			// Expect that the NodeClaims will all be marked expired
+			// Expect that the NodeClaims will all be marked drifted
 			Eventually(func(g Gomega) {
 				nodeClaimList := &corev1beta1.NodeClaimList{}
 				err := env.Client.List(env.Context, nodeClaimList)
@@ -324,51 +362,33 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				})
 			}).Should(Succeed())
 
-			// List nodes so that we get any updated information on the nodes. If we don't
-			// we have the potential to over-write any changes Karpenter makes to the nodes.
-			nodes := env.EventuallyExpectNodeCountWithSelector("==", 3, labels.SelectorFromSet(map[string]string{corev1beta1.NodePoolLabelKey: nodePool.Name}))
-
-			// Add a finalizer to each node so that we can stop termination disruptions
-			for _, node := range nodes {
-				node.Finalizers = append(node.Finalizers, common.TestingFinalizer)
-				env.ExpectUpdated(node)
-			}
-
-			// Half the number of replicas so that all pods can fit on one node.
-			dep.Spec.Replicas = lo.ToPtr(int32(3))
-			env.ExpectUpdated(dep)
-
-			// Remove the do-not-disrupt annotation so that the nodes are now deprovisionable
-			for _, pod := range env.ExpectPodsMatchingSelector(selector) {
+			By("enabling disruption by removing the do not disrupt annotation")
+			pods := env.EventuallyExpectHealthyPodCount(selector, 3)
+			// Remove the do-not-disrupt annotation so that the nodes are now disruptable
+			for _, pod := range pods {
 				delete(pod.Annotations, corev1beta1.DoNotDisruptAnnotationKey)
 				env.ExpectUpdated(pod)
 			}
 
-			env.EventuallyExpectTaintedNodeCount("==", 1)
+			nodes = env.EventuallyExpectNodeCount("==", 3)
+			// Expect one node tainted and a new node created 2 times.
+			tainted := env.EventuallyExpectTaintedNodeCount("==", 2)
+			env.EventuallyExpectCreatedNodeCount("==", 2)
 
-			// Set the expireAfter to "Never" to make sure new node isn't deleted
-			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
-			// racing at the end of the E2E test, leaking node resources into subsequent tests
-			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
-			env.ExpectUpdated(nodePool)
+			env.ExpectTestingFinalizerRemoved(tainted[0])
+			env.ExpectTestingFinalizerRemoved(tainted[1])
 
-			// Expect that there's another node created.
-			env.EventuallyExpectCreatedNodeClaimCount("==", 1)
-			nodes = env.EventuallyExpectCreatedNodeCount("==", 1)
+			env.EventuallyExpectNotFound(tainted[0], tainted[1])
 
-			// Expect that only one node is tainted, even considering the new node that was just created.
-			var nodeList *v1.NodeList
-			Expect(env.Client.List(env, nodeList, client.MatchingFields{"spec.taints[*].karpenter.sh/disruption": "disrupting"})).To(Succeed())
-			Expect(len(nodeList.Items)).To(BeNumerically("==", 1))
+			// Expect one node tainted and a new node created 2 times.
+			tainted = env.EventuallyExpectTaintedNodeCount("==", 1)
+			env.EventuallyExpectCreatedNodeCount("==", 3)
 
-			// Remove the finalizer from each node so that we can terminate
-			for _, node := range nodes {
-				env.ExpectTestingFinalizerRemoved(node)
-			}
+			env.ExpectTestingFinalizerRemoved(tainted[0])
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone
-			env.EventuallyExpectNotFound(&nodeList.Items[0])
+			env.EventuallyExpectNotFound(nodes[0], nodes[1], nodes[2])
 		})
 	})
 	It("should disrupt nodes that have drifted due to AMIs", func() {

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			Expect(env.ExpectTestingFinalizerRemoved(nodes[0])).To(Succeed())
 			env.EventuallyExpectNotFound(nodes[0])
 		})
-		FIt("should respect budgets for non-empty delete drift", func() {
+		It("should respect budgets for non-empty delete drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
 					Key:      v1beta1.LabelInstanceSize,

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			Expect(env.ExpectTestingFinalizerRemoved(nodes[0])).To(Succeed())
 			env.EventuallyExpectNotFound(nodes[0])
 		})
-		It("should respect budgets for non-empty delete drift", func() {
+		FIt("should respect budgets for non-empty delete drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
 					Key:      v1beta1.LabelInstanceSize,
@@ -286,10 +286,9 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			// we have the potential to over-write any changes Karpenter makes to the nodes.
 			nodes = env.EventuallyExpectNodeCount("==", 3)
 
+			// Mark one node as schedulable so the other two nodes can schedule to this node and delete.
 			nodes[0].Spec.Unschedulable = false
-			nodes[1].Spec.Unschedulable = false
 			env.ExpectUpdated(nodes[0])
-			env.ExpectUpdated(nodes[1])
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
 			By("removing the finalizer from the nodes")
@@ -371,7 +370,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			}
 
 			nodes = env.EventuallyExpectNodeCount("==", 3)
-			// Expect one node tainted and a new node created 2 times.
+			// Expect two nodes tainted, and 2 nodes created
 			tainted := env.EventuallyExpectTaintedNodeCount("==", 2)
 			env.EventuallyExpectCreatedNodeCount("==", 2)
 
@@ -380,7 +379,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 			env.EventuallyExpectNotFound(tainted[0], tainted[1])
 
-			// Expect one node tainted and a new node created 2 times.
+			// Expect one node tainted and a one more new node created.
 			tainted = env.EventuallyExpectTaintedNodeCount("==", 1)
 			env.EventuallyExpectCreatedNodeCount("==", 3)
 

--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Expiration", func() {
 			// Expect that two nodes are tainted.
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
-			// Add a finalizer to each node so that we can stop termination disruptions
+			// Remove finalizers
 			for _, node := range nodes {
 				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
 			}
@@ -261,10 +261,9 @@ var _ = Describe("Expiration", func() {
 			// we have the potential to over-write any changes Karpenter makes to the nodes.
 			nodes = env.EventuallyExpectNodeCount("==", 3)
 
+			// Mark one node as schedulable so the other two nodes can schedule to this node and delete.
 			nodes[0].Spec.Unschedulable = false
-			nodes[1].Spec.Unschedulable = false
 			env.ExpectUpdated(nodes[0])
-			env.ExpectUpdated(nodes[1])
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
 			By("removing the finalizer from the nodes")
@@ -347,7 +346,7 @@ var _ = Describe("Expiration", func() {
 			}
 
 			nodes = env.EventuallyExpectNodeCount("==", 3)
-			// Expect one node tainted and a new node created 2 times.
+			// Expect two nodes tainted and two nodes created
 			tainted := env.EventuallyExpectTaintedNodeCount("==", 2)
 			env.EventuallyExpectCreatedNodeCount("==", 2)
 

--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,6 +67,269 @@ var _ = AfterEach(func() { env.Cleanup() })
 var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("Expiration", func() {
+	Context("Budgets", func() {
+		It("should respect budgets for empty expiration", func() {
+			coretest.ReplaceRequirements(nodePool,
+				v1.NodeSelectorRequirement{
+					Key:      v1beta1.LabelInstanceSize,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"2xlarge"},
+				},
+			)
+			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
+				Nodes: "50%",
+			}}
+			var numPods int32 = 6
+			dep := coretest.Deployment(coretest.DeploymentOptions{
+				Replicas: numPods,
+				PodOptions: coretest.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							corev1beta1.DoNotDisruptAnnotationKey: "true",
+						},
+						Labels: map[string]string{"app": "large-app"},
+					},
+					// Each 2xlarge has 8 cpu, so each node should fit 2 pods.
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("3"),
+						},
+					},
+				},
+			})
+			selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+			env.ExpectCreated(nodeClass, nodePool, dep)
+
+			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
+			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
+
+			// Expect that the NodeClaims will all be marked expired
+			Eventually(func(g Gomega) {
+				nodeClaimList := &corev1beta1.NodeClaimList{}
+				err := env.Client.List(env.Context, nodeClaimList)
+				g.Expect(err).To(Succeed())
+				lo.ForEach(nodeClaimList.Items, func(nc corev1beta1.NodeClaim, _ int) {
+					g.Expect(nc.StatusConditions().GetCondition(corev1beta1.Expired).IsTrue()).To(BeTrue())
+				})
+			}).Should(Succeed())
+
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = append(node.Finalizers, "test/finalizer")
+				env.ExpectUpdated(node)
+			}
+
+			// Delete the deployment to make all nodes empty.
+			env.ExpectDeleted(dep)
+
+			env.EventuallyExpectTaintedNodeCount("==", 2)
+
+			// Set the expireAfter to "Never" to make sure new node isn't deleted
+			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
+			// racing at the end of the E2E test, leaking node resources into subsequent tests
+			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+			env.ExpectUpdated(nodePool)
+
+			// Expect that only one node is tainted, even considering the new node that was just created.
+			var nodeList *v1.NodeList
+			Expect(env.Client.List(env, nodeList, client.MatchingFields{"spec.taints[*].karpenter.sh/disruption": "disrupting"})).To(Succeed())
+			Expect(len(nodeList.Items)).To(BeNumerically("==", 2))
+
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
+					return finalizer == "test/finalizer"
+				})
+				env.ExpectUpdated(node)
+			}
+
+			// After the deletion timestamp is set and all pods are drained
+			// the node should be gone
+			env.EventuallyExpectNotFound(&nodeList.Items[0], &nodeList.Items[1])
+		})
+		It("should respect budgets for non-empty delete expiration", func() {
+			coretest.ReplaceRequirements(nodePool,
+				v1.NodeSelectorRequirement{
+					Key:      v1beta1.LabelInstanceSize,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"2xlarge"},
+				},
+			)
+			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
+				Nodes: "30%",
+			}}
+			var numPods int32 = 6
+			dep := coretest.Deployment(coretest.DeploymentOptions{
+				Replicas: numPods,
+				PodOptions: coretest.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							corev1beta1.DoNotDisruptAnnotationKey: "true",
+						},
+						Labels: map[string]string{"app": "large-app"},
+					},
+					// Each 2xlarge has 8 cpu, so each node should fit 2 pods.
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("3"),
+						},
+					},
+				},
+			})
+			selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+			env.ExpectCreated(nodeClass, nodePool, dep)
+
+			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
+			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
+
+			// Expect that the NodeClaims will all be marked expired
+			Eventually(func(g Gomega) {
+				nodeClaimList := &corev1beta1.NodeClaimList{}
+				err := env.Client.List(env.Context, nodeClaimList)
+				g.Expect(err).To(Succeed())
+				lo.ForEach(nodeClaimList.Items, func(nc corev1beta1.NodeClaim, _ int) {
+					g.Expect(nc.StatusConditions().GetCondition(corev1beta1.Expired).IsTrue()).To(BeTrue())
+				})
+			}).Should(Succeed())
+
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = append(node.Finalizers, "test/finalizer")
+				env.ExpectUpdated(node)
+			}
+
+			// Half the number of replicas so that all pods can fit on one node.
+			dep.Spec.Replicas = lo.ToPtr(int32(3))
+			env.ExpectUpdated(dep)
+
+			// Remove the do-not-disrupt annotation so that the nodes are now deprovisionable
+			for _, pod := range env.ExpectPodsMatchingSelector(selector) {
+				delete(pod.Annotations, corev1beta1.DoNotDisruptAnnotationKey)
+				env.ExpectUpdated(pod)
+			}
+
+			env.EventuallyExpectTaintedNodeCount("==", 1)
+
+			// Set the expireAfter to "Never" to make sure new node isn't deleted
+			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
+			// racing at the end of the E2E test, leaking node resources into subsequent tests
+			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+			env.ExpectUpdated(nodePool)
+
+			// Expect that only one node is tainted, even considering the new node that was just created.
+			var nodeList *v1.NodeList
+			Expect(env.Client.List(env, nodeList, client.MatchingFields{"spec.taints[*].karpenter.sh/disruption": "disrupting"})).To(Succeed())
+			Expect(len(nodeList.Items)).To(BeNumerically("==", 1))
+
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
+					return finalizer == "test/finalizer"
+				})
+				env.ExpectUpdated(node)
+			}
+
+			// After the deletion timestamp is set and all pods are drained
+			// the node should be gone
+			env.EventuallyExpectNotFound(&nodeList.Items[0])
+		})
+		It("should respect budgets for non-empty replace expiration", func() {
+			coretest.ReplaceRequirements(nodePool,
+				v1.NodeSelectorRequirement{
+					Key:      v1beta1.LabelInstanceSize,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"2xlarge"},
+				},
+			)
+			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
+				Nodes: "25%",
+			}}
+			var numPods int32 = 6
+			dep := coretest.Deployment(coretest.DeploymentOptions{
+				Replicas: numPods,
+				PodOptions: coretest.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							corev1beta1.DoNotDisruptAnnotationKey: "true",
+						},
+						Labels: map[string]string{"app": "large-app"},
+					},
+					// Each 2xlarge has 8 cpu, so each node should fit 2 pods.
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("3"),
+						},
+					},
+				},
+			})
+			selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+			env.ExpectCreated(nodeClass, nodePool, dep)
+
+			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
+			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+			env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
+
+			// Expect that the NodeClaims will all be marked expired
+			Eventually(func(g Gomega) {
+				nodeClaimList := &corev1beta1.NodeClaimList{}
+				err := env.Client.List(env.Context, nodeClaimList)
+				g.Expect(err).To(Succeed())
+				lo.ForEach(nodeClaimList.Items, func(nc corev1beta1.NodeClaim, _ int) {
+					g.Expect(nc.StatusConditions().GetCondition(corev1beta1.Expired).IsTrue()).To(BeTrue())
+				})
+			}).Should(Succeed())
+
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = append(node.Finalizers, "test/finalizer")
+				env.ExpectUpdated(node)
+			}
+
+			// Half the number of replicas so that all pods can fit on one node.
+			dep.Spec.Replicas = lo.ToPtr(int32(3))
+			env.ExpectUpdated(dep)
+
+			// Remove the do-not-disrupt annotation so that the nodes are now deprovisionable
+			for _, pod := range env.ExpectPodsMatchingSelector(selector) {
+				delete(pod.Annotations, corev1beta1.DoNotDisruptAnnotationKey)
+				env.ExpectUpdated(pod)
+			}
+
+			env.EventuallyExpectTaintedNodeCount("==", 1)
+
+			// Set the expireAfter to "Never" to make sure new node isn't deleted
+			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
+			// racing at the end of the E2E test, leaking node resources into subsequent tests
+			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+			env.ExpectUpdated(nodePool)
+
+			// Expect that there's another node created.
+			env.EventuallyExpectCreatedNodeClaimCount("==", 1)
+			nodes = env.EventuallyExpectCreatedNodeCount("==", 1)
+
+			// Expect that only one node is tainted, even considering the new node that was just created.
+			var nodeList *v1.NodeList
+			Expect(env.Client.List(env, nodeList, client.MatchingFields{"spec.taints[*].karpenter.sh/disruption": "disrupting"})).To(Succeed())
+			Expect(len(nodeList.Items)).To(BeNumerically("==", 1))
+
+			// Add a finalizer to each node so that we can stop termination disruptions
+			for _, node := range nodes {
+				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
+					return finalizer == "test/finalizer"
+				})
+				env.ExpectUpdated(node)
+			}
+
+			// After the deletion timestamp is set and all pods are drained
+			// the node should be gone
+			env.EventuallyExpectNotFound(&nodeList.Items[0])
+		})
+	})
 	It("should expire the node after the expiration is reached", func() {
 		var numPods int32 = 1
 		dep := coretest.Deployment(coretest.DeploymentOptions{

--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-provider-aws/test/pkg/environment/aws"
+	"github.com/aws/karpenter-provider-aws/test/pkg/environment/common"
 
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
@@ -117,7 +118,7 @@ var _ = Describe("Expiration", func() {
 
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range nodes {
-				node.Finalizers = append(node.Finalizers, "test/finalizer")
+				node.Finalizers = append(node.Finalizers, common.TestingFinalizer)
 				env.ExpectUpdated(node)
 			}
 
@@ -139,10 +140,7 @@ var _ = Describe("Expiration", func() {
 
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range nodes {
-				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
-					return finalizer == "test/finalizer"
-				})
-				env.ExpectUpdated(node)
+				env.ExpectTestingFinalizerRemoved(node)
 			}
 
 			// After the deletion timestamp is set and all pods are drained
@@ -198,7 +196,7 @@ var _ = Describe("Expiration", func() {
 
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range nodes {
-				node.Finalizers = append(node.Finalizers, "test/finalizer")
+				node.Finalizers = append(node.Finalizers, common.TestingFinalizer)
 				env.ExpectUpdated(node)
 			}
 
@@ -227,10 +225,7 @@ var _ = Describe("Expiration", func() {
 
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range nodes {
-				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
-					return finalizer == "test/finalizer"
-				})
-				env.ExpectUpdated(node)
+				env.ExpectTestingFinalizerRemoved(node)
 			}
 
 			// After the deletion timestamp is set and all pods are drained
@@ -286,7 +281,7 @@ var _ = Describe("Expiration", func() {
 
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range nodes {
-				node.Finalizers = append(node.Finalizers, "test/finalizer")
+				node.Finalizers = append(node.Finalizers, common.TestingFinalizer)
 				env.ExpectUpdated(node)
 			}
 
@@ -319,10 +314,7 @@ var _ = Describe("Expiration", func() {
 
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range nodes {
-				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
-					return finalizer == "test/finalizer"
-				})
-				env.ExpectUpdated(node)
+				env.ExpectTestingFinalizerRemoved(node)
 			}
 
 			// After the deletion timestamp is set and all pods are drained

--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -199,8 +199,8 @@ var _ = Describe("Expiration", func() {
 			env.ExpectUpdated(dep)
 
 			By("spreading the pods to each of the nodes")
-			pods := env.EventuallyExpectHealthyPodCount(selector, 3)
-			nodes := []*v1.Node{}
+			env.EventuallyExpectHealthyPodCount(selector, 3)
+			var nodes []*v1.Node
 			// Delete pods from the deployment until each node has one pod.
 			nodePods := []*v1.Pod{}
 			for {
@@ -250,7 +250,7 @@ var _ = Describe("Expiration", func() {
 			}).Should(Succeed())
 
 			By("enabling disruption by removing the do not disrupt annotation")
-			pods = env.EventuallyExpectHealthyPodCount(selector, 3)
+			pods := env.EventuallyExpectHealthyPodCount(selector, 3)
 			// Remove the do-not-disrupt annotation so that the nodes are now disruptable
 			for _, pod := range pods {
 				delete(pod.Annotations, corev1beta1.DoNotDisruptAnnotationKey)
@@ -268,8 +268,8 @@ var _ = Describe("Expiration", func() {
 			nodes = env.EventuallyExpectTaintedNodeCount("==", 2)
 
 			By("removing the finalizer from the nodes")
-			env.ExpectTestingFinalizerRemoved(nodes[0])
-			env.ExpectTestingFinalizerRemoved(nodes[1])
+			Expect(env.ExpectTestingFinalizerRemoved(nodes[0])).To(Succeed())
+			Expect(env.ExpectTestingFinalizerRemoved(nodes[1])).To(Succeed())
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone
@@ -351,8 +351,8 @@ var _ = Describe("Expiration", func() {
 			tainted := env.EventuallyExpectTaintedNodeCount("==", 2)
 			env.EventuallyExpectCreatedNodeCount("==", 2)
 
-			env.ExpectTestingFinalizerRemoved(tainted[0])
-			env.ExpectTestingFinalizerRemoved(tainted[1])
+			Expect(env.ExpectTestingFinalizerRemoved(tainted[0])).To(Succeed())
+			Expect(env.ExpectTestingFinalizerRemoved(tainted[1])).To(Succeed())
 
 			env.EventuallyExpectNotFound(tainted[0], tainted[1])
 
@@ -365,7 +365,7 @@ var _ = Describe("Expiration", func() {
 			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
 			env.ExpectUpdated(nodePool)
 
-			env.ExpectTestingFinalizerRemoved(tainted[0])
+			Expect(env.ExpectTestingFinalizerRemoved(tainted[0])).To(Succeed())
 
 			// After the deletion timestamp is set and all pods are drained
 			// the node should be gone


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates upstream karpenter one more commit and adds in e2e tests for budgets for Drift and Expiration. Consolidation will be added as a followup. 

**How was this change tested?**
make presubmit && make e2etests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.