### PR TITLE
ci: Pin to the latest patch version of 1.25.x in toolchain

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -35,6 +35,15 @@ kubebuilder() {
     arch=$(go env GOARCH)
     ln -sf $(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")/* ${KUBEBUILDER_ASSETS}
     find $KUBEBUILDER_ASSETS
+
+    # Install latest binaries for 1.25.x (contains CEL fix)
+    if [[ "${K8S_VERSION}" = "1.25.x" ]] && [[ "$OSTYPE" == "linux"* ]]; then
+        for binary in 'kube-apiserver' 'kubectl'; do
+            rm $KUBEBUILDER_ASSETS/$binary
+            wget -P $KUBEBUILDER_ASSETS dl.k8s.io/v1.25.16/bin/linux/${arch}/${binary}
+            chmod +x $KUBEBUILDER_ASSETS/$binary
+        done
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This pins to the latest version of the `v1.25.x` version of etcd and the apiserver to fix some CEL problems that we were seeing in the 1.25 version and not in newer versions. This pins in the same way that `kubernetes-sigs/karpenter` pins

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.