### PR TITLE
docs: Update v1beta1-controller-policy.json

### DIFF
--- a/website/content/en/v0.33/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/v0.33/upgrading/v1beta1-controller-policy.json
@@ -25,7 +25,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
       ],
       "Action": [
         "ec2:RunInstances",
@@ -49,7 +50,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
       ],
       "Action": "ec2:CreateTags",
       "Condition": {


### PR DESCRIPTION
Fixed docs by adding `arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*` resources for AllowScopedResourceCreationTagging and AllowScopedEC2InstanceActionsWithTags

**Description**
With 0.33, the controller policy in the upgrading guide needs to be updated. Specifically `arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*` needs to be added as a resource to certain policy statements.

Referenced https://github.com/aws/karpenter-provider-aws/blob/v0.33.0/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml#L61 and https://github.com/aws/karpenter-provider-aws/blob/v0.33.0/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml#L86. Let me know if i need to change anything else.

