### PR TITLE
ci: Disable Pod Identity for karpenter on K8s 1.23

### DIFF
--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -85,6 +85,34 @@ runs:
       if [[ "$GIT_REF" == '' ]]; then 
         GIT_REF=$(git rev-parse HEAD)
       fi
+
+      # Disable Pod Identity for Karpenter on K8s 1.23. Pod Identity is not supported on K8s 1.23 
+      # https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html#pod-id-considerations
+      if [[ "$K8S_VERSION" == '1.23' ]]; then 
+        KARPENTER_IAM="""
+          - metadata:
+              name: karpenter
+              namespace: kube-system
+            attachPolicyARNs:
+              - "arn:aws:iam::${{ inputs.account_id }}:policy/KarpenterControllerPolicy-${{ inputs.cluster_name }}"
+            permissionsBoundary: "arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"
+            roleName: karpenter-irsa-${{ inputs.cluster_name }}
+            roleOnly: true"""
+      else
+        KARPENTER_IAM="""podIdentityAssociations:
+          - namespace: kube-system
+            serviceAccountName: karpenter
+            roleName: karpenter-irsa-${{ inputs.cluster_name }}
+            permissionsBoundaryARN: "arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"
+            permissionPolicyARNs: 
+              - "arn:aws:iam::${{ inputs.account_id }}:policy/KarpenterControllerPolicy-${{ inputs.cluster_name }}""""
+        POD_IDENTITY="""- name: eks-pod-identity-agent
+        permissionsBoundary: "arn:aws:iam::$ACCOUNT_ID:policy/GithubActionsPermissionsBoundary"
+        configurationValues: |
+          tolerations:
+            - operator: Exists"""
+      fi 
+
       # Create or Upgrade the cluster based on whether the cluster already exists
       cmd="create"
       eksctl get cluster --name "$CLUSTER_NAME" && cmd="upgrade"
@@ -125,13 +153,6 @@ runs:
           logRetentionInDays: 30
       iam:
         serviceRolePermissionsBoundary: "arn:aws:iam::$ACCOUNT_ID:policy/GithubActionsPermissionsBoundary"
-        podIdentityAssociations:
-          - namespace: kube-system
-            serviceAccountName: karpenter
-            roleName: "karpenter-irsa-$CLUSTER_NAME"
-            permissionsBoundaryARN: "arn:aws:iam::$ACCOUNT_ID:policy/GithubActionsPermissionsBoundary"
-            permissionPolicyARNs: 
-              - "arn:aws:iam::$ACCOUNT_ID:policy/KarpenterControllerPolicy-$CLUSTER_NAME"
         serviceAccounts:
           - metadata:
               name: prometheus-kube-prometheus-prometheus
@@ -141,6 +162,7 @@ runs:
             permissionsBoundary: "arn:aws:iam::$ACCOUNT_ID:policy/GithubActionsPermissionsBoundary"
             roleName: "prometheus-irsa-$CLUSTER_NAME"
             roleOnly: true
+        $KARPENTER_IAM
         withOIDC: true
       addons:
       - name: vpc-cni
@@ -153,11 +175,7 @@ runs:
         permissionsBoundary: "arn:aws:iam::$ACCOUNT_ID:policy/GithubActionsPermissionsBoundary"
         wellKnownPolicies:
           ebsCSIController: true
-      - name: eks-pod-identity-agent
-        permissionsBoundary: "arn:aws:iam::$ACCOUNT_ID:policy/GithubActionsPermissionsBoundary"
-        configurationValues: |
-          tolerations:
-            - operator: Exists
+      $POD_IDENTITY
       EOF
 
       if [[ $PRIVATE_CLUSTER == 'true' ]]; then


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Disable Pod Identity for Karpenter on K8s 1.23. Pod Identity is not supported on K8s 1.23 https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html#pod-id-considerations 

**How was this change tested?**
- Forked account

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.