### PR TITLE
ci: Fix `make codegen` for network bandwidth

### DIFF
--- a/hack/code/bandwidth_gen/main.go
+++ b/hack/code/bandwidth_gen/main.go
@@ -32,11 +32,12 @@ import (
 )
 
 var uriSelectors = map[string]string{
-	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose-instances.html":       "#general-purpose-network-performance",
-	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/compute-optimized-instances.html":     "#compute-network-performance",
-	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/memory-optimized-instances.html":      "#memory-network-perf",
-	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/storage-optimized-instances.html":     "#storage-network-performance",
-	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html": "#gpu-network-performance",
+	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose-instances.html":            "#general-purpose-network-performance",
+	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/compute-optimized-instances.html":          "#compute-network-performance",
+	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/memory-optimized-instances.html":           "#memory-network-perf",
+	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/storage-optimized-instances.html":          "#storage-network-performance",
+	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html":      "#gpu-network-performance",
+	"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/high-performance-computing-instances.html": "#hpc-network-performance",
 }
 
 const fileFormat = `
@@ -92,11 +93,15 @@ func main() {
 				}
 			}
 
-			// collect any remaining instancetypes
-			for _, row := range doc.Find(selector).NextAllFiltered(".table-container").Eq(1).Find("tbody").Find("tr").Nodes {
-				instanceTypeData := row.FirstChild.NextSibling.FirstChild.FirstChild.Data
-				bandwidthData := row.FirstChild.NextSibling.NextSibling.NextSibling.FirstChild.Data
-				bandwidth[instanceTypeData] = int64(lo.Must(strconv.ParseFloat(bandwidthData, 64)) * 1000)
+			// Collect instance types bandwidth data from the baseline/bandwidth table underneath the standard table
+			// The HPC network performance doc is laid out differently than the other docs. There is no table underneath
+			// the standard table that contains information for network performance with baseline and burst bandwidth.
+			if selector != "#hpc-network-performance" {
+				for _, row := range doc.Find(selector).NextAllFiltered(".table-container").Eq(1).Find("tbody").Find("tr").Nodes {
+					instanceTypeData := row.FirstChild.NextSibling.FirstChild.FirstChild.Data
+					bandwidthData := row.FirstChild.NextSibling.NextSibling.NextSibling.FirstChild.Data
+					bandwidth[instanceTypeData] = int64(lo.Must(strconv.ParseFloat(bandwidthData, 64)) * 1000)
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This changes fixes `make codegen` when generating network bandwitdth for HPC instances

**How was this change tested?**

`make codegen`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.