### PR TITLE
ci: Adding `git_ref` of the karpenter snapshot for E2E each test

### DIFF
--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -80,6 +80,7 @@ runs:
       K8S_VERSION: ${{ inputs.k8s_version }}
       IP_FAMILY: ${{ inputs.ip_family }}
       PRIVATE_CLUSTER: ${{ inputs.private_cluster }}
+      GIT_REF:  ${{ inputs.git_ref }}
     run: |
       # Create or Upgrade the cluster based on whether the cluster already exists
       cmd="create"
@@ -98,6 +99,7 @@ runs:
           github.com/run-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           testing/type: "e2e"
           testing/cluster: "$CLUSTER_NAME"
+          test/git_ref: "$GIT_REF"
       kubernetesNetworkConfig:
         ipFamily: "$IP_FAMILY"
       managedNodeGroups:
@@ -186,11 +188,12 @@ runs:
     env:
       ACCOUNT_ID: ${{ inputs.account_id }}
       CLUSTER_NAME: ${{ inputs.cluster_name }}
+      GIT_REF:  ${{ inputs.git_ref }}
     run: |
       oidc_id=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query "cluster.identity.oidc.issuer" --output text | cut -d '/' -f 3,4,5)
       arn="arn:aws:iam::$ACCOUNT_ID:oidc-provider/${oidc_id}"
       aws iam tag-open-id-connect-provider --open-id-connect-provider-arn $arn \
-         --tags Key=testing/type,Value=e2e Key=testing/cluster,Value=$CLUSTER_NAME Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+         --tags Key=test/git_ref,Values="$GIT_REF" Key=testing/type,Value=e2e Key=testing/cluster,Value=$CLUSTER_NAME Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   - name: give KarpenterNodeRole permission to bootstrap
     shell: bash
     env:

--- a/.github/workflows/e2e-soak-trigger.yaml
+++ b/.github/workflows/e2e-soak-trigger.yaml
@@ -47,5 +47,6 @@ jobs:
       workflow_trigger: "soak"
       cluster_name: ${{ matrix.cluster_name }}
       cleanup: ${{ matrix.cluster_cleanup }}
+      git_ref: ${{ matrix.git_ref }}
     secrets:
       SLACK_WEBHOOK_SOAK_URL: ${{ secrets.SLACK_WEBHOOK_SOAK_URL }}

--- a/test/hack/soak/get_clusters.go
+++ b/test/hack/soak/get_clusters.go
@@ -29,6 +29,7 @@ import (
 
 type cluster struct {
 	Name    string `json:"cluster_name"`
+	GitRef  string `json:"git_ref"`
 	Cleanup bool   `json:"cluster_cleanup"`
 }
 
@@ -52,7 +53,10 @@ func main() {
 		}
 
 		if strings.HasPrefix(c, "soak-periodic-") {
-			outputList = append(outputList, &cluster{Name: c, Cleanup: clusterDetails.Cluster.CreatedAt.Before(expirationTime)})
+			outputList = append(outputList, &cluster{
+				Name:    c,
+				GitRef:  clusterDetails.Cluster.Tags["test/git_ref"],
+				Cleanup: clusterDetails.Cluster.CreatedAt.Before(expirationTime)})
 		}
 	}
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- We are currently seeing failures on our E2E soak testing as the E2E tests are running against a build of karpenter that does not support all the feature that are being tested
- We should run the e2e tests of the commit the karpenter snapshot is built on to avoid test failures 
 
**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.