### PR TITLE
Delete Launch templates on deletion of EC2NodeClass

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -67,6 +67,7 @@ func main() {
 			op.InstanceProvider,
 			op.PricingProvider,
 			op.AMIProvider,
+			op.LaunchTemplateProvider,
 		)...).
 		WithWebhooks(ctx, webhooks.NewWebhooks()...).
 		Start(ctx)

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -17,6 +17,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	servicesqs "github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/samber/lo"
@@ -46,10 +48,10 @@ import (
 func NewControllers(ctx context.Context, sess *session.Session, clk clock.Clock, kubeClient client.Client, recorder events.Recorder,
 	unavailableOfferings *cache.UnavailableOfferings, cloudProvider *cloudprovider.CloudProvider, subnetProvider *subnet.Provider,
 	securityGroupProvider *securitygroup.Provider, instanceProfileProvider *instanceprofile.Provider, instanceProvider *instance.Provider,
-	pricingProvider *pricing.Provider, amiProvider *amifamily.Provider) []controller.Controller {
+	pricingProvider *pricing.Provider, amiProvider *amifamily.Provider, launchTemplateProvider *launchtemplate.Provider) []controller.Controller {
 
 	controllers := []controller.Controller{
-		nodeclass.NewNodeClassController(kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider),
+		nodeclass.NewNodeClassController(kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, launchTemplateProvider),
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider),
 		nodeclaimtagging.NewController(kubeClient, instanceProvider),
 	}

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -117,7 +117,7 @@ func (c *Controller) Finalize(ctx context.Context, nodeClass *v1beta1.EC2NodeCla
 			return reconcile.Result{}, fmt.Errorf("deleting instance profile, %w", err)
 		}
 	}
-	if err := c.launchTemplateProvider.DeleteLaunchTemplates(ctx); err != nil {
+	if err := c.launchTemplateProvider.DeleteLaunchTemplates(ctx, nodeClass); err != nil {
 		return reconcile.Result{}, fmt.Errorf("deleting launch templates, %w", err)
 	}
 	controllerutil.RemoveFinalizer(nodeClass, v1beta1.TerminationFinalizer)

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -822,7 +822,7 @@ var _ = Describe("NodeClassController", func() {
 		})
 		It("should fail to delete the launch template", func() {
 			launchTemplateName := aws.String(fake.LaunchTemplateName())
-			awsEnv.EC2API.LaunchTemplates.Store(launchTemplateName, ec2.LaunchTemplate{LaunchTemplateName: launchTemplateName, LaunchTemplateId: aws.String(fake.LaunchTemplateID()), Tags: []*ec2.Tag{&ec2.Tag{Key: aws.String("karpenter.k8s.aws/cluster"), Value: aws.String("test-cluster")}}})
+			awsEnv.EC2API.LaunchTemplates.Store(launchTemplateName, &ec2.LaunchTemplate{LaunchTemplateName: launchTemplateName, LaunchTemplateId: aws.String(fake.LaunchTemplateID()), Tags: []*ec2.Tag{&ec2.Tag{Key: aws.String("karpenter.k8s.aws/cluster"), Value: aws.String("test-cluster")}}})
 			_, ok := awsEnv.EC2API.LaunchTemplates.Load(launchTemplateName)
 			Expect(ok).To(BeTrue())
 			ExpectApplied(ctx, env.Client, nodeClass)
@@ -835,7 +835,7 @@ var _ = Describe("NodeClassController", func() {
 		})
 		It("should not delete the launch template not associated with the nodeClass", func() {
 			launchTemplateName := aws.String(fake.LaunchTemplateName())
-			awsEnv.EC2API.LaunchTemplates.Store(launchTemplateName, ec2.LaunchTemplate{LaunchTemplateName: launchTemplateName, LaunchTemplateId: aws.String(fake.LaunchTemplateID()), Tags: []*ec2.Tag{&ec2.Tag{Key: aws.String("karpenter.k8s.aws/cluster"), Value: aws.String("test-cluster")}}})
+			awsEnv.EC2API.LaunchTemplates.Store(launchTemplateName, &ec2.LaunchTemplate{LaunchTemplateName: launchTemplateName, LaunchTemplateId: aws.String(fake.LaunchTemplateID()), Tags: []*ec2.Tag{&ec2.Tag{Key: aws.String("karpenter.k8s.aws/cluster"), Value: aws.String("test-cluster")}}})
 			_, ok := awsEnv.EC2API.LaunchTemplates.Load(launchTemplateName)
 			Expect(ok).To(BeTrue())
 			ExpectApplied(ctx, env.Client, nodeClass)
@@ -849,7 +849,7 @@ var _ = Describe("NodeClassController", func() {
 		})
 		It("should succeed to delete the launch template", func() {
 			launchTemplateName := aws.String(fake.LaunchTemplateName())
-			awsEnv.EC2API.LaunchTemplates.Store(launchTemplateName, ec2.LaunchTemplate{LaunchTemplateName: launchTemplateName, LaunchTemplateId: aws.String(fake.LaunchTemplateID()), Tags: []*ec2.Tag{&ec2.Tag{Key: aws.String("karpenter.k8s.aws/cluster"), Value: aws.String("test-cluster")}, {Key: aws.String("karpenter.k8s.aws/ec2nodeclass"), Value: aws.String(nodeClass.Name)}}})
+			awsEnv.EC2API.LaunchTemplates.Store(launchTemplateName, &ec2.LaunchTemplate{LaunchTemplateName: launchTemplateName, LaunchTemplateId: aws.String(fake.LaunchTemplateID()), Tags: []*ec2.Tag{&ec2.Tag{Key: aws.String("karpenter.k8s.aws/cluster"), Value: aws.String("test-cluster")}, {Key: aws.String("karpenter.k8s.aws/ec2nodeclass"), Value: aws.String(nodeClass.Name)}}})
 			_, ok := awsEnv.EC2API.LaunchTemplates.Load(launchTemplateName)
 			Expect(ok).To(BeTrue())
 			ExpectApplied(ctx, env.Client, nodeClass)
@@ -967,7 +967,6 @@ var _ = Describe("NodeClassController", func() {
 					},
 				},
 			}
-
 			nodeClass.Spec.Role = ""
 			nodeClass.Spec.InstanceProfile = lo.ToPtr("test-instance-profile")
 			ExpectApplied(ctx, env.Client, nodeClass)

--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -55,6 +55,14 @@ func RoleID() string {
 	return fmt.Sprintf("role-%s", randomdata.Alphanumeric(17))
 }
 
+func LaunchTemplateName() string {
+	return fmt.Sprintf("karpenter.k8s.aws/%s", randomdata.Alphanumeric(17))
+}
+
+func LaunchTemplateID() string {
+	return fmt.Sprint(randomdata.Alphanumeric(17))
+}
+
 func PrivateDNSName() string {
 	return fmt.Sprintf("ip-192-168-%d-%d.%s.compute.internal", randomdata.Number(0, 256), randomdata.Number(0, 256), DefaultRegion)
 }

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -59,6 +59,7 @@ type Options struct {
 	Labels                   map[string]string `hash:"ignore"`
 	KubeDNSIP                net.IP
 	AssociatePublicIPAddress *bool
+	NodeClassName            string
 }
 
 // LaunchTemplate holds the dynamically generated launch template parameters

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.uber.org/multierr"
 	"math"
 	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"go.uber.org/multierr"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -415,9 +415,11 @@ func (p *Provider) DeleteLaunchTemplates(ctx context.Context, nodeClass *v1beta1
 		_, err := p.ec2api.DeleteLaunchTemplateWithContext(ctx, &ec2.DeleteLaunchTemplateInput{LaunchTemplateName: name})
 		deleteErr = multierr.Append(deleteErr, err)
 	}
+	if len(ltNames) > 0 {
+		logging.FromContext(ctx).With("launchTemplates", utils.PrettySlice(aws.StringValueSlice(ltNames), 5)).Debugf("deleted launch templates")
+	}
 	if deleteErr != nil {
 		return fmt.Errorf("deleting launch templates, %w", deleteErr)
 	}
-	logging.FromContext(ctx).With("launchTemplates", utils.PrettySlice(aws.StringValueSlice(ltNames), 5)).Debugf("deleted launch templates")
 	return nil
 }

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -418,6 +418,6 @@ func (p *Provider) DeleteLaunchTemplates(ctx context.Context, nodeClass *v1beta1
 	if deleteErr != nil {
 		return fmt.Errorf("deleting launch templates, %w", deleteErr)
 	}
-	logging.FromContext(ctx).With("launchTemplates", utils.PrettySlice(aws.StringValueSlice(ltNames), 5)).Debugf("deleted %v launch templates", len(ltNames))
+	logging.FromContext(ctx).With("launchTemplates", utils.PrettySlice(aws.StringValueSlice(ltNames), 5)).Debugf("deleted launch templates")
 	return nil
 }

--- a/test/suites/integration/launch_template_test.go
+++ b/test/suites/integration/launch_template_test.go
@@ -1,0 +1,47 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Launch Template Deletion", func() {
+	FIt("should remove the generated Launch Templates when deleting the NodeClass", func() {
+		pod := coretest.Pod()
+		env.ExpectCreated(nodePool, nodeClass, pod)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		env.ExpectDeleted(nodePool, nodeClass)
+		Eventually(func(g Gomega) {
+			output, _ := env.EC2API.DescribeLaunchTemplatesWithContext(env.Context, &ec2.DescribeLaunchTemplatesInput{
+				Filters: []*ec2.Filter{
+					{Name: aws.String(fmt.Sprintf("tag:%s", v1beta1.LabelNodeClass)), Values: []*string{aws.String(nodeClass.Name)}},
+				},
+			})
+			g.Expect(len(output.LaunchTemplates)).To(HaveLen(0))
+		}).Should(Succeed())
+	})
+})

--- a/test/suites/integration/launch_template_test.go
+++ b/test/suites/integration/launch_template_test.go
@@ -42,6 +42,6 @@ var _ = Describe("Launch Template Deletion", func() {
 				},
 			})
 			g.Expect(output.LaunchTemplates).To(HaveLen(0))
-		}).Should(Succeed())
+		}).WithPolling(5.0).Should(Succeed())
 	})
 })

--- a/test/suites/integration/launch_template_test.go
+++ b/test/suites/integration/launch_template_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 var _ = Describe("Launch Template Deletion", func() {
-	FIt("should remove the generated Launch Templates when deleting the NodeClass", func() {
+	It("should remove the generated Launch Templates when deleting the NodeClass", func() {
 		pod := coretest.Pod()
 		env.ExpectCreated(nodePool, nodeClass, pod)
 		env.EventuallyExpectHealthy(pod)

--- a/test/suites/integration/launch_template_test.go
+++ b/test/suites/integration/launch_template_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Launch Template Deletion", func() {
 					{Name: aws.String(fmt.Sprintf("tag:%s", v1beta1.LabelNodeClass)), Values: []*string{aws.String(nodeClass.Name)}},
 				},
 			})
-			g.Expect(len(output.LaunchTemplates)).To(HaveLen(0))
+			g.Expect(output.LaunchTemplates).To(HaveLen(0))
 		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #995 <!-- issue number -->

**Description**
Added a method to delete the launch templates on deletion of EC2NodeClass. Added tests for the same.

**How was this change tested?**
Deployed the changes on my local EKS cluster. Steps followed -
1. Install Karpenter
2. Created Nodepool that references a Nodeclass
3. Deployed sample applications
4. Removed sample applications
5. Removed the Nodeclass object

Performing the nodeclass object deletion will trigger a flow that deletes the launch templates.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.