### PR TITLE
ci: Dry run `prepare-website` on merge to main and presubmit

### DIFF
--- a/.github/workflows/dryrun-gen-pr.yaml
+++ b/.github/workflows/dryrun-gen-pr.yaml
@@ -1,0 +1,13 @@
+name: DryRunGenPR
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  dryrun-gen:
+    if: github.repository == 'aws/karpenter-provider-aws'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - run: make prepare-website
+        env:
+          GIT_TAG: v0.10000.0 # Mock version for testing website generation

--- a/.github/workflows/dryrun-gen.yaml
+++ b/.github/workflows/dryrun-gen.yaml
@@ -1,11 +1,11 @@
-name: DocGenCI
+name: DryRunGen
 on:
   push:
     branches:
       - 'main'
       - 'release-v*'
 jobs:
-  docgen-ci:
+  dryrun-gen:
     permissions:
       id-token: write # aws-actions/configure-aws-credentials@v4.0.1
     if: github.repository == 'aws/karpenter-provider-aws'
@@ -21,3 +21,6 @@ jobs:
       - run: make codegen
         env:
           ENABLE_GIT_PUSH: false
+      - run: make prepare-website
+        env:
+          GIT_TAG: v0.10000.0 # Mock version for testing website generation

--- a/.github/workflows/snapshot-pr.yaml
+++ b/.github/workflows/snapshot-pr.yaml
@@ -1,4 +1,4 @@
-name: PullRequestSnapshot
+name: SnapshotPR
 on:
   workflow_run:
     workflows:
@@ -6,7 +6,7 @@ on:
     types:
       - completed
 jobs:
-  release:
+  snapshot:
     permissions:
       id-token: write
       pull-requests: write

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -5,7 +5,7 @@ on:
       - 'main'
       - 'release-v*'
 jobs:
-  release:
+  snapshot:
     permissions:
       id-token: write # aws-actions/configure-aws-credentials@v4.0.1
     if: github.repository == 'aws/karpenter-provider-aws'


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Dry-run the `make prepare-website` generation as part of merge into main

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.