### PR TITLE
chore: bump k8s support to 1.29 for v0.34.x

### DIFF
--- a/hack/docgen.sh
+++ b/hack/docgen.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 compatibilitymatrix() {
+    versionCount=7
     go run hack/docs/version_compatibility.go hack/docs/compatibility-karpenter.yaml "$(git describe --exact-match --tags || echo "no tag")"
-    go run hack/docs/compatibilitymetrix_gen_docs.go website/content/en/preview/upgrading/compatibility.md hack/docs/compatibility-karpenter.yaml 6
+    go run hack/docs/compatibilitymetrix_gen_docs.go website/content/en/preview/upgrading/compatibility.md hack/docs/compatibility-karpenter.yaml $versionCount
 }
 
 

--- a/hack/docgen.sh
+++ b/hack/docgen.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 compatibilitymatrix() {
+    # versionCount is the number of K8s versions to display in the compatibility matrix
     versionCount=7
     go run hack/docs/version_compatibility.go hack/docs/compatibility-karpenter.yaml "$(git describe --exact-match --tags || echo "no tag")"
     go run hack/docs/compatibilitymetrix_gen_docs.go website/content/en/preview/upgrading/compatibility.md hack/docs/compatibility-karpenter.yaml $versionCount

--- a/pkg/providers/version/version.go
+++ b/pkg/providers/version/version.go
@@ -33,7 +33,7 @@ const (
 	// If a user runs a karpenter image on a k8s version outside the min and max,
 	// One error message will be fired to notify
 	MinK8sVersion = "1.23"
-	MaxK8sVersion = "1.28"
+	MaxK8sVersion = "1.29"
 )
 
 // Provider get the APIServer version. This will be initialized at start up and allows karpenter to have an understanding of the cluster version


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Bumps the supported kubernetes version for v0.34.x to 1.29. Additionally, updates the docgen to include all supported versions (1.23 - 1.29). 
**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.