### PR TITLE
fix: discover instances in all available zones

### DIFF
--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -126,6 +126,10 @@ var _ = Describe("NodeClassController", func() {
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
+				{
+					ID:   "subnet-test4",
+					Zone: "test-zone-1a-local",
+				},
 			}))
 		})
 		It("Should have the correct ordering for the Subnets", func() {
@@ -208,6 +212,10 @@ var _ = Describe("NodeClassController", func() {
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
+				{
+					ID:   "subnet-test4",
+					Zone: "test-zone-1a-local",
+				},
 			}))
 
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -253,6 +261,10 @@ var _ = Describe("NodeClassController", func() {
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
+				{
+					ID:   "subnet-test4",
+					Zone: "test-zone-1a-local",
+				},
 			}))
 
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -297,6 +309,10 @@ var _ = Describe("NodeClassController", func() {
 				{
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
+				},
+				{
+					ID:   "subnet-test4",
+					Zone: "test-zone-1a-local",
 				},
 			}))
 

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -423,6 +423,15 @@ func (e *EC2API) DescribeSubnetsWithContext(_ context.Context, input *ec2.Descri
 				{Key: aws.String("foo"), Value: aws.String("bar")},
 			},
 		},
+		{
+			SubnetId:                aws.String("subnet-test4"),
+			AvailabilityZone:        aws.String("test-zone-1a-local"),
+			AvailableIpAddressCount: aws.Int64(100),
+			MapPublicIpOnLaunch:     aws.Bool(true),
+			Tags: []*ec2.Tag{
+				{Key: aws.String("Name"), Value: aws.String("test-subnet-4")},
+			},
+		},
 	}
 	if len(input.Filters) == 0 {
 		return nil, fmt.Errorf("InvalidParameterValue: The filter 'null' is invalid")
@@ -485,6 +494,7 @@ func (e *EC2API) DescribeAvailabilityZonesWithContext(context.Context, *ec2.Desc
 		{ZoneName: aws.String("test-zone-1a"), ZoneId: aws.String("testzone1a"), ZoneType: aws.String("availability-zone")},
 		{ZoneName: aws.String("test-zone-1b"), ZoneId: aws.String("testzone1b"), ZoneType: aws.String("availability-zone")},
 		{ZoneName: aws.String("test-zone-1c"), ZoneId: aws.String("testzone1c"), ZoneType: aws.String("availability-zone")},
+		{ZoneName: aws.String("test-zone-1a-local"), ZoneId: aws.String("testzone1alocal"), ZoneType: aws.String("local-zone")},
 	}}, nil
 }
 
@@ -529,6 +539,10 @@ func (e *EC2API) DescribeInstanceTypeOfferingsWithContext(_ context.Context, _ *
 			{
 				InstanceType: aws.String("m5.large"),
 				Location:     aws.String("test-zone-1c"),
+			},
+			{
+				InstanceType: aws.String("m5.large"),
+				Location:     aws.String("test-zone-1a-local"),
 			},
 			{
 				InstanceType: aws.String("m5.xlarge"),

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -99,10 +99,7 @@ func (p *Provider) List(ctx context.Context, kc *corev1beta1.KubeletConfiguratio
 		return nil, err
 	}
 	// Get AvailabilityZones from EC2
-	availabilityZones, err := p.getAvailabilityZones(ctx)
-	if err != nil {
-		return nil, err
-	}
+	instanceTypeZones := p.getInstanceTypeZones(ctx, instanceTypeOfferings)
 	// Constrain AZs from subnets
 	subnets, err := p.subnetProvider.List(ctx, nodeClass)
 	if err != nil {
@@ -121,7 +118,7 @@ func (p *Provider) List(ctx context.Context, kc *corev1beta1.KubeletConfiguratio
 		return item.([]*cloudprovider.InstanceType), nil
 	}
 	result := lo.Map(instanceTypes, func(i *ec2.InstanceTypeInfo, _ int) *cloudprovider.InstanceType {
-		return NewInstanceType(ctx, i, kc, p.region, nodeClass, p.createOfferings(ctx, i, instanceTypeOfferings[aws.StringValue(i.InstanceType)], availabilityZones, subnetZones))
+		return NewInstanceType(ctx, i, kc, p.region, nodeClass, p.createOfferings(ctx, i, instanceTypeOfferings[aws.StringValue(i.InstanceType)], instanceTypeZones, subnetZones))
 	})
 	for _, instanceType := range instanceTypes {
 		InstanceTypeVCPU.With(prometheus.Labels{
@@ -142,18 +139,18 @@ func (p *Provider) LivenessProbe(req *http.Request) error {
 	return p.pricingProvider.LivenessProbe(req)
 }
 
-func (p *Provider) createOfferings(ctx context.Context, instanceType *ec2.InstanceTypeInfo, instanceTypeZones, availabilityZones, subnetZones sets.Set[string]) []cloudprovider.Offering {
+func (p *Provider) createOfferings(ctx context.Context, instanceType *ec2.InstanceTypeInfo, instanceTypeZones, zones, subnetZones sets.Set[string]) []cloudprovider.Offering {
 	var offerings []cloudprovider.Offering
-	for az := range availabilityZones {
+	for zone := range zones {
 		// while usage classes should be a distinct set, there's no guarantee of that
 		for capacityType := range sets.NewString(aws.StringValueSlice(instanceType.SupportedUsageClasses)...) {
 			// exclude any offerings that have recently seen an insufficient capacity error from EC2
-			isUnavailable := p.unavailableOfferings.IsUnavailable(*instanceType.InstanceType, az, capacityType)
+			isUnavailable := p.unavailableOfferings.IsUnavailable(*instanceType.InstanceType, zone, capacityType)
 			var price float64
 			var ok bool
 			switch capacityType {
 			case ec2.UsageClassTypeSpot:
-				price, ok = p.pricingProvider.SpotPrice(*instanceType.InstanceType, az)
+				price, ok = p.pricingProvider.SpotPrice(*instanceType.InstanceType, zone)
 			case ec2.UsageClassTypeOnDemand:
 				price, ok = p.pricingProvider.OnDemandPrice(*instanceType.InstanceType)
 			case "capacity-block":
@@ -163,9 +160,9 @@ func (p *Provider) createOfferings(ctx context.Context, instanceType *ec2.Instan
 				logging.FromContext(ctx).Errorf("Received unknown capacity type %s for instance type %s", capacityType, *instanceType.InstanceType)
 				continue
 			}
-			available := !isUnavailable && ok && instanceTypeZones.Has(az) && subnetZones.Has(az)
+			available := !isUnavailable && ok && instanceTypeZones.Has(zone) && subnetZones.Has(zone)
 			offerings = append(offerings, cloudprovider.Offering{
-				Zone:         az,
+				Zone:         zone,
 				CapacityType: capacityType,
 				Price:        price,
 				Available:    available,
@@ -175,7 +172,7 @@ func (p *Provider) createOfferings(ctx context.Context, instanceType *ec2.Instan
 	return offerings
 }
 
-func (p *Provider) getAvailabilityZones(ctx context.Context) (sets.Set[string], error) {
+func (p *Provider) getInstanceTypeZones(ctx context.Context, instanceTypeOfferings map[string]sets.Set[string]) sets.Set[string] {
 	// DO NOT REMOVE THIS LOCK ----------------------------------------------------------------------------
 	// We lock here so that multiple callers to getAvailabilityZones do not result in cache misses and multiple
 	// calls to EC2 when we could have just made one call.
@@ -183,26 +180,20 @@ func (p *Provider) getAvailabilityZones(ctx context.Context) (sets.Set[string], 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if cached, ok := p.cache.Get(AvailabilityZonesCacheKey); ok {
-		return cached.(sets.Set[string]), nil
+		return cached.(sets.Set[string])
 	}
-
-	// Get zones from EC2
+	// Get zones from offerings
 	instanceTypeZones := sets.Set[string]{}
-	output, err := p.ec2api.DescribeAvailabilityZonesWithContext(ctx, &ec2.DescribeAvailabilityZonesInput{})
-	if err != nil {
-		return nil, fmt.Errorf("describing availability zones, %w", err)
-	}
-	for i := range output.AvailabilityZones {
-		zone := output.AvailabilityZones[i]
-		if aws.StringValue(zone.ZoneType) == "availability-zone" {
-			instanceTypeZones.Insert(aws.StringValue(zone.ZoneName))
+	for _, zones := range instanceTypeOfferings {
+		for zone := range zones {
+			instanceTypeZones.Insert(zone)
 		}
 	}
 	if p.cm.HasChanged("zones", instanceTypeZones) {
 		logging.FromContext(ctx).With("zones", instanceTypeZones.UnsortedList()).Debugf("discovered availability zones")
 	}
 	p.cache.Set(AvailabilityZonesCacheKey, instanceTypeZones, 24*time.Hour)
-	return instanceTypeZones, nil
+	return instanceTypeZones
 }
 
 func (p *Provider) getInstanceTypeOfferings(ctx context.Context) (map[string]sets.Set[string], error) {

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -190,7 +190,7 @@ func (p *Provider) getInstanceTypeZones(ctx context.Context, instanceTypeOfferin
 		}
 	}
 	if p.cm.HasChanged("zones", instanceTypeZones) {
-		logging.FromContext(ctx).With("zones", instanceTypeZones.UnsortedList()).Debugf("discovered availability zones")
+		logging.FromContext(ctx).With("zones", instanceTypeZones.UnsortedList()).Debugf("discovered zones")
 	}
 	p.cache.Set(AvailabilityZonesCacheKey, instanceTypeZones, 24*time.Hour)
 	return instanceTypeZones

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -700,6 +700,19 @@ var _ = Describe("InstanceTypes", func() {
 			Expect(aws.Float64Value(value)).To(BeNumerically(">", 0))
 		}
 	})
+	It("should launch instances in local zones", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		pod := coretest.UnschedulablePod(coretest.PodOptions{
+			NodeRequirements: []v1.NodeSelectorRequirement{{
+				Key:      v1.LabelTopologyZone,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{"test-zone-1a-local"},
+			}},
+		})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		ExpectScheduled(ctx, env.Client, pod)
+
+	})
 
 	Context("Overhead", func() {
 		var info *ec2.InstanceTypeInfo


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5239 

**Description**
Updates instance type discovery to use zones from the instance type offerings rather than via `DescribeAvailabilityZones`. This maintains a single source of truth for zones while also discovering non-az zones (e.g. local zones).

Note: originally local-zone e2e testing was going to be included here, this is going to be decoupled into a separate PR (coming soon).

**How was this change tested?**
- [x] `make test`
- [x] `/karpenter snapshot`
- [x] test against personal cluster w/ local zones

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.