### PR TITLE
ci: Allow ci to run

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   codegen:
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   analyze:
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deflake.yaml
+++ b/.github/workflows/deflake.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   deflake:
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   docgen-ci:
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-conformance-trigger.yaml
+++ b/.github/workflows/e2e-conformance-trigger.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   resolve:
-    if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'aws/karpenter-provider-aws' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/resolve-args.yaml
     with:
       allowed_comment: "conformance"

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   resolve:
-    if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'aws/karpenter-provider-aws' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/resolve-args.yaml
     with:
       allowed_comment: "snapshot"

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   resolve:
-    if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'aws/karpenter-provider-aws' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/resolve-args.yaml
     with:
       allowed_comment: "scale"

--- a/.github/workflows/publish-test-tools.yaml
+++ b/.github/workflows/publish-test-tools.yaml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 jobs:
   publish-tools:
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 jobs:
   release:
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -6,7 +6,7 @@ permissions:
   id-token: write
 jobs:
   release:
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       discussions: write
       pull-requests: write
-    if: github.repository == 'aws/karpenter'
+    if: github.repository == 'aws/karpenter-provider-aws'
     name: Stale issue bot
     steps:
       - uses: actions/stale@v8.0.0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Allow CI to run with the repo name change. CI was currently gated by the name of the repository (`aws/karpenter`) which changed between the last couple versions of Karpenter.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.