### PR TITLE
Fix for InvalidLaunchTemplateId.NotFound error

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -25,14 +25,18 @@ import (
 )
 
 const (
-	launchTemplateNotFoundCode = "InvalidLaunchTemplateName.NotFoundException"
+	launchTemplateNameNotFoundCode = "InvalidLaunchTemplateName.NotFoundException"
+
+	//The specified launch template ID does not exist
+	launchTemplateIDNotFoundCode = "InvalidLaunchTemplateId.NotFound"
 )
 
 var (
 	// This is not an exhaustive list, add to it as needed
 	notFoundErrorCodes = sets.New[string](
 		"InvalidInstanceID.NotFound",
-		launchTemplateNotFoundCode,
+		launchTemplateNameNotFoundCode,
+		launchTemplateIDNotFoundCode,
 		sqs.ErrCodeQueueDoesNotExist,
 		iam.ErrCodeNoSuchEntityException,
 	)
@@ -102,7 +106,7 @@ func IsLaunchTemplateNotFound(err error) bool {
 	}
 	var awsError awserr.Error
 	if errors.As(err, &awsError) {
-		return awsError.Code() == launchTemplateNotFoundCode
+		return awsError.Code() == launchTemplateNameNotFoundCode
 	}
 	return false
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -26,9 +26,6 @@ import (
 
 const (
 	launchTemplateNameNotFoundCode = "InvalidLaunchTemplateName.NotFoundException"
-
-	//The specified launch template ID does not exist
-	launchTemplateIDNotFoundCode = "InvalidLaunchTemplateId.NotFound"
 )
 
 var (
@@ -36,7 +33,7 @@ var (
 	notFoundErrorCodes = sets.New[string](
 		"InvalidInstanceID.NotFound",
 		launchTemplateNameNotFoundCode,
-		launchTemplateIDNotFoundCode,
+		"InvalidLaunchTemplateId.NotFound",
 		sqs.ErrCodeQueueDoesNotExist,
 		iam.ErrCodeNoSuchEntityException,
 	)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
If we delete EC2NodeClass and there is a cache eviction later, we see errors like these -
`{"level":"ERROR","time":"2024-01-25T05:33:52.210Z","logger":"controller","message":"failed to delete launch template, InvalidLaunchTemplateId.NotFound: The specified launch template, with template ID lt-019c5be5798f24ca7, does not exist.\n\tstatus code: 400, request id: 86bff5c8-9bc6-485a-a5a8-1619d6c81283","commit":"7cdc79a-dirty","launch-template":"karpenter.k8s.aws/2686062690276844038"}`

The fix that was added earlier to handle this scenario was checking if `InvalidLaunchTemplateName.NotFoundException` has occurred when it should have been checking for `InvalidLaunchTemplateId.NotFound`.

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.