### PR TITLE
test: Ignore CFN cleanup when flag is set

### DIFF
--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -39,10 +39,11 @@ inputs:
     default: 'false'
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
-    required: false
   enable_local_zones:
     description: "Whether to include local zones in the VPC created for the cluster."
-    required: false
+    default: 'false'
+  cleanup:
+    description: "Whether to cleanup resources on failure"
     default: 'false'
 runs:
   using: "composite"
@@ -86,6 +87,7 @@ runs:
       PRIVATE_CLUSTER: ${{ inputs.private_cluster }}
       GIT_REF:  ${{ inputs.git_ref }}
       ENABLE_LOCAL_ZONES: ${{ inputs.enable_local_zones }}
+      CLEANUP: ${{ inputs.cleanup }}
     run: |
       if [[ "$GIT_REF" == '' ]]; then
         GIT_REF=$(git rev-parse HEAD)
@@ -195,7 +197,12 @@ runs:
         yq -i '.managedNodeGroups[0].privateNetworking=true' clusterconfig.yaml
       fi
 
-      eksctl ${cmd} cluster -f clusterconfig.yaml
+      # Disable rollback of the CloudFormation on Create if we aren't cleaning up the run
+      if [[ $CLEANUP == 'false' ]] && [[ $cmd == 'create' ]]; then
+        eksctl ${cmd} cluster -f clusterconfig.yaml --cfn-disable-rollback
+      else
+        eksctl ${cmd} cluster -f clusterconfig.yaml
+      fi
 
       # Add the SQS and SSM VPC endpoints if we are creating a private cluster
       # We need to grab all of the VPC details for the cluster in order to add the endpoint

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -137,6 +137,7 @@ jobs:
           prometheus_workspace_id: ${{ vars.WORKSPACE_ID }}
           prometheus_region: ${{ vars.PROMETHEUS_REGION }}
           enable_local_zones: ${{ inputs.suite == 'LocalZone' }}
+          cleanup: ${{ inputs.cleanup }}
       - name: run the ${{ inputs.suite }} test suite
         env:
           SUITE: ${{ inputs.suite }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates our testing CI so that disabling cleanup also disables CFN rollback

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.