### PR TITLE
ci: Make VPC endpoints a regional resources

### DIFF
--- a/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
+++ b/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
@@ -36,7 +36,7 @@ func (v *VPCEndpoint) String() string {
 }
 
 func (v *VPCEndpoint) Global() bool {
-	return true
+	return false
 }
 
 func (v *VPCEndpoint) Get(ctx context.Context, clusterName string) (ids []string, err error) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- VPC endpoint is not a global resources in AWS, and should be tracked as such

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.