### PR TITLE
feat: Placement Group Support

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -67,6 +67,7 @@ func main() {
 			op.InstanceProvider,
 			op.PricingProvider,
 			op.AMIProvider,
+			op.PlacementGroupProvider,
 		)...).
 		WithWebhooks(ctx, webhooks.NewWebhooks()...).
 		Start(ctx)

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -105,6 +105,9 @@ type EC2NodeClassSpec struct {
 	// +kubebuilder:default={"httpEndpoint":"enabled","httpProtocolIPv6":"disabled","httpPutResponseHopLimit":2,"httpTokens":"required"}
 	// +optional
 	MetadataOptions *MetadataOptions `json:"metadataOptions,omitempty"`
+	// PlacementGroupSelectorTerms is a list of PlacementGroupSelector. The terms are ORed.
+	// +optional
+	PlacementGroupSelectorTerms []PlacementGroupSelectorTerm `json:"placementGroupSelectorTerms,omitempty" hash:"ignore"`
 	// Context is a Reserved field in EC2 APIs
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
 	// +optional
@@ -165,6 +168,14 @@ type AMISelectorTerm struct {
 	// You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
 	// +optional
 	Owner string `json:"owner,omitempty"`
+}
+
+// PlacementGroupSelectorTerm defines the selection logic for ec2 placement groups
+// that are used to launch nodes. If multiple fields are used for selection, the requirements are ANDed
+type PlacementGroupSelectorTerm struct {
+	// Name of the placement group to be selected
+	// +optional
+	Name string `json:"name,omitempty"`
 }
 
 // MetadataOptions contains parameters for specifying the exposure of the

--- a/pkg/apis/v1beta1/ec2nodeclass_status.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_status.go
@@ -63,6 +63,9 @@ type EC2NodeClassStatus struct {
 	// cluster under the AMI selectors.
 	// +optional
 	AMIs []AMI `json:"amis,omitempty"`
+	// PlacementGroups contains the ec2 placement group arns
+	// +optional
+	PlacementGroups []string `json:"placementGroups,omitempty"`
 	// InstanceProfile contains the resolved instance profile for the role
 	// +optional
 	InstanceProfile string `json:"instanceProfile,omitempty"`

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -37,6 +37,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/placementgroup"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/securitygroup"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/sqs"
@@ -46,10 +47,10 @@ import (
 func NewControllers(ctx context.Context, sess *session.Session, clk clock.Clock, kubeClient client.Client, recorder events.Recorder,
 	unavailableOfferings *cache.UnavailableOfferings, cloudProvider *cloudprovider.CloudProvider, subnetProvider *subnet.Provider,
 	securityGroupProvider *securitygroup.Provider, instanceProfileProvider *instanceprofile.Provider, instanceProvider *instance.Provider,
-	pricingProvider *pricing.Provider, amiProvider *amifamily.Provider) []controller.Controller {
+	pricingProvider *pricing.Provider, amiProvider *amifamily.Provider, placementGroupProvider *placementgroup.Provider) []controller.Controller {
 
 	controllers := []controller.Controller{
-		nodeclass.NewNodeClassController(kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider),
+		nodeclass.NewNodeClassController(kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, placementGroupProvider),
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider),
 		nodeclaimtagging.NewController(kubeClient, instanceProvider),
 	}

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	awsEnv = test.NewEnvironment(ctx, env)
 
-	nodeClassController = nodeclass.NewNodeClassController(env.Client, events.NewRecorder(&record.FakeRecorder{}), awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider)
+	nodeClassController = nodeclass.NewNodeClassController(env.Client, events.NewRecorder(&record.FakeRecorder{}), awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.PlacementGroupProvider)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -54,6 +54,7 @@ type EC2Behavior struct {
 	DescribeAvailabilityZonesOutput     AtomicPtr[ec2.DescribeAvailabilityZonesOutput]
 	DescribeSpotPriceHistoryInput       AtomicPtr[ec2.DescribeSpotPriceHistoryInput]
 	DescribeSpotPriceHistoryOutput      AtomicPtr[ec2.DescribeSpotPriceHistoryOutput]
+	DescribePlacementGroupsOutput       AtomicPtr[ec2.DescribePlacementGroupsOutput]
 	CreateFleetBehavior                 MockedFunction[ec2.CreateFleetInput, ec2.CreateFleetOutput]
 	TerminateInstancesBehavior          MockedFunction[ec2.TerminateInstancesInput, ec2.TerminateInstancesOutput]
 	DescribeInstancesBehavior           MockedFunction[ec2.DescribeInstancesInput, ec2.DescribeInstancesOutput]
@@ -88,6 +89,7 @@ func (e *EC2API) Reset() {
 	e.DescribeInstanceTypesOutput.Reset()
 	e.DescribeInstanceTypeOfferingsOutput.Reset()
 	e.DescribeAvailabilityZonesOutput.Reset()
+	e.DescribePlacementGroupsOutput.Reset()
 	e.CreateFleetBehavior.Reset()
 	e.TerminateInstancesBehavior.Reset()
 	e.DescribeInstancesBehavior.Reset()
@@ -643,4 +645,16 @@ func (e *EC2API) DescribeSpotPriceHistoryPagesWithContext(ctx aws.Context, input
 	}
 	fn(out, false)
 	return nil
+}
+
+func (e *EC2API) DescribePlacementGroupsWithContext(_ aws.Context, _ *ec2.DescribePlacementGroupsInput, _ ...request.Option) (*ec2.DescribePlacementGroupsOutput, error) {
+	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
+		return nil, e.NextError.Get()
+	}
+	if !e.DescribePlacementGroupsOutput.IsNil() {
+		return e.DescribePlacementGroupsOutput.Clone(), nil
+	}
+	return nil, errors.New("no placement groups data provided")
+
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -59,6 +59,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/placementgroup"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/securitygroup"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/subnet"
@@ -87,6 +88,7 @@ type Operator struct {
 	VersionProvider           *version.Provider
 	InstanceTypesProvider     *instancetype.Provider
 	InstanceProvider          *instance.Provider
+	PlacementGroupProvider    *placementgroup.Provider
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
@@ -144,7 +146,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	)
 	versionProvider := version.NewProvider(operator.KubernetesInterface, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	amiProvider := amifamily.NewProvider(versionProvider, ssm.New(sess), ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	amiResolver := amifamily.New(amiProvider)
+	placementGroupProvider := placementgroup.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	amiResolver := amifamily.New(amiProvider, placementGroupProvider)
 	launchTemplateProvider := launchtemplate.NewProvider(
 		ctx,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
@@ -199,6 +202,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		PricingProvider:           pricingProvider,
 		InstanceTypesProvider:     instanceTypeProvider,
 		InstanceProvider:          instanceProvider,
+		PlacementGroupProvider:    placementGroupProvider,
 	}
 }
 

--- a/pkg/providers/placementgroup/placementgroup.go
+++ b/pkg/providers/placementgroup/placementgroup.go
@@ -1,0 +1,88 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placementgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/patrickmn/go-cache"
+
+	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+
+	"knative.dev/pkg/logging"
+
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+)
+
+type Provider struct {
+	sync.RWMutex
+	ec2api ec2iface.EC2API
+	cache  *cache.Cache
+	cm     *pretty.ChangeMonitor
+}
+
+func NewProvider(ec2api ec2iface.EC2API, cache *cache.Cache) *Provider {
+	return &Provider{
+		ec2api: ec2api,
+		cm:     pretty.NewChangeMonitor(),
+		// TODO: Remove cache for v1beta1, utilize resolved subnet from the AWSNodeTemplate.status
+		// Subnets are sorted on AvailableIpAddressCount, descending order
+		cache: cache,
+	}
+}
+
+func (p *Provider) Get(ctx context.Context, nodeClass *v1beta1.EC2NodeClass) (*ec2.PlacementGroup, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	// Get selectors from the nodeClass, exit if no selectors defined
+	selectors := nodeClass.Spec.PlacementGroupSelectorTerms
+	if selectors == nil {
+		return nil, nil
+	}
+
+	// Look for a cached result
+	hash, err := hashstructure.Hash(selectors, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	if err != nil {
+		return nil, err
+	}
+	if cached, ok := p.cache.Get(fmt.Sprint(hash)); ok {
+		return cached.(*ec2.PlacementGroup), nil
+	}
+
+	var match *ec2.PlacementGroup
+	// Look up all ec2 placement groups
+	output, err := p.ec2api.DescribePlacementGroupsWithContext(ctx, &ec2.DescribePlacementGroupsInput{})
+	if err != nil {
+		logging.FromContext(ctx).Errorf("discovering placement groups, %w", err)
+		return nil, err
+	}
+	for i := range output.PlacementGroups {
+		// filter results to only include those that match at least 1 selector
+		for x := range selectors {
+			if *output.PlacementGroups[i].GroupName == selectors[x].Name {
+				match = output.PlacementGroups[i]
+				p.cache.SetDefault(fmt.Sprint(hash), match)
+				break
+			}
+		}
+	}
+	return match, nil
+}

--- a/pkg/providers/placementgroup/suite_test.go
+++ b/pkg/providers/placementgroup/suite_test.go
@@ -1,0 +1,119 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placementgroup_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "knative.dev/pkg/logging/testing"
+
+	"github.com/aws/karpenter-provider-aws/pkg/apis"
+	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/test"
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+
+	"sigs.k8s.io/karpenter/pkg/operator/scheme"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+var ctx context.Context
+var stop context.CancelFunc
+var env *coretest.Environment
+var awsEnv *test.Environment
+var nodeClass *v1beta1.EC2NodeClass
+
+func TestAWS(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Provider/AWS")
+}
+
+var _ = BeforeSuite(func() {
+	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+	ctx, stop = context.WithCancel(ctx)
+	awsEnv = test.NewEnvironment(ctx, env)
+})
+
+var _ = AfterSuite(func() {
+	stop()
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = BeforeEach(func() {
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+	nodeClass = test.EC2NodeClass(v1beta1.EC2NodeClass{
+		Spec: v1beta1.EC2NodeClassSpec{
+			AMIFamily: aws.String(v1beta1.AMIFamilyAL2),
+			SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
+				{
+					Tags: map[string]string{
+						"*": "*",
+					},
+				},
+			},
+			SecurityGroupSelectorTerms: []v1beta1.SecurityGroupSelectorTerm{
+				{
+					Tags: map[string]string{
+						"*": "*",
+					},
+				},
+			},
+		},
+	})
+	awsEnv.Reset()
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("PlacementGroupProvider", func() {
+	Context("Get", func() {
+		It("should discover placement groups by name", func() {
+			expected := &ec2.PlacementGroup{GroupArn: aws.String("test-group-arn"), GroupName: aws.String("test-group-name")}
+			awsEnv.EC2API.DescribePlacementGroupsOutput.Set(&ec2.DescribePlacementGroupsOutput{PlacementGroups: []*ec2.PlacementGroup{expected}})
+			nodeClass.Spec.PlacementGroupSelectorTerms = []v1beta1.PlacementGroupSelectorTerm{
+				{
+					Name: *expected.GroupName,
+				},
+			}
+			pg, err := awsEnv.PlacementGroupProvider.Get(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(pg).To(Equal(expected))
+		})
+		It("should filter only matches", func() {
+			expected := &ec2.PlacementGroup{GroupArn: aws.String("test-group-arn"), GroupName: aws.String("test-group-name")}
+			awsEnv.EC2API.DescribePlacementGroupsOutput.Set(&ec2.DescribePlacementGroupsOutput{PlacementGroups: []*ec2.PlacementGroup{expected}})
+			nodeClass.Spec.PlacementGroupSelectorTerms = []v1beta1.PlacementGroupSelectorTerm{
+				{
+					Name: "does-not-match",
+				},
+			}
+			pg, err := awsEnv.PlacementGroupProvider.Get(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(pg).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Fixes #3324

**Description**
Allows for the configuration of a Placement Group when defining an `AWSNodeTemplate` resource. Based on existing work by @preflightsiren on PR #4553. 

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates (in progress!) <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.