### PR TITLE
ci: E2E testing for local zones

### DIFF
--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -40,6 +40,10 @@ inputs:
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
     required: false
+  enable_local_zones:
+    description: "Whether to include local zones in the VPC created for the cluster."
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -81,14 +85,15 @@ runs:
       IP_FAMILY: ${{ inputs.ip_family }}
       PRIVATE_CLUSTER: ${{ inputs.private_cluster }}
       GIT_REF:  ${{ inputs.git_ref }}
+      ENABLE_LOCAL_ZONES: ${{ inputs.enable_local_zones }}
     run: |
-      if [[ "$GIT_REF" == '' ]]; then 
+      if [[ "$GIT_REF" == '' ]]; then
         GIT_REF=$(git rev-parse HEAD)
       fi
 
-      # Disable Pod Identity for Karpenter on K8s 1.23. Pod Identity is not supported on K8s 1.23 
+      # Disable Pod Identity for Karpenter on K8s 1.23. Pod Identity is not supported on K8s 1.23
       # https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html#pod-id-considerations
-      if [[ "$K8S_VERSION" == '1.23' ]]; then 
+      if [[ "$K8S_VERSION" == '1.23' ]]; then
         KARPENTER_IAM="""
           - metadata:
               name: karpenter
@@ -104,14 +109,14 @@ runs:
             serviceAccountName: karpenter
             roleName: karpenter-irsa-${{ inputs.cluster_name }}
             permissionsBoundaryARN: "arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"
-            permissionPolicyARNs: 
+            permissionPolicyARNs:
               - "arn:aws:iam::${{ inputs.account_id }}:policy/KarpenterControllerPolicy-${{ inputs.cluster_name }}""""
         POD_IDENTITY="""- name: eks-pod-identity-agent
         permissionsBoundary: "arn:aws:iam::$ACCOUNT_ID:policy/GithubActionsPermissionsBoundary"
         configurationValues: |
           tolerations:
             - operator: Exists"""
-      fi 
+      fi
 
       # Create or Upgrade the cluster based on whether the cluster already exists
       cmd="create"
@@ -178,6 +183,13 @@ runs:
       $POD_IDENTITY
       EOF
 
+      if [[ $ENABLE_LOCAL_ZONES == "true" ]]; then
+        local_zones=$(AWS_REGION=$REGION aws ec2 describe-availability-zones | yq '.AvailabilityZones | filter(.ZoneType == "local-zone") | [.[].ZoneName] | join(" ")')
+        for zone in $local_zones; do
+          yq -i ".localZones += [\"$zone\"]" clusterconfig.yaml
+        done
+      fi
+
       if [[ $PRIVATE_CLUSTER == 'true' ]]; then
         yq -i '.privateCluster.enabled=true' clusterconfig.yaml
         yq -i '.managedNodeGroups[0].privateNetworking=true' clusterconfig.yaml
@@ -211,9 +223,9 @@ runs:
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       GIT_REF: ${{ inputs.git_ref }}
     run: |
-      if [[ "$GIT_REF" == '' ]]; then 
+      if [[ "$GIT_REF" == '' ]]; then
         GIT_REF=$(git rev-parse HEAD)
-      fi 
+      fi
       oidc_id=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query "cluster.identity.oidc.issuer" --output text | cut -d '/' -f 3,4,5)
       arn="arn:aws:iam::$ACCOUNT_ID:oidc-provider/${oidc_id}"
       aws iam tag-open-id-connect-provider --open-id-connect-provider-arn $arn \

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -59,19 +59,30 @@ jobs:
       max-parallel: ${{ inputs.parallelism || 100 }}
       matrix:
         suite:
-          - Integration
-          - NodeClaim
-          - Consolidation
-          - Interruption
-          - Drift
-          - Expiration
-          - Chaos
-          - IPv6
+          - name: Integration
+            region: ${{ inputs.region }}
+          - name: NodeClaim
+            region: ${{ inputs.region }}
+          - name: Consolidation
+            region: ${{ inputs.region }}
+          - name: Interruption
+            region: ${{ inputs.region }}
+          - name: Drift
+            region: ${{ inputs.region }}
+          - name: Expiration
+            region: ${{ inputs.region }}
+          - name: Chaos
+            region: ${{ inputs.region }}
+          - name: IPv6
+            region: ${{ inputs.region }}
+          - name: LocalZone
+            # LAX is the only local zone available in the CI account, therefore only use us-west-2
+            region: us-west-2
     uses: ./.github/workflows/e2e.yaml
     with:
-      suite: ${{ matrix.suite }}
+      suite: ${{ matrix.suite.name }}
       git_ref: ${{ inputs.git_ref }}
-      region: ${{ inputs.region }}
+      region: ${{ matrix.suite.region }}
       k8s_version: ${{ inputs.k8s_version }}
       cleanup: ${{ inputs.cleanup }}
       workflow_trigger: ${{ inputs.workflow_trigger }}
@@ -83,7 +94,7 @@ jobs:
       statuses: write # ./.github/actions/commit-status/start
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      # This version matches the version switch between IRSA -> Pod Identity 
+      # This version matches the version switch between IRSA -> Pod Identity
       # https://github.com/aws/karpenter-provider-aws/pull/5262
       from_git_ref: 8f500c23be18aa5cb8089a83c43e763303faa9ac
       to_git_ref: ${{ inputs.git_ref }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,6 +26,7 @@ on:
           - IPv6
           - Scale
           - PrivateCluster
+          - LocalZone
       k8s_version:
         type: choice
         options:
@@ -108,12 +109,12 @@ jobs:
           CLUSTER_NAME: ${{ inputs.cluster_name }}
           WORKFLOW_TRIGGER: ${{ inputs.workflow_trigger }}
         run: |
-          if [[ "$CLUSTER_NAME" == '' ]]; then 
-            if [[ "$WORKFLOW_TRIGGER" == 'soak' ]]; then 
+          if [[ "$CLUSTER_NAME" == '' ]]; then
+            if [[ "$WORKFLOW_TRIGGER" == 'soak' ]]; then
               CLUSTER_NAME=$(echo "soak-periodic-$RANDOM$RANDOM" | awk '{print tolower($0)}' | tr / -)
-            else 
+            else
               CLUSTER_NAME=$(echo "$SUITE-$RANDOM$RANDOM" | awk '{print tolower($0)}' | tr / -)
-            fi 
+            fi
           fi
           echo "Using cluster name \"$CLUSTER_NAME\""
           echo CLUSTER_NAME="$CLUSTER_NAME" >> "$GITHUB_OUTPUT"
@@ -134,6 +135,7 @@ jobs:
           ecr_region: ${{ vars.SNAPSHOT_REGION }}
           prometheus_workspace_id: ${{ vars.WORKSPACE_ID }}
           prometheus_region: ${{ vars.PROMETHEUS_REGION }}
+          enable_local_zones: ${{ inputs.suite == 'LocalZone' }}
       - name: run the ${{ inputs.suite }} test suite
         env:
           SUITE: ${{ inputs.suite }}
@@ -148,7 +150,7 @@ jobs:
           kubectl delete nodepool --all
           kubectl delete ec2nodeclass --all
           kubectl delete deployment --all
-      
+
           TEST_SUITE="$SUITE" ENABLE_METRICS=$ENABLE_METRICS METRICS_REGION=${{ vars.TIMESTREAM_REGION }} GIT_REF="$(git rev-parse HEAD)" \
             CLUSTER_NAME="${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}" CLUSTER_ENDPOINT="$(aws eks describe-cluster --name ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }} --query "cluster.endpoint" --output text)" \
             INTERRUPTION_QUEUE="${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}" make e2etests

--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -210,6 +210,14 @@ func (env *Environment) GetSpotInstanceRequest(id *string) *ec2.SpotInstanceRequ
 	return siro.SpotInstanceRequests[0]
 }
 
+// GetZones returns all available zones mapped from zone -> zone type
+func (env *Environment) GetZones() map[string]string {
+	output := lo.Must(env.EC2API.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{}))
+	return lo.Associate(output.AvailabilityZones, func(zone *ec2.AvailabilityZone) (string, string) {
+		return lo.FromPtr(zone.ZoneName), lo.FromPtr(zone.ZoneType)
+	})
+}
+
 // GetSubnets returns all subnets matching the label selector
 // mapped from AZ -> {subnet-ids...}
 func (env *Environment) GetSubnets(tags map[string]string) map[string][]string {

--- a/test/suites/localzone/suite_test.go
+++ b/test/suites/localzone/suite_test.go
@@ -1,0 +1,104 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localzone_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	"sigs.k8s.io/karpenter/pkg/test"
+
+	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-provider-aws/test/pkg/environment/aws"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var env *aws.Environment
+var nodeClass *v1beta1.EC2NodeClass
+var nodePool *corev1beta1.NodePool
+
+func TestLocalZone(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = aws.NewEnvironment(t)
+	})
+	AfterSuite(func() {
+		env.Stop()
+	})
+	RunSpecs(t, "LocalZone")
+}
+
+var _ = BeforeEach(func() {
+	env.BeforeEach()
+	nodeClass = env.DefaultEC2NodeClass()
+	// The majority of local zones do not support GP3. Feature support in local zones can be tracked here:
+	// https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/
+	nodeClass.Spec.BlockDeviceMappings = append(nodeClass.Spec.BlockDeviceMappings, &v1beta1.BlockDeviceMapping{
+		DeviceName: lo.ToPtr("/dev/xvda"),
+		EBS: &v1beta1.BlockDevice{
+			VolumeSize: func() *resource.Quantity {
+				quantity, err := resource.ParseQuantity("80Gi")
+				Expect(err).To(BeNil())
+				return &quantity
+			}(),
+			VolumeType: lo.ToPtr("gp2"),
+			Encrypted:  lo.ToPtr(false),
+		},
+	})
+	nodePool = env.DefaultNodePool(nodeClass)
+	nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, v1.NodeSelectorRequirement{
+		Key:      v1.LabelTopologyZone,
+		Operator: v1.NodeSelectorOpIn,
+		Values:   lo.Keys(lo.PickByValues(env.GetZones(), []string{"local-zone"})),
+	})
+})
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.AfterEach() })
+
+var _ = Describe("LocalZone", func() {
+	It("should successfully scale up nodes in a local zone", func() {
+		nodeCount := 3
+		depLabels := map[string]string{
+			"foo": "bar",
+		}
+		dep := test.Deployment(test.DeploymentOptions{
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: depLabels,
+				},
+				TopologySpreadConstraints: []v1.TopologySpreadConstraint{{
+					TopologyKey:       v1.LabelHostname,
+					MaxSkew:           1,
+					WhenUnsatisfiable: v1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: depLabels,
+					},
+				}},
+			},
+			Replicas: int32(nodeCount),
+		})
+		env.ExpectCreated(nodeClass, nodePool, dep)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(depLabels), nodeCount)
+		env.EventuallyExpectNodeCount("==", nodeCount)
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #4513 

**Description**
In light of a recent regression (#5239) this PR adds support for end to end tests in local zones. Since local zones come with a number of caveats, rather than adapting the entire test suite to run in local zones, a new suite is added and will be run in it's own region with a local zone enabled. This test suite may be expanded in the future but for the time being it will at least guarantee that we can launch instances in local zones.

**How was this change tested?**
- [x] New tests validated using `go test` against a personal EKS cluster
- [ ] Workflow updates validated via workflow run in personal fork

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.