### PR TITLE
docs: issue-5495: typo "consolidastion"

### DIFF
--- a/website/content/en/docs/_index.md
+++ b/website/content/en/docs/_index.md
@@ -18,7 +18,7 @@ Karpenter works by:
 
 As someone using Karpenter, once your Kubernetes cluster and the Karpenter controller are up and running (see [Getting Started]({{<ref "./getting-started" >}})), you can:
 
-* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidastion, or Kubelet configuration values.
+* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidation, or Kubelet configuration values.
   NodePool-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
 
   - Taints (`taints`): Identify taints to add to provisioned nodes. If a pod doesn't have a matching toleration for the taint, the effect set by the taint occurs (NoSchedule, PreferNoSchedule, or NoExecute). See Kubernetes [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.

--- a/website/content/en/preview/_index.md
+++ b/website/content/en/preview/_index.md
@@ -18,7 +18,7 @@ Karpenter works by:
 
 As someone using Karpenter, once your Kubernetes cluster and the Karpenter controller are up and running (see [Getting Started]({{<ref "./getting-started" >}})), you can:
 
-* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidastion, or Kubelet configuration values.
+* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidation, or Kubelet configuration values.
   NodePool-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
 
   - Taints (`taints`): Identify taints to add to provisioned nodes. If a pod doesn't have a matching toleration for the taint, the effect set by the taint occurs (NoSchedule, PreferNoSchedule, or NoExecute). See Kubernetes [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.

--- a/website/content/en/v0.32/_index.md
+++ b/website/content/en/v0.32/_index.md
@@ -18,7 +18,7 @@ Karpenter works by:
 
 As someone using Karpenter, once your Kubernetes cluster and the Karpenter controller are up and running (see [Getting Started]({{<ref "./getting-started" >}})), you can:
 
-* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidastion, or Kubelet configuration values.
+* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidation, or Kubelet configuration values.
   NodePool-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
 
   - Taints (`taints`): Identify taints to add to provisioned nodes. If a pod doesn't have a matching toleration for the taint, the effect set by the taint occurs (NoSchedule, PreferNoSchedule, or NoExecute). See Kubernetes [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.

--- a/website/content/en/v0.33/_index.md
+++ b/website/content/en/v0.33/_index.md
@@ -18,7 +18,7 @@ Karpenter works by:
 
 As someone using Karpenter, once your Kubernetes cluster and the Karpenter controller are up and running (see [Getting Started]({{<ref "./getting-started" >}})), you can:
 
-* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidastion, or Kubelet configuration values.
+* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidation, or Kubelet configuration values.
   NodePool-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
 
   - Taints (`taints`): Identify taints to add to provisioned nodes. If a pod doesn't have a matching toleration for the taint, the effect set by the taint occurs (NoSchedule, PreferNoSchedule, or NoExecute). See Kubernetes [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5495

**Description**
Fixes minor typo where "consolidastion" should be "consolidation" (there is currently an extra "s")

**How was this change tested?**

**Does this change impact docs?**
- [] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [X] Yes, issue opened: #5495 
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.