### PR TITLE
fix: Fix retrieving NodePool when rolling back to v0.31.x

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -16,7 +16,7 @@ tools() {
     go install github.com/mikefarah/yq/v4@latest
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
     go install github.com/sigstore/cosign/cmd/cosign@latest
     go install -tags extended github.com/gohugoio/hugo@v0.110.0
     go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -325,15 +325,8 @@ func (c *CloudProvider) resolveInstanceTypeFromInstance(ctx context.Context, ins
 
 func (c *CloudProvider) resolveNodePoolFromInstance(ctx context.Context, instance *instance.Instance) (*corev1beta1.NodePool, error) {
 	provisionerName := instance.Tags[v1alpha5.ProvisionerNameLabelKey]
-	nodePoolName := instance.Tags[corev1beta1.NodePoolLabelKey]
 
 	switch {
-	case nodePoolName != "":
-		nodePool := &corev1beta1.NodePool{}
-		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
-			return nil, err
-		}
-		return nodePool, nil
 	case provisionerName != "":
 		provisioner := &v1alpha5.Provisioner{}
 		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: provisionerName}, provisioner); err != nil {


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5613

**Description**

This fixes an issue where a user has deployed a NodeClaim to their cluster with a Node and a NodeClaim that has entered a terminating state. This ensures that we don't try to retrieve the parent NodePool information for the Node when we are getting the node from the CloudProvider.

**How was this change tested?**

`make apply` and validate rollback scenario

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.