### PR TITLE
perf: Cherry-pick Reduction of Memory Usage from the InstanceType Provide into v0.33.x

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -35,5 +35,5 @@ const (
 
 const (
 	// DefaultCleanupInterval triggers cache cleanup (lazy eviction) at this interval.
-	DefaultCleanupInterval = 10 * time.Minute
+	DefaultCleanupInterval = time.Minute
 )


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

**Description**
- Clearing out the cache for the instance types provider on expired items. 
- Save items based on the EC2NodeClass resolution instead of EC2Nodeclass UUID

**E2E  Integration Periodic Run** 
**Memory Utilization** 
<img width="1205" alt="Screenshot 2023-12-14 at 4 08 27 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/8920b88d-c83a-4705-bf97-05401599e645">

**CPU Utilization** 
<img width="1196" alt="Screenshot 2023-12-14 at 5 20 22 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/bcf75b75-7c45-430b-af0f-fcd29a71a73d">


**E2E Integration with PR Run** 
**Memory Utilization** 
<img width="984" alt="Screenshot 2023-12-14 at 9 09 01 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/deb0a8b4-1ef0-46f9-82d7-0ab31e6ce7a5">


**CPU Utilization** 
<img width="979" alt="Screenshot 2023-12-14 at 9 14 07 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/21b73bbe-23f4-4794-831c-cd4c5ae10951">


- E2E integration was used comparing the memory usage  


**How was this change tested?**
- `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.