### PR TITLE
chore: Scope list call with EC2NodeClass tag

### DIFF
--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -112,6 +112,10 @@ var _ = Describe("GarbageCollection", func() {
 					Value: aws.String(nodePool.Name),
 				},
 				{
+					Key:   aws.String(v1beta1.LabelNodeClass),
+					Value: aws.String(nodeClass.Name),
+				},
+				{
 					Key:   aws.String(corev1beta1.ManagedByAnnotationKey),
 					Value: aws.String(options.FromContext(ctx).ClusterName),
 				},
@@ -173,6 +177,10 @@ var _ = Describe("GarbageCollection", func() {
 						},
 						{
 							Key:   aws.String(corev1beta1.NodePoolLabelKey),
+							Value: aws.String("default"),
+						},
+						{
+							Key:   aws.String(v1beta1.LabelNodeClass),
 							Value: aws.String("default"),
 						},
 						{

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -134,6 +134,10 @@ func (p *Provider) List(ctx context.Context) ([]*Instance, error) {
 			},
 			{
 				Name:   aws.String("tag-key"),
+				Values: aws.StringSlice([]string{v1beta1.LabelNodeClass}),
+			},
+			{
+				Name:   aws.String("tag-key"),
 				Values: aws.StringSlice([]string{fmt.Sprintf("kubernetes.io/cluster/%s", options.FromContext(ctx).ClusterName)}),
 			},
 			instanceStateFilter,

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -147,6 +147,10 @@ var _ = Describe("InstanceProvider", func() {
 							Value: aws.String("default"),
 						},
 						{
+							Key:   aws.String(v1beta1.LabelNodeClass),
+							Value: aws.String("default"),
+						},
+						{
 							Key:   aws.String(corev1beta1.ManagedByAnnotationKey),
 							Value: aws.String(options.FromContext(ctx).ClusterName),
 						},

--- a/test/suites/nodeclaim/garbage_collection_test.go
+++ b/test/suites/nodeclaim/garbage_collection_test.go
@@ -28,6 +28,7 @@ import (
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
+	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/aws/karpenter-provider-aws/pkg/utils"
 	environmentaws "github.com/aws/karpenter-provider-aws/test/pkg/environment/aws"
@@ -83,6 +84,10 @@ var _ = Describe("GarbageCollection", func() {
 						{
 							Key:   aws.String(corev1beta1.NodePoolLabelKey),
 							Value: aws.String(nodePool.Name),
+						},
+						{
+							Key:   aws.String(v1beta1.LabelNodeClass),
+							Value: aws.String(nodeClass.Name),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change scopes the call to list out instance to EC2NodeClass-owned instances

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.