### PR TITLE
docs: remove topologySpreadConstraints compatibility note

### DIFF
--- a/website/content/en/docs/upgrading/compatibility.md
+++ b/website/content/en/docs/upgrading/compatibility.md
@@ -6,12 +6,12 @@ description: >
   Compatibility issues for Karpenter
 ---
 
-# Compatibility 
+# Compatibility
 
 To make upgrading easier we aim to minimize the introduction of breaking changes.
 Before you begin upgrading Karpenter, consider Karpenter compatibility issues related to Kubernetes and the NodePool API (previously Provisioner).
 
-## Compatibility Matrix 
+## Compatibility Matrix
 
 [comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)
 
@@ -20,15 +20,6 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 | karpenter  | 0.21.x+ | 0.21.x+ | 0.25.x+ | 0.28.x+ | 0.28.x+ | 0.31.x+ |
 
 [comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
-
-{{% alert title="Note" color="warning" %}}
-Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
-- `matchLabelKeys`
-- `nodeAffinityPolicy`
-- `nodeTaintsPolicy`
-
-For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
-{{% /alert %}}
 
 {{% alert title="Note" color="warning" %}}
 Karpenter supports using [Kubernetes Common Expression Language](https://kubernetes.io/docs/reference/using-api/cel/) for validating its Custom Resource Definitions out-of-the-box; however, this feature is not supported on versions of Kubernetes < 1.25. If you are running an earlier version of Kubernetes, you will need to use the Karpenter admission webhooks for validation instead. You can enable these webhooks with `--set webhook.enabled=true` when applying the Karpenter helm chart.

--- a/website/content/en/preview/upgrading/compatibility.md
+++ b/website/content/en/preview/upgrading/compatibility.md
@@ -6,12 +6,12 @@ description: >
   Compatibility issues for Karpenter
 ---
 
-# Compatibility 
+# Compatibility
 
 To make upgrading easier we aim to minimize the introduction of breaking changes.
 Before you begin upgrading Karpenter, consider Karpenter compatibility issues related to Kubernetes and the NodePool API (previously Provisioner).
 
-## Compatibility Matrix 
+## Compatibility Matrix
 
 [comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)
 
@@ -20,15 +20,6 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 | karpenter  | 0.21.x+ | 0.21.x+ | 0.25.x+ | 0.28.x+ | 0.28.x+ | 0.31.x+ |
 
 [comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
-
-{{% alert title="Note" color="warning" %}}
-Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
-- `matchLabelKeys`
-- `nodeAffinityPolicy`
-- `nodeTaintsPolicy`
-
-For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
-{{% /alert %}}
 
 {{% alert title="Note" color="warning" %}}
 Karpenter supports using [Kubernetes Common Expression Language](https://kubernetes.io/docs/reference/using-api/cel/) for validating its Custom Resource Definitions out-of-the-box; however, this feature is not supported on versions of Kubernetes < 1.25. If you are running an earlier version of Kubernetes, you will need to use the Karpenter admission webhooks for validation instead. You can enable these webhooks with `--set webhook.enabled=true` when applying the Karpenter helm chart.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Removes the note indicating that Karpenter does not support `matchLabelKeys`, `nodeAffinityPolicy`, and `nodeTaintsPolicy`. Can be merged once https://github.com/kubernetes-sigs/karpenter/pull/852 merges.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.