### PR TITLE
deps: bump go version to 1.22

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -8,6 +8,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      id: setup-go
       with:
         go-version-file: go.mod
         check-latest: true
@@ -21,7 +22,9 @@ runs:
         path: |
           /usr/local/kubebuilder/bin
           ~/go/bin
-        key: ${{ runner.os }}-${{ inputs.k8sVersion }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
+        # Added go version to compensate for this issue with govulncheck: https://github.com/golang/go/issues/65590. Could re-evaluate if this is necessary once the
+        # upstream go issue is corrected and if this is causing too many cache misses.
+        key: ${{ runner.os }}-${{ inputs.k8sVersion }}-${{ steps.setup-go.outputs.go-version }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       shell: bash
       env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/test/hack/resource/go.mod
+++ b/test/hack/resource/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws/test/hack/resource
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.22.1

--- a/test/hack/soak/go.mod
+++ b/test/hack/soak/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter/test/hack/soak
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.47.9

--- a/tools/allocatable-diff/go.mod
+++ b/tools/allocatable-diff/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws/tools/allocatable-diff
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/karpenter-provider-aws v0.33.1-0.20231206223517-f73ccfa65419

--- a/tools/kompat/go.mod
+++ b/tools/kompat/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws/tools/kompat
 
-go 1.20
+go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/website/go.mod
+++ b/website/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws/website
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/docsy v0.6.0 // indirect


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Bumps go to the latest release: [release notes](https://tip.golang.org/doc/go1.22)

Justification for pinning to the patch version: https://github.com/golang/go/issues/62278

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.