### PR TITLE
update templates to point to kubernetes-sigs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -8,6 +8,8 @@ body:
   attributes:
     label: Description
     value: |
+      ** READ BEFORE CONTINUING: If your issue is not specific to AWS, please cut a ticket in github.com/kubernetes-sigs/karpenter.
+
       **Observed Behavior**:
 
       **Expected Behavior**:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -8,6 +8,8 @@ body:
   attributes:
     label: Description
     value: |
+      ** READ BEFORE CONTINUING: If your issue is not specific to AWS, please cut a ticket in github.com/kubernetes-sigs/karpenter.
+
       **What problem are you trying to solve?**
 
       **How important is this feature to you?**


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a line at the top of bug and feature issue templates so that users can redirect to upstream karpenter for cutting issues.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.