### PR TITLE
Cache eviction should not throw error if the LT is already deleted

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -370,6 +370,13 @@ func (p *Provider) cachedEvictedFunc(ctx context.Context) func(string, interface
 		}
 		launchTemplate := lt.(*ec2.LaunchTemplate)
 		if _, err := p.ec2api.DeleteLaunchTemplate(&ec2.DeleteLaunchTemplateInput{LaunchTemplateId: launchTemplate.LaunchTemplateId}); err != nil {
+			if awserrors.IsLaunchTemplateNotFound(err) {
+				logging.FromContext(ctx).With(
+					"id", aws.StringValue(launchTemplate.LaunchTemplateId),
+					"name", aws.StringValue(launchTemplate.LaunchTemplateName),
+				).Debugf("launch template no longer exists")
+				return
+			}
 			logging.FromContext(ctx).With("launch-template", launchTemplate.LaunchTemplateName).Errorf("failed to delete launch template, %v", err)
 			return
 		}

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -369,14 +369,7 @@ func (p *Provider) cachedEvictedFunc(ctx context.Context) func(string, interface
 			return
 		}
 		launchTemplate := lt.(*ec2.LaunchTemplate)
-		if _, err := p.ec2api.DeleteLaunchTemplate(&ec2.DeleteLaunchTemplateInput{LaunchTemplateId: launchTemplate.LaunchTemplateId}); err != nil {
-			if awserrors.IsLaunchTemplateNotFound(err) {
-				logging.FromContext(ctx).With(
-					"id", aws.StringValue(launchTemplate.LaunchTemplateId),
-					"name", aws.StringValue(launchTemplate.LaunchTemplateName),
-				).Debugf("launch template no longer exists")
-				return
-			}
+		if _, err := p.ec2api.DeleteLaunchTemplate(&ec2.DeleteLaunchTemplateInput{LaunchTemplateId: launchTemplate.LaunchTemplateId}); awserrors.IgnoreNotFound(err) != nil {
 			logging.FromContext(ctx).With("launch-template", launchTemplate.LaunchTemplateName).Errorf("failed to delete launch template, %v", err)
 			return
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5535

**Description**
If we delete EC2NodeClass and there is a cache eviction later, we see errors like these -
`{"level":"ERROR","time":"2024-01-25T05:33:52.210Z","logger":"controller","message":"failed to delete launch template, InvalidLaunchTemplateId.NotFound: The specified launch template, with template ID lt-019c5be5798f24ca7, does not exist.\n\tstatus code: 400, request id: 86bff5c8-9bc6-485a-a5a8-1619d6c81283","commit":"7cdc79a-dirty","launch-template":"karpenter.k8s.aws/2686062690276844038"}`
The change in the PR handles this case by instead printing a debug log that indicates that the LT is already deleted.

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.