### PR TITLE
docs: Add EC2NodeClass tag to pre-defined tags

### DIFF
--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -506,6 +506,7 @@ Karpenter adds tags to all resources it creates, including EC2 Instances, EBS vo
 Name: <node-name>
 karpenter.sh/nodeclaim: <nodeclaim-name>
 karpenter.sh/nodepool: <nodepool-name>
+karpenter.k8s.aws/ec2nodeclass: <ec2nodeclass-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -508,6 +508,7 @@ Karpenter adds tags to all resources it creates, including EC2 Instances, EBS vo
 Name: <node-name>
 karpenter.sh/nodeclaim: <nodeclaim-name>
 karpenter.sh/nodepool: <nodepool-name>
+karpenter.k8s.aws/ec2nodeclass: <ec2nodeclass-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.32/concepts/nodeclasses.md
+++ b/website/content/en/v0.32/concepts/nodeclasses.md
@@ -506,6 +506,7 @@ Karpenter adds tags to all resources it creates, including EC2 Instances, EBS vo
 Name: <node-name>
 karpenter.sh/nodeclaim: <nodeclaim-name>
 karpenter.sh/nodepool: <nodepool-name>
+karpenter.k8s.aws/ec2nodeclass: <ec2nodeclass-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.33/concepts/nodeclasses.md
+++ b/website/content/en/v0.33/concepts/nodeclasses.md
@@ -506,6 +506,7 @@ Karpenter adds tags to all resources it creates, including EC2 Instances, EBS vo
 Name: <node-name>
 karpenter.sh/nodeclaim: <nodeclaim-name>
 karpenter.sh/nodepool: <nodepool-name>
+karpenter.k8s.aws/ec2nodeclass: <ec2nodeclass-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds documentation to the `karpenter.k8s.aws/ec2nodeclass` tag always being specified when Karpenter launches instances, volumes, launch templates, ENIs, etc.

**How was this change tested?**

Validated with resources in the EC2 console

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.