### PR TITLE
docs: Template prometheus values based on Karpenter namespace

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -13,7 +13,7 @@ extraScrapeConfigs: |
       - role: endpoints
         namespaces:
           names:
-          - kube-system
+          - $KARPENTER_NAMESPACE
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_endpoints_name

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -4,7 +4,7 @@ helm repo update
 
 kubectl create namespace monitoring
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | tee prometheus-values.yaml
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/grafana-values.yaml | tee grafana-values.yaml

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,7 +3,6 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
-export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,6 +3,7 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
+export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -13,7 +13,7 @@ extraScrapeConfigs: |
       - role: endpoints
         namespaces:
           names:
-          - kube-system
+          - $KARPENTER_NAMESPACE
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_endpoints_name

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -4,7 +4,7 @@ helm repo update
 
 kubectl create namespace monitoring
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | tee prometheus-values.yaml
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/grafana-values.yaml | tee grafana-values.yaml

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,6 +3,7 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
+export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,7 +3,6 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
-export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -13,7 +13,7 @@ extraScrapeConfigs: |
       - role: endpoints
         namespaces:
           names:
-          - karpenter
+          - $KARPENTER_NAMESPACE
       relabel_configs:
       - source_labels: [__meta_kubernetes_endpoint_port_name]
         regex: http-metrics

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,8 +3,9 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
+export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | tee prometheus-values.yaml
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/grafana-values.yaml | tee grafana-values.yaml

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,7 +3,6 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
-export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml

--- a/website/content/en/v0.33/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/v0.33/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -13,7 +13,7 @@ extraScrapeConfigs: |
       - role: endpoints
         namespaces:
           names:
-          - kube-system
+          - $KARPENTER_NAMESPACE
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_endpoints_name

--- a/website/content/en/v0.33/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.33/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,8 +3,9 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
+export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | tee prometheus-values.yaml
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/grafana-values.yaml | tee grafana-values.yaml

--- a/website/content/en/v0.33/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.33/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -3,7 +3,6 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 kubectl create namespace monitoring
-export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml

--- a/website/content/en/v0.34/getting-started/getting-started-with-karpenter/prometheus-values.yaml
+++ b/website/content/en/v0.34/getting-started/getting-started-with-karpenter/prometheus-values.yaml
@@ -13,7 +13,7 @@ extraScrapeConfigs: |
       - role: endpoints
         namespaces:
           names:
-          - kube-system
+          - $KARPENTER_NAMESPACE
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_endpoints_name

--- a/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -4,7 +4,7 @@ helm repo update
 
 kubectl create namespace monitoring
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | tee prometheus-values.yaml
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/grafana-values.yaml | tee grafana-values.yaml

--- a/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -4,7 +4,6 @@ helm repo update
 
 
 kubectl create namespace monitoring
-export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml

--- a/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step09-add-prometheus-grafana.sh
@@ -2,7 +2,9 @@ helm repo add grafana-charts https://grafana.github.io/helm-charts
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 
+
 kubectl create namespace monitoring
+export KARPENTER_NAMESPACE=${KARPENTER_NAMESPACE:-kube-system}
 
 curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | envsubst | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A

**Description**
The Monitoring with Grafana part of the getting started guide for Karpenter hardcodes the Karpenter namespace to "kube-system" in the prometheus scrape targets configuration.  This is a configurable option in the walk-through. This PR templates the prometheus values file.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.