### PR TITLE
perf: Cherry-pick Reduction of Memory Usage from the InstanceType Provide into v0.32.x

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -35,5 +35,5 @@ const (
 
 const (
 	// DefaultCleanupInterval triggers cache cleanup (lazy eviction) at this interval.
-	DefaultCleanupInterval = 10 * time.Minute
+	DefaultCleanupInterval = time.Minute
 )

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -114,7 +114,8 @@ func (p *Provider) List(ctx context.Context, kc *corev1beta1.KubeletConfiguratio
 	// Compute fully initialized instance types hash key
 	subnetHash, _ := hashstructure.Hash(subnets, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	kcHash, _ := hashstructure.Hash(kc, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	key := fmt.Sprintf("%d-%d-%d-%s-%016x-%016x", p.instanceTypesSeqNum, p.instanceTypeOfferingsSeqNum, p.unavailableOfferings.SeqNum, nodeClass.UID, subnetHash, kcHash)
+	blockDeviceMappingsHash, _ := hashstructure.Hash(nodeClass.Spec.BlockDeviceMappings, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	key := fmt.Sprintf("%d-%d-%d-%016x-%016x-%016x-%s", p.instanceTypesSeqNum, p.instanceTypeOfferingsSeqNum, p.unavailableOfferings.SeqNum, subnetHash, kcHash, blockDeviceMappingsHash, aws.StringValue(nodeClass.Spec.AMIFamily))
 
 	if item, ok := p.cache.Get(key); ok {
 		return item.([]*cloudprovider.InstanceType), nil
@@ -229,10 +230,12 @@ func (p *Provider) getInstanceTypeOfferings(ctx context.Context) (map[string]set
 		}); err != nil {
 		return nil, fmt.Errorf("describing instance type zone offerings, %w", err)
 	}
-	if p.cm.HasChanged("instance-type-count", len(instanceTypeOfferings)) {
+	if p.cm.HasChanged("instance-type-offering", instanceTypeOfferings) {
+		// Only update instanceTypesSeqNun with the instance type offerings  have been changed
+		// This is to not create new keys with duplicate instance type offerings option
+		atomic.AddUint64(&p.instanceTypeOfferingsSeqNum, 1)
 		logging.FromContext(ctx).With("instance-type-count", len(instanceTypeOfferings)).Debugf("discovered offerings for instance types")
 	}
-	atomic.AddUint64(&p.instanceTypeOfferingsSeqNum, 1)
 	p.cache.SetDefault(InstanceTypeOfferingsCacheKey, instanceTypeOfferings)
 	return instanceTypeOfferings, nil
 }
@@ -269,10 +272,12 @@ func (p *Provider) GetInstanceTypes(ctx context.Context) ([]*ec2.InstanceTypeInf
 		return nil, fmt.Errorf("fetching instance types using ec2.DescribeInstanceTypes, %w", err)
 	}
 	if p.cm.HasChanged("instance-types", instanceTypes) {
+		// Only update instanceTypesSeqNun with the instance types have been changed
+		// This is to not create new keys with duplicate instance types option
+		atomic.AddUint64(&p.instanceTypesSeqNum, 1)
 		logging.FromContext(ctx).With(
 			"count", len(instanceTypes)).Debugf("discovered instance types")
 	}
-	atomic.AddUint64(&p.instanceTypesSeqNum, 1)
 	p.cache.SetDefault(InstanceTypesCacheKey, instanceTypes)
 	return instanceTypes, nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

**Description**
- Clearing out the cache for the instance types provider on expired items. 
- Save items based on the EC2NodeClass resolution instead of EC2Nodeclass UUID

**E2E  Integration Periodic Run** 
**Memory Utilization** 
<img width="1205" alt="Screenshot 2023-12-14 at 4 08 27 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/8920b88d-c83a-4705-bf97-05401599e645">

**CPU Utilization** 
<img width="1196" alt="Screenshot 2023-12-14 at 5 20 22 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/bcf75b75-7c45-430b-af0f-fcd29a71a73d">


**E2E Integration with PR Run** 
**Memory Utilization** 
<img width="984" alt="Screenshot 2023-12-14 at 9 09 01 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/deb0a8b4-1ef0-46f9-82d7-0ab31e6ce7a5">


**CPU Utilization** 
<img width="979" alt="Screenshot 2023-12-14 at 9 14 07 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/21b73bbe-23f4-4794-831c-cd4c5ae10951">


- E2E integration was used comparing the memory usage  


**How was this change tested?**
- `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.