### PR TITLE
feat(chart): Added cosign signature

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -135,6 +135,15 @@ publishHelmChart() {
     helm push "${HELM_CHART_FILE_NAME}" "oci://${RELEASE_REPO}"
     rm "${HELM_CHART_FILE_NAME}"
     cd ..
+
+    cosignHelmChart "${RELEASE_REPO}" "${HELM_CHART_VERSION}"
+}
+
+cosignHelmChart() {
+    RELEASE_REPO=$1
+    HELM_CHART_VERSION=$2
+    digest="$(crane digest "${RELEASE_REPO}:${HELM_CHART_VERSION}")"
+    cosign sign --yes "${RELEASE_REPO}:${HELM_CHART_VERSION}@${digest}"
 }
 
 createNewWebsiteDirectory() {

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -23,6 +23,7 @@ tools() {
     go install github.com/onsi/ginkgo/v2/ginkgo@latest
     go install github.com/rhysd/actionlint/cmd/actionlint@latest
     go install github.com/mattn/goveralls@latest
+    go install github.com/google/go-containerregistry/cmd/crane@latest
 
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
         echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR signs the released Helm charts with `cosign`. I've not updated the docs as it's probably best to do a release with this code and then check it's functioning correctly.

```bash
cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity-regexp='https://github\.com/aws/karpenter-provider-aws/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository=aws/karpenter-provider-aws --certificate-github-workflow-name=Release "public.ecr.aws/karpenter/karpenter:${KARPENTER_VERSION}"
```

This PR has been split out of https://github.com/aws/karpenter-provider-aws/pull/5561.

**How was this change tested?**
Ad-hoc.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.