### PR TITLE
chore: prefer newer generation instance type when pricing the same

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -381,7 +381,9 @@ func orderInstanceTypesByPrice(instanceTypes []*cloudprovider.InstanceType, requ
 			jPrice = instanceTypes[j].Offerings.Available().Requirements(requirements).Cheapest().Price
 		}
 		if iPrice == jPrice {
-			return instanceTypes[i].Name < instanceTypes[j].Name
+			// sort newer generation instance types before old when the price is the same
+			// e.g.  c6i.large ( $0.085 ) before c5.large ( $0.085 )
+			return instanceTypes[i].Name > instanceTypes[j].Name
 		}
 		return iPrice < jPrice
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
If a on-demand node pool contains instances from multiple generations ( i.e. c5.large and c6i.large ) and the instances are priced the same, Karpenter "randomly" allocates nodes from both instance types.  Because new generations have improved performance characteristics, they should be preferred.  This change fixes the alphabetical sorting of instance types to be descending when the price is the same.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.