### PR TITLE
docs: Update Drift fields include correct CRD path

### DIFF
--- a/website/content/en/docs/concepts/disruption.md
+++ b/website/content/en/docs/concepts/disruption.md
@@ -126,25 +126,24 @@ In special cases, drift can correspond to multiple values and must be handled di
 ##### NodePool
 | Fields         |
 |----------------|
-| Requirements   |
+| spec.template.spec.requirements   |
 
 ##### EC2NodeClass
 | Fields                        |
 |-------------------------------|
-| Subnet Selector Terms         |
-| Security Group Selector Terms |
-| AMI Selector Terms            |
+| spec.subnetSelectorTerms      |
+| spec.securityGroupSelectorTerms  |
+| spec.amiSelectorTerms  |
 
 #### Behavioral Fields
 Behavioral Fields are treated as over-arching settings on the NodePool to dictate how Karpenter behaves. These fields don’t correspond to settings on the NodeClaim or instance. They’re set by the user to control Karpenter’s Provisioning and disruption logic. Since these don’t map to a desired state of NodeClaims, __behavioral fields are not considered for Drift__.
 
-__Behavioral Fields__
-- Weight                      
-- Limits                      
-- ConsolidationPolicy               
-- ConsolidateAfter      
-- ExpireAfter  
----      
+##### NodePool
+| Fields         |
+|----------------|
+| spec.weight       |
+| spec.limits       |
+| spec.disruption.* |
 
 Read the [Drift Design](https://github.com/aws/karpenter-core/blob/main/designs/drift.md) for more.
 

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -138,25 +138,24 @@ In special cases, drift can correspond to multiple values and must be handled di
 ##### NodePool
 | Fields         |
 |----------------|
-| Requirements   |
+| spec.template.spec.requirements   |
 
 ##### EC2NodeClass
 | Fields                        |
 |-------------------------------|
-| Subnet Selector Terms         |
-| Security Group Selector Terms |
-| AMI Selector Terms            |
+| spec.subnetSelectorTerms      |
+| spec.securityGroupSelectorTerms  |
+| spec.amiSelectorTerms  |
 
 #### Behavioral Fields
 Behavioral Fields are treated as over-arching settings on the NodePool to dictate how Karpenter behaves. These fields don’t correspond to settings on the NodeClaim or instance. They’re set by the user to control Karpenter’s Provisioning and disruption logic. Since these don’t map to a desired state of NodeClaims, __behavioral fields are not considered for Drift__.
 
-__Behavioral Fields__
-- Weight                      
-- Limits                      
-- ConsolidationPolicy               
-- ConsolidateAfter      
-- ExpireAfter  
----      
+##### NodePool
+| Fields              |
+|---------------------|
+| spec.weight         |
+| spec.limits         |
+| spec.disruption.*   |
 
 Read the [Drift Design](https://github.com/aws/karpenter-core/blob/main/designs/drift.md) for more.
 

--- a/website/content/en/v0.32/concepts/disruption.md
+++ b/website/content/en/v0.32/concepts/disruption.md
@@ -126,25 +126,24 @@ In special cases, drift can correspond to multiple values and must be handled di
 ##### NodePool
 | Fields         |
 |----------------|
-| Requirements   |
+| spec.template.spec.requirements   |
 
 ##### EC2NodeClass
 | Fields                        |
 |-------------------------------|
-| Subnet Selector Terms         |
-| Security Group Selector Terms |
-| AMI Selector Terms            |
+| spec.subnetSelectorTerms      |
+| spec.securityGroupSelectorTerms  |
+| spec.amiSelectorTerms  |
 
 #### Behavioral Fields
 Behavioral Fields are treated as over-arching settings on the NodePool to dictate how Karpenter behaves. These fields don’t correspond to settings on the NodeClaim or instance. They’re set by the user to control Karpenter’s Provisioning and disruption logic. Since these don’t map to a desired state of NodeClaims, __behavioral fields are not considered for Drift__.
 
-__Behavioral Fields__
-- Weight                      
-- Limits                      
-- ConsolidationPolicy               
-- ConsolidateAfter      
-- ExpireAfter  
----      
+##### NodePool
+| Fields         |
+|----------------|
+| spec.weight         |
+| spec.limits         |
+| spec.disruption.*   |
 
 Read the [Drift Design](https://github.com/aws/karpenter-core/blob/main/designs/drift.md) for more.
 

--- a/website/content/en/v0.33/concepts/disruption.md
+++ b/website/content/en/v0.33/concepts/disruption.md
@@ -126,25 +126,24 @@ In special cases, drift can correspond to multiple values and must be handled di
 ##### NodePool
 | Fields         |
 |----------------|
-| Requirements   |
+| spec.template.spec.requirements   |
 
 ##### EC2NodeClass
 | Fields                        |
 |-------------------------------|
-| Subnet Selector Terms         |
-| Security Group Selector Terms |
-| AMI Selector Terms            |
+| spec.subnetSelectorTerms      |
+| spec.securityGroupSelectorTerms  |
+| spec.amiSelectorTerms  |
 
 #### Behavioral Fields
 Behavioral Fields are treated as over-arching settings on the NodePool to dictate how Karpenter behaves. These fields don’t correspond to settings on the NodeClaim or instance. They’re set by the user to control Karpenter’s Provisioning and disruption logic. Since these don’t map to a desired state of NodeClaims, __behavioral fields are not considered for Drift__.
 
-__Behavioral Fields__
-- Weight                      
-- Limits                      
-- ConsolidationPolicy               
-- ConsolidateAfter      
-- ExpireAfter  
----      
+##### NodePool
+| Fields         |
+|----------------|
+| spec.weight         |
+| spec.limits         |
+| spec.disruption.*   |
 
 Read the [Drift Design](https://github.com/aws/karpenter-core/blob/main/designs/drift.md) for more.
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Update Behavioral Fields to include the disruption field 
- Update docs to include CRD field path in reference to drift 

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.