### PR TITLE
chrore: Add CredentialProvider to Bottlerocket settings

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -16,7 +16,6 @@ package bootstrap
 
 import (
 	"github.com/pelletier/go-toml/v2"
-	"time"
 )
 
 func NewBottlerocketConfig(userdata *string) (*BottlerocketConfig, error) {
@@ -87,7 +86,7 @@ type BottlerocketStaticPod struct {
 // https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
 type BottlerocketCredentialProvider struct {
 	Enabled       *bool             `toml:"enabled"`
-	CacheDuration time.Duration     `toml:"cache-duration,omitempty"`
+	CacheDuration *string           `toml:"cache-duration,omitempty"`
 	ImagePatterns []string          `toml:"image-patterns"`
 	Environment   map[string]string `toml:"environment,omitempty"`
 }

--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"github.com/pelletier/go-toml/v2"
+	"time"
 )
 
 func NewBottlerocketConfig(userdata *string) (*BottlerocketConfig, error) {
@@ -43,41 +44,52 @@ type BottlerocketSettings struct {
 
 // BottlerocketKubernetes is k8s specific configuration for bottlerocket api
 type BottlerocketKubernetes struct {
-	APIServer                          *string                          `toml:"api-server"`
-	CloudProvider                      *string                          `toml:"cloud-provider"`
-	ClusterCertificate                 *string                          `toml:"cluster-certificate"`
-	ClusterName                        *string                          `toml:"cluster-name"`
-	ClusterDNSIP                       *string                          `toml:"cluster-dns-ip,omitempty"`
-	NodeLabels                         map[string]string                `toml:"node-labels,omitempty"`
-	NodeTaints                         map[string][]string              `toml:"node-taints,omitempty"`
-	MaxPods                            *int                             `toml:"max-pods,omitempty"`
-	StaticPods                         map[string]BottlerocketStaticPod `toml:"static-pods,omitempty"`
-	EvictionHard                       map[string]string                `toml:"eviction-hard,omitempty"`
-	KubeReserved                       map[string]string                `toml:"kube-reserved,omitempty"`
-	SystemReserved                     map[string]string                `toml:"system-reserved,omitempty"`
-	AllowedUnsafeSysctls               []string                         `toml:"allowed-unsafe-sysctls,omitempty"`
-	ServerTLSBootstrap                 *bool                            `toml:"server-tls-bootstrap,omitempty"`
-	RegistryQPS                        *int                             `toml:"registry-qps,omitempty"`
-	RegistryBurst                      *int                             `toml:"registry-burst,omitempty"`
-	EventQPS                           *int                             `toml:"event-qps,omitempty"`
-	EventBurst                         *int                             `toml:"event-burst,omitempty"`
-	KubeAPIQPS                         *int                             `toml:"kube-api-qps,omitempty"`
-	KubeAPIBurst                       *int                             `toml:"kube-api-burst,omitempty"`
-	ContainerLogMaxSize                *string                          `toml:"container-log-max-size,omitempty"`
-	ContainerLogMaxFiles               *int                             `toml:"container-log-max-files,omitempty"`
-	CPUManagerPolicy                   *string                          `toml:"cpu-manager-policy,omitempty"`
-	CPUManagerReconcilePeriod          *string                          `toml:"cpu-manager-reconcile-period,omitempty"`
-	TopologyManagerScope               *string                          `toml:"topology-manager-scope,omitempty"`
-	ImageGCHighThresholdPercent        *string                          `toml:"image-gc-high-threshold-percent,omitempty"`
-	ImageGCLowThresholdPercent         *string                          `toml:"image-gc-low-threshold-percent,omitempty"`
-	CPUCFSQuota                        *bool                            `toml:"cpu-cfs-quota-enforced,omitempty"`
-	ShutdownGracePeriod                *string                          `toml:"shutdown-grace-period,omitempty"`
-	ShutdownGracePeriodForCriticalPods *string                          `toml:"shutdown-grace-period-for-critical-pods,omitempty"`
+	APIServer                          *string                                   `toml:"api-server"`
+	CloudProvider                      *string                                   `toml:"cloud-provider"`
+	ClusterCertificate                 *string                                   `toml:"cluster-certificate"`
+	ClusterName                        *string                                   `toml:"cluster-name"`
+	ClusterDNSIP                       *string                                   `toml:"cluster-dns-ip,omitempty"`
+	CredentialProviders                map[string]BottlerocketCredentialProvider `toml:"credential-providers,omitempty"`
+	NodeLabels                         map[string]string                         `toml:"node-labels,omitempty"`
+	NodeTaints                         map[string][]string                       `toml:"node-taints,omitempty"`
+	MaxPods                            *int                                      `toml:"max-pods,omitempty"`
+	StaticPods                         map[string]BottlerocketStaticPod          `toml:"static-pods,omitempty"`
+	EvictionHard                       map[string]string                         `toml:"eviction-hard,omitempty"`
+	KubeReserved                       map[string]string                         `toml:"kube-reserved,omitempty"`
+	SystemReserved                     map[string]string                         `toml:"system-reserved,omitempty"`
+	AllowedUnsafeSysctls               []string                                  `toml:"allowed-unsafe-sysctls,omitempty"`
+	ServerTLSBootstrap                 *bool                                     `toml:"server-tls-bootstrap,omitempty"`
+	RegistryQPS                        *int                                      `toml:"registry-qps,omitempty"`
+	RegistryBurst                      *int                                      `toml:"registry-burst,omitempty"`
+	EventQPS                           *int                                      `toml:"event-qps,omitempty"`
+	EventBurst                         *int                                      `toml:"event-burst,omitempty"`
+	KubeAPIQPS                         *int                                      `toml:"kube-api-qps,omitempty"`
+	KubeAPIBurst                       *int                                      `toml:"kube-api-burst,omitempty"`
+	ContainerLogMaxSize                *string                                   `toml:"container-log-max-size,omitempty"`
+	ContainerLogMaxFiles               *int                                      `toml:"container-log-max-files,omitempty"`
+	CPUManagerPolicy                   *string                                   `toml:"cpu-manager-policy,omitempty"`
+	CPUManagerReconcilePeriod          *string                                   `toml:"cpu-manager-reconcile-period,omitempty"`
+	TopologyManagerScope               *string                                   `toml:"topology-manager-scope,omitempty"`
+	ImageGCHighThresholdPercent        *string                                   `toml:"image-gc-high-threshold-percent,omitempty"`
+	ImageGCLowThresholdPercent         *string                                   `toml:"image-gc-low-threshold-percent,omitempty"`
+	CPUCFSQuota                        *bool                                     `toml:"cpu-cfs-quota-enforced,omitempty"`
+	ShutdownGracePeriod                *string                                   `toml:"shutdown-grace-period,omitempty"`
+	ShutdownGracePeriodForCriticalPods *string                                   `toml:"shutdown-grace-period-for-critical-pods,omitempty"`
 }
 
 type BottlerocketStaticPod struct {
 	Enabled  *bool   `toml:"enabled,omitempty"`
 	Manifest *string `toml:"manifest,omitempty"`
+}
+
+// BottlerocketCredentialProvider is k8s specific configuration for Bottlerocket Kubelet image credential provider
+// https://bottlerocket.dev/en/os/1.18.x/api/settings/kubernetes/#credential-providers
+// https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
+type BottlerocketCredentialProvider struct {
+	Enabled       *bool             `toml:"enabled"`
+	CacheDuration time.Duration     `toml:"cache-duration,omitempty"`
+	ImagePatterns []string          `toml:"image-patterns"`
+	Environment   map[string]string `toml:"environment,omitempty"`
 }
 
 func (c *BottlerocketConfig) UnmarshalTOML(data []byte) error {

--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -35,7 +35,7 @@ type BottlerocketConfig struct {
 	Settings    BottlerocketSettings   `toml:"-"`
 }
 
-// BottlerocketSettings is a subset of all configuration in https://github.com/bottlerocket-os/bottlerocket/blob/develop/sources/models/src/aws-k8s-1.22/mod.rs
+// BottlerocketSettings is a subset of all configuration in https://github.com/bottlerocket-os/bottlerocket/blob/d427c40931cba6e6bedc5b75e9c084a6e1818db9/sources/models/src/lib.rs#L260
 // These settings apply across all K8s versions that karpenter supports.
 type BottlerocketSettings struct {
 	Kubernetes BottlerocketKubernetes `toml:"kubernetes"`
@@ -82,8 +82,7 @@ type BottlerocketStaticPod struct {
 }
 
 // BottlerocketCredentialProvider is k8s specific configuration for Bottlerocket Kubelet image credential provider
-// https://bottlerocket.dev/en/os/1.18.x/api/settings/kubernetes/#credential-providers
-// https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
+// See Bottlerocket struct at https://github.com/bottlerocket-os/bottlerocket/blob/d427c40931cba6e6bedc5b75e9c084a6e1818db9/sources/models/modeled-types/src/kubernetes.rs#L1307
 type BottlerocketCredentialProvider struct {
 	Enabled       *bool             `toml:"enabled"`
 	CacheDuration *string           `toml:"cache-duration,omitempty"`


### PR DESCRIPTION
Fixes #5507

**Description**

This PR adds support for [settings.kubernetes.credential-providers](https://bottlerocket.dev/en/os/1.18.x/api/settings/kubernetes/#credential-providers) for Bottlerocket.

**How was this change tested?**

By building a dev version of Karpenter with the changes of this PR, pushing the image to a private ECR repository and switched the image URL of Karpenter with the dev image on an existing EKS cluster which was already using Karpenter.
When Karpenter was deployed, it spun up a new Bottlerocket instance with the example configuration of [the original issue](https://github.com/aws/karpenter-provider-aws/issues/5507).
After going into the node with SSM I was able to confirm the configuration was updated as expected (which wasn't the case before).

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.