### PR TITLE
chore: respect AssociatePublicIPAddress with EFA

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -291,6 +291,10 @@ func (p *Provider) generateNetworkInterfaces(options *amifamily.LaunchTemplate) 
 				DeviceIndex:   lo.ToPtr(lo.Ternary[int64](i == 0, 0, 1)),
 				InterfaceType: lo.ToPtr(ec2.NetworkInterfaceTypeEfa),
 				Groups:        lo.Map(options.SecurityGroups, func(s v1beta1.SecurityGroup, _ int) *string { return aws.String(s.ID) }),
+				// Instances launched with multiple pre-configured network interfaces cannot set AssociatePublicIPAddress to true. This is an EC2 limitation. However, this does not apply for instances
+				// with a single EFA network interface, and we should support those use cases. Launch failures with multiple enis should be considered user misconfiguration.
+				// ref: https://docs.aws.amazon.com/cli/latest/reference/ec2/request-spot-fleet.html
+				AssociatePublicIpAddress: options.AssociatePublicIPAddress,
 			}
 		})
 	}

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -293,7 +293,6 @@ func (p *Provider) generateNetworkInterfaces(options *amifamily.LaunchTemplate) 
 				Groups:        lo.Map(options.SecurityGroups, func(s v1beta1.SecurityGroup, _ int) *string { return aws.String(s.ID) }),
 				// Instances launched with multiple pre-configured network interfaces cannot set AssociatePublicIPAddress to true. This is an EC2 limitation. However, this does not apply for instances
 				// with a single EFA network interface, and we should support those use cases. Launch failures with multiple enis should be considered user misconfiguration.
-				// ref: https://docs.aws.amazon.com/cli/latest/reference/ec2/request-spot-fleet.html
 				AssociatePublicIpAddress: options.AssociatePublicIPAddress,
 			}
 		})

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1560,7 +1560,7 @@ var _ = Describe("LaunchTemplates", func() {
 				Expect(*input.LaunchTemplateData.ImageId).To(ContainSubstring("test-ami"))
 			})
 		})
-		Context("Subnet-based Launch Template Configration", func() {
+		Context("Public IP Association", func() {
 			It("should explicitly set 'AssociatePublicIPAddress' to false in the Launch Template", func() {
 				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
 					{Tags: map[string]string{"Name": "test-subnet-1"}},
@@ -1573,52 +1573,10 @@ var _ = Describe("LaunchTemplates", func() {
 				input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
 				Expect(*input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeFalse())
 			})
-
-			It("should overwrite 'AssociatePublicIPAddress' to true when specified by user in the EC2NodeClass", func() {
-				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-					{Tags: map[string]string{"Name": "test-subnet-1"}},
-					{Tags: map[string]string{"Name": "test-subnet-3"}},
-				}
-				nodeClass.Spec.AssociatePublicIPAddress = lo.ToPtr(true)
-
-				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-				pod := coretest.UnschedulablePod()
-				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-				ExpectScheduled(ctx, env.Client, pod)
-				input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect(*input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeTrue())
-			})
-
-			It("should set 'AssociatePublicIPAddress' to false when specified by user in the EC2NodeClass", func() {
-				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-					{Tags: map[string]string{"Name": "test-subnet-1"}},
-					{Tags: map[string]string{"Name": "test-subnet-3"}},
-				}
-				nodeClass.Spec.AssociatePublicIPAddress = lo.ToPtr(false)
-
-				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-				pod := coretest.UnschedulablePod()
-				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-				ExpectScheduled(ctx, env.Client, pod)
-				input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect(*input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeFalse())
-			})
-
-			It("should set 'AssociatePublicIPAddress' to false when not specified by the user in the EC2NodeClass using private subnet", func() {
-				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-					{Tags: map[string]string{"Name": "test-subnet-1"}},
-					{Tags: map[string]string{"Name": "test-subnet-3"}},
-				}
-
-				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-				pod := coretest.UnschedulablePod()
-				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-				ExpectScheduled(ctx, env.Client, pod)
-				input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect(*input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeFalse())
-			})
 			It("should not explicitly set 'AssociatePublicIPAddress' when the subnets are configured to assign public IPv4 addresses", func() {
-				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{{Tags: map[string]string{"Name": "test-subnet-2"}}}
+				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+					{Tags: map[string]string{"Name": "test-subnet-2"}},
+				}
 				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 				pod := coretest.UnschedulablePod()
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
@@ -1626,6 +1584,27 @@ var _ = Describe("LaunchTemplates", func() {
 				input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
 				Expect(len(input.LaunchTemplateData.NetworkInterfaces)).To(BeNumerically("==", 0))
 			})
+			DescribeTable(
+				"should set 'AssociatePublicIPAddress' based on EC2NodeClass",
+				func(setValue, expectedValue, isEFA bool) {
+					nodeClass.Spec.AssociatePublicIPAddress = lo.ToPtr(setValue)
+					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+					pod := coretest.UnschedulablePod(lo.Ternary(isEFA, coretest.PodOptions{
+						ResourceRequirements: v1.ResourceRequirements{
+							Requests: v1.ResourceList{v1beta1.ResourceEFA: resource.MustParse("2")},
+							Limits:   v1.ResourceList{v1beta1.ResourceEFA: resource.MustParse("2")},
+						},
+					}, coretest.PodOptions{}))
+					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+					ExpectScheduled(ctx, env.Client, pod)
+					input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
+					Expect(*input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress).To(Equal(expectedValue))
+				},
+				Entry("AssociatePublicIPAddress is true", true, true, false),
+				Entry("AssociatePublicIPAddress is false", false, false, false),
+				Entry("AssociatePublicIPAddress is true (EFA)", true, true, true),
+				Entry("AssociatePublicIPAddress is false (EFA)", false, false, true),
+			)
 		})
 		Context("Kubelet Args", func() {
 			It("should specify the --dns-cluster-ip flag when clusterDNSIP is set", func() {

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -35,7 +35,7 @@ spec:
   # Each term in the array of subnetSelectorTerms is ORed together
   # Within a single term, all conditions are ANDed
   subnetSelectorTerms:
-    # Select on any subnet that has the "karpenter.sh/discovery: ${CLUSTER_NAME}" 
+    # Select on any subnet that has the "karpenter.sh/discovery: ${CLUSTER_NAME}"
     # AND the "environment: test" tag OR any subnet with ID "subnet-09fa4a0a8f233a921"
     - tags:
         karpenter.sh/discovery: "${CLUSTER_NAME}"
@@ -46,8 +46,8 @@ spec:
   # Each term in the array of securityGroupSelectorTerms is ORed together
   # Within a single term, all conditions are ANDed
   securityGroupSelectorTerms:
-    # Select on any security group that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag 
-    # AND the "environment: test" tag OR any security group with the "my-security-group" name 
+    # Select on any security group that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag
+    # AND the "environment: test" tag OR any security group with the "my-security-group" name
     # OR any security group with ID "sg-063d7acfb4b06c82c"
     - tags:
         karpenter.sh/discovery: "${CLUSTER_NAME}"
@@ -70,15 +70,15 @@ spec:
   # Each term in the array of amiSelectorTerms is ORed together
   # Within a single term, all conditions are ANDed
   amiSelectorTerms:
-    # Select on any AMI that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag 
-    # AND the "environment: test" tag OR any AMI with the "my-ami" name 
+    # Select on any AMI that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag
+    # AND the "environment: test" tag OR any AMI with the "my-ami" name
     # OR any AMI with ID "ami-123"
     - tags:
         karpenter.sh/discovery: "${CLUSTER_NAME}"
         environment: test
     - name: my-ami
     - id: ami-123
-      
+
   # Optional, use instance-store volumes for node ephemeral-storage
   instanceStorePolicy: RAID0
 
@@ -252,7 +252,7 @@ This selection logic is modeled as terms, where each term contains multiple cond
 
 ```yaml
 subnetSelectorTerms:
-  # Select on any subnet that has the "karpenter.sh/discovery: ${CLUSTER_NAME}" 
+  # Select on any subnet that has the "karpenter.sh/discovery: ${CLUSTER_NAME}"
   # AND the "environment: test" tag OR any subnet with ID "subnet-09fa4a0a8f233a921"
   - tags:
       karpenter.sh/discovery: "${CLUSTER_NAME}"
@@ -320,8 +320,8 @@ This selection logic is modeled as terms, where each term contains multiple cond
 
 ```yaml
 securityGroupSelectorTerms:
-  # Select on any security group that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag 
-  # AND the "environment: test" tag OR any security group with the "my-security-group" name 
+  # Select on any security group that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag
+  # AND the "environment: test" tag OR any security group with the "my-security-group" name
   # OR any security group with ID "sg-063d7acfb4b06c82c"
   - tags:
       karpenter.sh/discovery: "${CLUSTER_NAME}"
@@ -407,8 +407,8 @@ This selection logic is modeled as terms, where each term contains multiple cond
 
 ```yaml
 amiSelectorTerms:
-  # Select on any AMI that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag 
-  # AND the "environment: test" tag OR any AMI with the "my-ami" name 
+  # Select on any AMI that has both the "karpenter.sh/discovery: ${CLUSTER_NAME}" tag
+  # AND the "environment: test" tag OR any AMI with the "my-ami" name
   # OR any AMI with ID "ami-123"
   - tags:
       karpenter.sh/discovery: "${CLUSTER_NAME}"
@@ -633,25 +633,25 @@ The `instanceStorePolicy` field controls how [instance-store](https://docs.aws.a
 
 If you intend to use these volumes for faster node ephemeral-storage, set `instanceStorePolicy` to `RAID0`:
 
-```yaml	
-spec:	
+```yaml
+spec:
   instanceStorePolicy: RAID0
 ```
 
-This will set the allocatable ephemeral-storage of each node to the total size of the instance-store volume(s).	
+This will set the allocatable ephemeral-storage of each node to the total size of the instance-store volume(s).
 
-The disks must be formatted & mounted in a RAID0 and be the underlying filesystem for the Kubelet & Containerd. Instructions for each AMI family are listed below:	
+The disks must be formatted & mounted in a RAID0 and be the underlying filesystem for the Kubelet & Containerd. Instructions for each AMI family are listed below:
 
-#### AL2	
+#### AL2
 
-On AL2, Karpenter automatically configures the disks through an additional boostrap argument (`--local-disks raid0`). The device name is `/dev/md/0` and its mount point is `/mnt/k8s-disks/0`. You should ensure any additional disk setup does not interfere with these.	
+On AL2, Karpenter automatically configures the disks through an additional boostrap argument (`--local-disks raid0`). The device name is `/dev/md/0` and its mount point is `/mnt/k8s-disks/0`. You should ensure any additional disk setup does not interfere with these.
 
-#### Others	
+#### Others
 
-For all other AMI families, you must configure the disks yourself. Check out the [`setup-local-disks`](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bin/setup-local-disks) script in [amazon-eks-ami](https://github.com/awslabs/amazon-eks-ami) to see how this is done for AL2.	
+For all other AMI families, you must configure the disks yourself. Check out the [`setup-local-disks`](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bin/setup-local-disks) script in [amazon-eks-ami](https://github.com/awslabs/amazon-eks-ami) to see how this is done for AL2.
 
-{{% alert title="Tip" color="secondary" %}}	
-Since the Kubelet & Containerd will be using the instance-store filesystem, you may consider using a more minimal root volume size.	
+{{% alert title="Tip" color="secondary" %}}
+Since the Kubelet & Containerd will be using the instance-store filesystem, you may consider using a more minimal root volume size.
 {{% /alert %}}
 
 ## spec.userData
@@ -872,9 +872,8 @@ spec:
 A boolean field that controls whether instances created by Karpenter for this EC2NodeClass will have an associated public IP address. This overrides the `MapPublicIpOnLaunch` setting applied to the subnet the node is launched in. If this field is not set, the `MapPublicIpOnLaunch` field will be respected.
 
 {{% alert title="Note" color="warning" %}}
-If a `NodeClaim` requests `vpc.amazonaws.com/efa` resources, the `associatePublicIPAddress` field is ignored.
-A public IP address may only be associated with a node at launch if a single network interface is configured.
-This is inherently incompatible with instances configured for EFA workloads since Karpenter will configure an EFA for each network card on the instance.
+If a `NodeClaim` requests `vpc.amazonaws.com/efa` resources, `spec.associatePublicIPAddress` is respected. However, if this `NodeClaim` requests **multiple** EFA resources and the value for `spec.associatePublicIPAddress` is true, the instance will fail to launch. This is due to an EC2 restriction which
+requires that the field is only set to true when configuring an instance with a single ENI at launch. When using this field, it is advised that users segregate their EFA workload to use a separate `NodePool` / `EC2NodeClass` pair.
 {{% /alert %}}
 
 ## status.subnets


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates network interface generation to respect `AssociatePublicIPAddress` for EFA interfaces. This originally wasn't rejected due to a potential footgun: setting this value to true when launching instances with multiple EFAs will result in launch failure. The following error will be reported:
```
{"level":"ERROR","time":"2024-02-15T05:41:31.594Z","logger":"controller","message":"Reconciler error","commit":"95f42f1-dirty","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"efa-tt6zp"},"namespace":"","name":"efa-tt6zp","reconcileID":"45b919ce-8b3a-480f-b0cd-a10eec71ff91","error":"launching nodeclaim, creating instance, with fleet error(s), InvalidParameterCombination: The associatePublicIPAddress parameter cannot be specified when launching with multiple network interfaces.; UnfulfillableCapacity: Unable to fulfill capacity due to your request configuration. Please adjust your request and try again."}
```
It isn't possible to eliminate this footgun through validation of the EC2NodeClass becuase EFA requests are drive through pod resource requests, not through any field on the EC2NodeClass. 

This left us with a few options:
1) Always respect `AssociatePublicIPAddress`, even when it results in instance launch failure. This is considered user misconfiguration.
2) Only respect `AssociatePublicIPAddress` when set to false. This eliminates the footgun while still enabling the most useful application (that we've heard requested), disabling public IPs in public subnets.
3) Don't respect `AssociatePublicIPAddress`, always set to nil.

After some discussion with @jonathan-innis offline, we decided option 1 was the best option. The following reasons were considered:
- Principle of least surprise, don't silently drop user configured settings
- Enables edge case of enabling on single interface EFA instances
- Error message from EC2 is plenty descriptive

**How was this change tested?**
`make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.