### PR TITLE
fix: target down in Prometheus

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -15,6 +15,10 @@ extraScrapeConfigs: |
           names:
           - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: http-metrics
+      - source_labels:
+          [
+            __meta_kubernetes_endpoints_name,
+            __meta_kubernetes_endpoint_port_name,
+          ]
         action: keep
+        regex: karpenter;http-metrics

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -16,9 +16,7 @@ extraScrapeConfigs: |
           - kube-system
       relabel_configs:
       - source_labels:
-          [
-            __meta_kubernetes_endpoints_name,
-            __meta_kubernetes_endpoint_port_name,
-          ]
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
         action: keep
         regex: karpenter;http-metrics

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -15,6 +15,10 @@ extraScrapeConfigs: |
           names:
           - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: http-metrics
+      - source_labels:
+          [
+            __meta_kubernetes_endpoints_name,
+            __meta_kubernetes_endpoint_port_name,
+          ]
         action: keep
+        regex: karpenter;http-metrics

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -16,9 +16,7 @@ extraScrapeConfigs: |
           - kube-system
       relabel_configs:
       - source_labels:
-          [
-            __meta_kubernetes_endpoints_name,
-            __meta_kubernetes_endpoint_port_name,
-          ]
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
         action: keep
         regex: karpenter;http-metrics

--- a/website/content/en/v0.33/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/v0.33/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -15,6 +15,10 @@ extraScrapeConfigs: |
           names:
           - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: http-metrics
+      - source_labels:
+          [
+            __meta_kubernetes_endpoints_name,
+            __meta_kubernetes_endpoint_port_name,
+          ]
         action: keep
+        regex: karpenter;http-metrics

--- a/website/content/en/v0.33/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/v0.33/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -16,9 +16,7 @@ extraScrapeConfigs: |
           - kube-system
       relabel_configs:
       - source_labels:
-          [
-            __meta_kubernetes_endpoints_name,
-            __meta_kubernetes_endpoint_port_name,
-          ]
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
         action: keep
         regex: karpenter;http-metrics


### PR DESCRIPTION

Fixes #N/A

**Description**
It is recommended to set the installation namespace for Karpenter controllers to `kube-system`, but it can interfere with other endpoints located there. This fix specifies for Prometheus job to scrap only the karpenter endpoint.
![image](https://github.com/aws/karpenter-provider-aws/assets/1875831/bf165429-5fb7-4283-b9f5-9b2ff154d38b)


**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.