### PR TITLE
ci: Fix `helm diff` and `crane digest` command

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -96,5 +96,5 @@ runs:
     run: |
       helm diff upgrade --namespace kube-system \
         karpenter oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/karpenter/snapshot/karpenter \
-        --version v0-$(git rev-parse HEAD) \
+        --version 0-$(git rev-parse HEAD) \
         --reuse-values --three-way-merge --detailed-exitcode

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -138,7 +138,7 @@ publishHelmChart() {
     rm "${HELM_CHART_FILE_NAME}"
     cd ..
 
-    cosignHelmChart "${RELEASE_REPO}" "${HELM_CHART_VERSION}"
+    cosignHelmChart "${RELEASE_REPO}/${CHART_NAME}" "${HELM_CHART_VERSION}"
 }
 
 cosignHelmChart() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fix `helm diff` command in our E2E test jobs
Fix the call to `crane` to make sure that it is pulling the digest from the correct repo

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.