### PR TITLE
chore: Update issue templates to not include ticket routing in rendered issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -4,12 +4,15 @@ labels:
 - bug
 - needs-triage
 body:
+- type: markdown
+  attributes:
+    value: |
+      > [!IMPORTANT]
+      > If your issue is not specific to AWS, please cut a ticket in [kubernetes-sigs/karpenter](https://github.com/kubernetes-sigs/karpenter/issues/new/choose).
 - type: textarea
   attributes:
     label: Description
     value: |
-      ** READ BEFORE CONTINUING: If your issue is not specific to AWS, please cut a ticket in [kubernetes-sigs/karpenter](https://github.com/kubernetes-sigs/karpenter/issues/new/choose).
-
       **Observed Behavior**:
 
       **Expected Behavior**:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -4,12 +4,15 @@ labels:
 - feature
 - needs-triage
 body:
+- type: markdown
+  attributes:
+    value: |
+      > [!IMPORTANT]
+      > If your issue is not specific to AWS, please cut a ticket in [kubernetes-sigs/karpenter](https://github.com/kubernetes-sigs/karpenter/issues/new/choose).
 - type: textarea
   attributes:
     label: Description
     value: |
-      ** READ BEFORE CONTINUING: If your issue is not specific to AWS, please cut a ticket in [kubernetes-sigs/karpenter](https://github.com/kubernetes-sigs/karpenter/issues/new/choose).
-
       **What problem are you trying to solve?**
 
       **How important is this feature to you?**


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This updates the issue template to use [Github alert syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) for surfacing the important routing detail in markdown at the top of issues, but not to include this note in the rendered issue once it's created.

Issue creation will now look like this when someone goes through the issue creation form:

<img width="975" alt="Screenshot 2024-01-02 at 12 37 48 PM" src="https://github.com/aws/karpenter-provider-aws/assets/26334334/83c1dde3-1fe5-4daa-8707-474ca728b18f">

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.