### PR TITLE
chore: Adding `-y` to cosign prompt to allow signing images

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -114,7 +114,7 @@ buildDate(){
 }
 
 cosignImages() {
-    COSIGN_EXPERIMENTAL=1 cosign sign \
+    cosign sign --yes \
         -a GIT_HASH="$(git rev-parse HEAD)" \
         -a GIT_VERSION="${RELEASE_VERSION}" \
         -a BUILD_DATE="$(buildDate)" \


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Adding `-y` to cosign our karpenter images

**How was this change tested?**
- N/A 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.