### PR TITLE
docs: Fix hard-coded AWS partition in IAM policy

### DIFF
--- a/website/content/en/v0.32/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/v0.32/upgrading/v1beta1-controller-policy.json
@@ -142,7 +142,7 @@
     {
       "Sid": "AllowInterruptionQueueActions",
       "Effect": "Allow",
-      "Resource": "arn:aws:sqs:${AWS_REGION}:${AWS_ACCOUNT_ID}:${CLUSTER_NAME}",
+      "Resource": "arn:${AWS_PARTITION}:sqs:${AWS_REGION}:${AWS_ACCOUNT_ID}:${CLUSTER_NAME}",
       "Action": [
         "sqs:DeleteMessage",
         "sqs:GetQueueUrl",


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
In the IAM policy for the v0.32 upgrade guide, one ARN is hard-coded to use `aws` as the partition instead of an environment variable, causing the upgrade procedure to fail in other partitions.

**How was this change tested?**
Tested following the upgrade instructions in AWS GovCloud.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.