### PR TITLE
docs: Fix controller v1beta1 policy docs

### DIFF
--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -122,7 +122,6 @@ For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read 
   "Resource": [
     "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
@@ -149,7 +148,8 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
   ],
   "Action": [
     "ec2:RunInstances",
@@ -182,6 +182,7 @@ actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-templ
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
   ],
   "Action": "ec2:CreateTags",
   "Condition": {

--- a/website/content/en/docs/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/docs/upgrading/v1beta1-controller-policy.json
@@ -7,7 +7,6 @@
       "Resource": [
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::image/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::snapshot/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:security-group/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:subnet/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
@@ -25,7 +24,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"
       ],
       "Action": [
         "ec2:RunInstances",
@@ -49,7 +49,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"
       ],
       "Action": "ec2:CreateTags",
       "Condition": {

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -122,7 +122,6 @@ For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read 
   "Resource": [
     "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
@@ -149,7 +148,8 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
   ],
   "Action": [
     "ec2:RunInstances",
@@ -181,7 +181,8 @@ actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-templ
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
   ],
   "Action": "ec2:CreateTags",
   "Condition": {

--- a/website/content/en/preview/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/preview/upgrading/v1beta1-controller-policy.json
@@ -7,7 +7,6 @@
       "Resource": [
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::image/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::snapshot/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:security-group/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:subnet/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
@@ -25,7 +24,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"
       ],
       "Action": [
         "ec2:RunInstances",
@@ -49,7 +49,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"
       ],
       "Action": "ec2:CreateTags",
       "Condition": {

--- a/website/content/en/v0.33/reference/cloudformation.md
+++ b/website/content/en/v0.33/reference/cloudformation.md
@@ -122,7 +122,6 @@ For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read 
   "Resource": [
     "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
@@ -149,7 +148,8 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
   ],
   "Action": [
     "ec2:RunInstances",
@@ -181,7 +181,8 @@ actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-templ
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
   ],
   "Action": "ec2:CreateTags",
   "Condition": {

--- a/website/content/en/v0.33/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/v0.33/upgrading/v1beta1-controller-policy.json
@@ -7,7 +7,6 @@
       "Resource": [
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::image/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::snapshot/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:security-group/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:subnet/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
@@ -25,7 +24,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"
       ],
       "Action": [
         "ec2:RunInstances",
@@ -49,7 +49,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"
       ],
       "Action": "ec2:CreateTags",
       "Condition": {


### PR DESCRIPTION
Fixes #5407 
**Description**
Fixes the other copies of the karpenter controller policy to match what is in the "getting-started-with-karpenter/cloudformation.yaml", getting the necessary changes for the added "spot-instance-requests" CreateTag permission to work.

**How was this change tested?**
Policy from upgrading doc, without these changes, failed on a v0.33.1 deployment with RunInstances/CreateTag lack of permissions.  Fixing the policy, as shown in this PR, allowed my v0.33.1 system to come up.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.