### PR TITLE
docs: fix incorrect resource tag

### DIFF
--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -202,7 +202,7 @@ actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-templ
 
 #### AllowScopedResourceTagging
 
-The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `karpenter.sh/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
+The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `kubernetes.io/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
 ```json
 {
   "Sid": "AllowScopedResourceTagging",

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -211,7 +211,7 @@ The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amaz
   "Action": "ec2:CreateTags",
   "Condition": {
     "StringEquals": {
-      "aws:ResourceTag/karpenter.sh/cluster/${ClusterName}": "owned"
+      "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
     },
     "StringLike": {
       "aws:ResourceTag/karpenter.sh/nodepool": "*"

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -202,7 +202,7 @@ actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-templ
 
 #### AllowScopedResourceTagging
 
-The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `karpenter.sh/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
+The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `kubernetes.io/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
 ```json
 {
   "Sid": "AllowScopedResourceTagging",

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -211,7 +211,7 @@ The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amaz
   "Action": "ec2:CreateTags",
   "Condition": {
     "StringEquals": {
-      "aws:ResourceTag/karpenter.sh/cluster/${ClusterName}": "owned"
+      "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
     },
     "StringLike": {
       "aws:ResourceTag/karpenter.sh/nodepool": "*"

--- a/website/content/en/v0.32/reference/cloudformation.md
+++ b/website/content/en/v0.32/reference/cloudformation.md
@@ -202,7 +202,7 @@ actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-templ
 
 #### AllowScopedResourceTagging
 
-The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `karpenter.sh/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
+The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `kubernetes.io/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
 ```json
 {
   "Sid": "AllowScopedResourceTagging",

--- a/website/content/en/v0.32/reference/cloudformation.md
+++ b/website/content/en/v0.32/reference/cloudformation.md
@@ -211,7 +211,7 @@ The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amaz
   "Action": "ec2:CreateTags",
   "Condition": {
     "StringEquals": {
-      "aws:ResourceTag/karpenter.sh/cluster/${ClusterName}": "owned"
+      "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
     },
     "StringLike": {
       "aws:ResourceTag/karpenter.sh/nodepool": "*"

--- a/website/content/en/v0.33/reference/cloudformation.md
+++ b/website/content/en/v0.33/reference/cloudformation.md
@@ -202,7 +202,7 @@ actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-templ
 
 #### AllowScopedResourceTagging
 
-The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `karpenter.sh/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
+The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `kubernetes.io/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
 ```json
 {
   "Sid": "AllowScopedResourceTagging",

--- a/website/content/en/v0.33/reference/cloudformation.md
+++ b/website/content/en/v0.33/reference/cloudformation.md
@@ -211,7 +211,7 @@ The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amaz
   "Action": "ec2:CreateTags",
   "Condition": {
     "StringEquals": {
-      "aws:ResourceTag/karpenter.sh/cluster/${ClusterName}": "owned"
+      "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
     },
     "StringLike": {
       "aws:ResourceTag/karpenter.sh/nodepool": "*"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

fix incorrect resource tag in `AllowScopedResourceTagging`

If use `"aws:ResourceTag/karpenter.sh/cluster/${ClusterName}": "owned"`, the controller cannot add some tag to the node

**How was this change tested?**

N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.