### PR TITLE
chore: Add additional restricted tag keys

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -425,12 +425,14 @@ spec:
                   rule: self.all(k, k != '')
                 - message: tag contains a restricted tag matching kubernetes.io/cluster/
                   rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
-                - message: tag contains a restricted tag matching karpenter.sh/provisioner-name
-                  rule: self.all(k, k != 'karpenter.sh/provisioner-name')
                 - message: tag contains a restricted tag matching karpenter.sh/nodepool
                   rule: self.all(k, k != 'karpenter.sh/nodepool')
                 - message: tag contains a restricted tag matching karpenter.sh/managed-by
                   rule: self.all(k, k !='karpenter.sh/managed-by')
+                - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                  rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                  rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
               userData:
                 description: |-
                   UserData to be applied to the provisioned nodes.

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -75,9 +75,10 @@ type EC2NodeClassSpec struct {
 	// Tags to be applied on ec2 resources like instances and launch templates.
 	// +kubebuilder:validation:XValidation:message="empty tag keys aren't supported",rule="self.all(k, k != '')"
 	// +kubebuilder:validation:XValidation:message="tag contains a restricted tag matching kubernetes.io/cluster/",rule="self.all(k, !k.startsWith('kubernetes.io/cluster') )"
-	// +kubebuilder:validation:XValidation:message="tag contains a restricted tag matching karpenter.sh/provisioner-name",rule="self.all(k, k != 'karpenter.sh/provisioner-name')"
 	// +kubebuilder:validation:XValidation:message="tag contains a restricted tag matching karpenter.sh/nodepool",rule="self.all(k, k != 'karpenter.sh/nodepool')"
 	// +kubebuilder:validation:XValidation:message="tag contains a restricted tag matching karpenter.sh/managed-by",rule="self.all(k, k !='karpenter.sh/managed-by')"
+	// +kubebuilder:validation:XValidation:message="tag contains a restricted tag matching karpenter.sh/nodeclaim",rule="self.all(k, k !='karpenter.sh/nodeclaim')"
+	// +kubebuilder:validation:XValidation:message="tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass",rule="self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')"
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
 	// BlockDeviceMappings to be applied to provisioned nodes.

--- a/pkg/apis/v1beta1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation_cel_test.go
@@ -83,6 +83,14 @@ var _ = Describe("CEL/Validation", func() {
 				corev1beta1.ManagedByAnnotationKey: "test",
 			}
 			Expect(env.Client.Create(ctx, nc)).To(Not(Succeed()))
+			nc.Spec.Tags = map[string]string{
+				v1beta1.LabelNodeClass: "test",
+			}
+			Expect(env.Client.Create(ctx, nc)).To(Not(Succeed()))
+			nc.Spec.Tags = map[string]string{
+				"karpenter.sh/nodeclaim": "test",
+			}
+			Expect(env.Client.Create(ctx, nc)).To(Not(Succeed()))
 		})
 	})
 	Context("SubnetSelectorTerms", func() {

--- a/pkg/apis/v1beta1/ec2nodeclass_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation_webhook_test.go
@@ -95,6 +95,14 @@ var _ = Describe("Webhook/Validation", func() {
 				"karpenter.sh/managed-by": "test",
 			}
 			Expect(nc.Validate(ctx)).To(Not(Succeed()))
+			nc.Spec.Tags = map[string]string{
+				v1beta1.LabelNodeClass: "test",
+			}
+			Expect(nc.Validate(ctx)).To(Not(Succeed()))
+			nc.Spec.Tags = map[string]string{
+				"karpenter.sh/nodeclaim": "test",
+			}
+			Expect(nc.Validate(ctx)).To(Not(Succeed()))
 		})
 	})
 	Context("SubnetSelectorTerms", func() {

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -70,6 +70,8 @@ var (
 		regexp.MustCompile(`^kubernetes\.io/cluster/[0-9A-Za-z][A-Za-z0-9\-_]*$`),
 		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(v1beta1.NodePoolLabelKey))),
 		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(v1beta1.ManagedByAnnotationKey))),
+		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(LabelNodeClass))),
+		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(TagNodeClaim))),
 	}
 	AMIFamilyBottlerocket                      = "Bottlerocket"
 	AMIFamilyAL2                               = "AL2"
@@ -111,4 +113,7 @@ var (
 	LabelInstanceAcceleratorCount             = Group + "/instance-accelerator-count"
 	AnnotationEC2NodeClassHash                = Group + "/ec2nodeclass-hash"
 	AnnotationInstanceTagged                  = Group + "/tagged"
+
+	TagNodeClaim = v1beta1.Group + "/nodeclaim"
+	TagName      = "Name"
 )

--- a/pkg/controllers/nodeclaim/tagging/controller.go
+++ b/pkg/controllers/nodeclaim/tagging/controller.go
@@ -38,11 +38,6 @@ import (
 	corecontroller "sigs.k8s.io/karpenter/pkg/operator/controller"
 )
 
-const (
-	TagNodeClaim = corev1beta1.Group + "/nodeclaim"
-	TagName      = "Name"
-)
-
 type Controller struct {
 	kubeClient       client.Client
 	instanceProvider *instance.Provider
@@ -96,8 +91,8 @@ func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontrolle
 
 func (c *Controller) tagInstance(ctx context.Context, nc *corev1beta1.NodeClaim, id string) error {
 	tags := map[string]string{
-		TagName:      nc.Status.NodeName,
-		TagNodeClaim: nc.Name,
+		v1beta1.TagName:      nc.Status.NodeName,
+		v1beta1.TagNodeClaim: nc.Name,
 	}
 
 	// Remove tags which have been already populated

--- a/pkg/controllers/nodeclaim/tagging/suite_test.go
+++ b/pkg/controllers/nodeclaim/tagging/suite_test.go
@@ -120,7 +120,7 @@ var _ = Describe("TaggingController", func() {
 		ExpectReconcileSucceeded(ctx, taggingController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(nodeClaim.Annotations).To(Not(HaveKey(v1beta1.AnnotationInstanceTagged)))
 		Expect(lo.ContainsBy(ec2Instance.Tags, func(tag *ec2.Tag) bool {
-			return *tag.Key == tagging.TagName
+			return *tag.Key == v1beta1.TagName
 		})).To(BeFalse())
 	})
 
@@ -136,7 +136,7 @@ var _ = Describe("TaggingController", func() {
 		ExpectReconcileSucceeded(ctx, taggingController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(nodeClaim.Annotations).To(Not(HaveKey(v1beta1.AnnotationInstanceTagged)))
 		Expect(lo.ContainsBy(ec2Instance.Tags, func(tag *ec2.Tag) bool {
-			return *tag.Key == tagging.TagName
+			return *tag.Key == v1beta1.TagName
 		})).To(BeFalse())
 	})
 
@@ -183,7 +183,7 @@ var _ = Describe("TaggingController", func() {
 		ExpectReconcileSucceeded(ctx, taggingController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(nodeClaim.Annotations).To(Not(HaveKey(v1beta1.AnnotationInstanceTagged)))
 		Expect(lo.ContainsBy(ec2Instance.Tags, func(tag *ec2.Tag) bool {
-			return *tag.Key == tagging.TagName
+			return *tag.Key == v1beta1.TagName
 		})).To(BeFalse())
 	})
 
@@ -211,8 +211,8 @@ var _ = Describe("TaggingController", func() {
 			Expect(nodeClaim.Annotations).To(HaveKey(v1beta1.AnnotationInstanceTagged))
 
 			expectedTags := map[string]string{
-				tagging.TagName:      nodeClaim.Status.NodeName,
-				tagging.TagNodeClaim: nodeClaim.Name,
+				v1beta1.TagName:      nodeClaim.Status.NodeName,
+				v1beta1.TagNodeClaim: nodeClaim.Name,
 			}
 			instanceTags := instance.NewInstance(ec2Instance).Tags
 			for tag, value := range expectedTags {
@@ -222,9 +222,9 @@ var _ = Describe("TaggingController", func() {
 				Expect(instanceTags).To(HaveKeyWithValue(tag, value))
 			}
 		},
-		Entry("with only karpenter.k8s.aws/nodeclaim tag", tagging.TagName),
-		Entry("with only Name tag", tagging.TagNodeClaim),
+		Entry("with only karpenter.k8s.aws/nodeclaim tag", v1beta1.TagName),
+		Entry("with only Name tag", v1beta1.TagNodeClaim),
 		Entry("with both Name and karpenter.k8s.aws/nodeclaim tags"),
-		Entry("with nothing to tag", tagging.TagName, tagging.TagNodeClaim),
+		Entry("with nothing to tag", v1beta1.TagName, v1beta1.TagNodeClaim),
 	)
 })

--- a/test/suites/integration/validation_test.go
+++ b/test/suites/integration/validation_test.go
@@ -151,6 +151,12 @@ var _ = Describe("Validation", func() {
 
 			nodeClass.Spec.Tags = map[string]string{fmt.Sprintf("kubernetes.io/cluster/%s", env.ClusterName): "owned"}
 			Expect(env.Client.Create(env.Context, nodeClass)).ToNot(Succeed())
+
+			nodeClass.Spec.Tags = map[string]string{"karpenter.sh/nodeclaim": "custom-value"}
+			Expect(env.Client.Create(env.Context, nodeClass)).ToNot(Succeed())
+
+			nodeClass.Spec.Tags = map[string]string{"karpenter.k8s.aws/ec2nodeclass": "custom-value"}
+			Expect(env.Client.Create(env.Context, nodeClass)).ToNot(Succeed())
 		})
 		It("should fail when securityGroupSelectorTerms has id and other filters", func() {
 			nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds additional restricted tag keys (`karpenter.k8s.aws/ec2nodeclass` and `karpenter.sh/nodeclaim`) for values that are fully managed by Karpenter

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.