### PR TITLE
fix: Fix global tag parsing for helm chart

### DIFF
--- a/charts/karpenter/templates/configmap.yaml
+++ b/charts/karpenter/templates/configmap.yaml
@@ -50,7 +50,7 @@ data:
   aws.interruptionQueueName: "{{ . }}"
 {{- end }}
 {{- with .Values.settings.aws.tags }}
-  aws.tags: "{{ . }}"
+  aws.tags: {{ . | toJson | quote }}
 {{- end }}
 {{- with .Values.settings.aws.reservedENIs }}
   aws.reservedENIs: "{{ . }}"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5448

**Description**

Fix global tag parsing in v0.32.x

**How was this change tested?**

`make apply` with `aws.tags` set

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.