### PR TITLE
ci: Drop provisioning OIDC provider for Github from IAM CF

### DIFF
--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -26,18 +26,6 @@ Parameters:
     Type: String
     Description: "Timestream table to count number of resources to"
 Resources:
-  GithubOIDCProvider:
-    Type: AWS::IAM::OIDCProvider
-    Properties:
-      Url: https://token.actions.githubusercontent.com
-      ClientIdList:
-        - sts.amazonaws.com
-      # Relevant context for all these thumbprints can be found in the GH issue and blogpost:
-      # https://github.com/aws-actions/configure-aws-credentials/issues/357#issuecomment-1605290219
-      # https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
-      ThumbprintList:
-        - 6938fd4d98bab03faadb97b34396831e3780aea1
-        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
   GithubActionsPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -398,7 +386,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !Ref GithubOIDCProvider
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change drops provisioning the Github OIDC provider into our AWS account from this CloudFormation file since it is being provisioned by a different mechanism

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.