### PR TITLE
ci: Drop unneeded calls to pull-through cache

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -57,7 +57,6 @@ Helm Chart Version $(helmChartVersion $RELEASE_VERSION)"
   cosignImages
   publishHelmChart "karpenter" "${RELEASE_VERSION}" "${RELEASE_REPO_ECR}"
   publishHelmChart "karpenter-crd" "${RELEASE_VERSION}" "${RELEASE_REPO_ECR}"
-  pullPrivateReplica "$RELEASE_VERSION"
 }
 
 authenticate() {
@@ -121,16 +120,6 @@ cosignImages() {
         -a GIT_VERSION="${RELEASE_VERSION}" \
         -a BUILD_DATE="$(buildDate)" \
         "${CONTROLLER_IMG}"
-}
-
-pullPrivateReplica(){
-  authenticatePrivateRepo
-  RELEASE_IDENTIFIER=$1
-  PULL_THROUGH_CACHE_PATH="${PRIVATE_HOST}/ecr-public/${ECR_GALLERY_NAME}/"
-  HELM_CHART_VERSION=$(helmChartVersion "$RELEASE_VERSION")
-  docker pull "${PULL_THROUGH_CACHE_PATH}controller:${RELEASE_IDENTIFIER}"
-  helm pull "oci://${PULL_THROUGH_CACHE_PATH}karpenter" --version "${HELM_CHART_VERSION}"
-  helm pull "oci://${PULL_THROUGH_CACHE_PATH}karpenter-crd" --version "${HELM_CHART_VERSION}"
 }
 
 publishHelmChart() {

--- a/hack/release/snapshot.sh
+++ b/hack/release/snapshot.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GIT_TAG=$(git describe --exact-match --tags || echo "no tag")
 HEAD_HASH=$(git rev-parse HEAD)
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Calls to the pull-through cache are unneeded since this was only do local cache hydration into the account. Since we are pulling snapshots from a different ECR anyways, there's no need to do pull-through cache hydration here on release.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.