### PR TITLE
docs: update v1beta1 upgrade guide to use expiration instead of drift

### DIFF
--- a/website/content/en/docs/upgrading/v1beta1-migration.md
+++ b/website/content/en/docs/upgrading/v1beta1-migration.md
@@ -144,7 +144,7 @@ The [`karpenter-convert`](https://github.com/aws/karpenter/tree/release-v0.32.x/
 
     1. Periodic Rolling with [Expiration]({{< relref "../concepts/disruption#automated-methods" >}}):
        - Add the following taint to the old Provisioner: `karpenter.sh/legacy=true:NoSchedule`
-       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired.
+       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired. *Please note that in beta APIs, this is the same as `disruption.expireAfter`*
        - Watch as replacement nodes are launched from the new NodePool resource.
 
        Because Karpenter will only roll one node at a time, it may take some time for Karpenter to completely roll all nodes under a Provisioner.

--- a/website/content/en/preview/upgrading/v1beta1-migration.md
+++ b/website/content/en/preview/upgrading/v1beta1-migration.md
@@ -144,7 +144,7 @@ The [`karpenter-convert`](https://github.com/aws/karpenter/tree/release-v0.32.x/
 
     1. Periodic Rolling with [Expiration]({{< relref "../concepts/disruption#automated-methods" >}}):
        - Add the following taint to the old Provisioner: `karpenter.sh/legacy=true:NoSchedule`
-       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired.
+       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired. *Please note that in beta APIs, this is the same as `disruption.expireAfter`*
        - Watch as replacement nodes are launched from the new NodePool resource.
 
        Because Karpenter will only roll one node at a time, it may take some time for Karpenter to completely roll all nodes under a Provisioner.

--- a/website/content/en/v0.32/upgrading/v1beta1-migration.md
+++ b/website/content/en/v0.32/upgrading/v1beta1-migration.md
@@ -144,7 +144,7 @@ The [`karpenter-convert`](https://github.com/aws/karpenter/tree/release-v0.32.x/
 
     1. Periodic Rolling with [Expiration]({{< relref "../concepts/disruption#automated-methods" >}}):
        - Add the following taint to the old Provisioner: `karpenter.sh/legacy=true:NoSchedule`
-       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired.
+       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired. *Please note that in beta APIs, this is the same as `disruption.expireAfter`*
        - Watch as replacement nodes are launched from the new NodePool resource.
 
        Because Karpenter will only roll one node at a time, it may take some time for Karpenter to completely roll all nodes under a Provisioner.

--- a/website/content/en/v0.33/upgrading/v1beta1-migration.md
+++ b/website/content/en/v0.33/upgrading/v1beta1-migration.md
@@ -144,7 +144,7 @@ The [`karpenter-convert`](https://github.com/aws/karpenter/tree/release-v0.32.x/
 
     1. Periodic Rolling with [Expiration]({{< relref "../concepts/disruption#automated-methods" >}}):
        - Add the following taint to the old Provisioner: `karpenter.sh/legacy=true:NoSchedule`
-       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired.
+       - Set the Expiration in your Provisioner to a small value like `ttlSecondsUntilExpired: 300` to mark all nodes older than 5 minutes as expired. *Please note that in beta APIs, this is the same as `disruption.expireAfter`*
        - Watch as replacement nodes are launched from the new NodePool resource.
 
        Because Karpenter will only roll one node at a time, it may take some time for Karpenter to completely roll all nodes under a Provisioner.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
For users that were upgrading from before v0.31 to then using the migration guide, it was possible that nodes would not properly drift since the feature that the rolling relied on was only introduced for nodes created with a Karpenter version v0.30. 

This changes Drift to use expiration instead so that it can work for all users, regardless of where they're beginning their migration path.

**How was this change tested?**
make website

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.