### PR TITLE
Revert "chore(deps-dev): bump the website-deps group in /website with 1 update"

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "ansi-regex": ">=5.0.1",
         "autoprefixer": "^10.4.17",
-        "hugo-extended": "0.123.3",
+        "hugo-extended": "0.122.0",
         "postcss": "^8.4.35",
         "postcss-cli": "^11.0.0"
       }
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.123.3",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.123.3.tgz",
-      "integrity": "sha512-NfWuSoDfzqPgvY9xBaZ1VMEAeqoAuswW0pn4CcmnduVVyRXmTnpX0HdgG+tj6DtldJmMXHh24ZNnjdI9wus0yg==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.122.0.tgz",
+      "integrity": "sha512-f9kPVSKxk5mq62wmw1tbhg5CV7n93Tbt7jZoy+C3yfRlEZhGqBlxaEJ3MeeNoilz3IPy5STHB7R0Bdhuap7mHA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",
-    "hugo-extended": "0.123.3"
+    "hugo-extended": "0.122.0"
   },
 
   "scripts": {


### PR DESCRIPTION
Reverts aws/karpenter-provider-aws#5729
Fixes #5734


Something in the latest `hugo-extended` package broke how scripts are rendered. We should revert this so that the website starts rendering normally again, but should track down what needs to be changed here before we re-upgrade back to the version that contains this break.