### PR TITLE
fix: Reduce indentation for servicemonitor endpoints

### DIFF
--- a/charts/karpenter/templates/servicemonitor.yaml
+++ b/charts/karpenter/templates/servicemonitor.yaml
@@ -24,6 +24,6 @@ spec:
     - port: http-metrics
       path: /metrics
     {{- with .Values.serviceMonitor.endpointConfig }}
-      {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end -}}


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

The indentation for `serviceMonitor` endpoints was set too high, causing bad yaml to be rendered

```
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: karpenter
  namespace: foo
spec:
  namespaceSelector:
    matchNames:
      - foo
  selector:
    matchLabels:
      bar
  endpoints:
    - port: http-metrics
      path: /metrics
      - path: /metrics
        port: webhook-metrics
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.