### PR TITLE
ci: add cluster exclusion list to cleanup

### DIFF
--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -35,6 +35,7 @@ import (
 const sweeperCleanedResourcesTableName = "sweeperCleanedResources"
 
 var excludedClusters = []string{
+	// TODO: @jmdeal remove after SQS investigation
 	"soak-periodic-46287782",
 }
 

--- a/test/hack/resource/go.mod
+++ b/test/hack/resource/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/samber/lo v1.38.1
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17
 )
 
 require (
@@ -30,6 +31,5 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/test/hack/resource/pkg/resourcetypes/instanceprofile.go
+++ b/test/hack/resource/pkg/resourcetypes/instanceprofile.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	"golang.org/x/exp/slices"
 )
 
 type InstanceProfile struct {
@@ -41,7 +43,7 @@ func (ip *InstanceProfile) Global() bool {
 	return true
 }
 
-func (ip *InstanceProfile) GetExpired(ctx context.Context, expirationTime time.Time) (names []string, err error) {
+func (ip *InstanceProfile) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (names []string, err error) {
 	out, err := ip.iamClient.ListInstanceProfiles(ctx, &iam.ListInstanceProfilesInput{})
 	if err != nil {
 		return names, err
@@ -58,6 +60,13 @@ func (ip *InstanceProfile) GetExpired(ctx context.Context, expirationTime time.T
 		})
 		if err != nil {
 			errs[i] = err
+			continue
+		}
+
+		clusterName, found := lo.Find(out.InstanceProfiles[i].Tags, func(tag iamtypes.Tag) bool {
+			return *tag.Key == k8sClusterTag
+		})
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
 			continue
 		}
 

--- a/test/hack/resource/pkg/resourcetypes/resourcetypes.go
+++ b/test/hack/resource/pkg/resourcetypes/resourcetypes.go
@@ -39,7 +39,7 @@ type Type interface {
 	// Get returns all resources of the type associated with the clusterName
 	Get(ctx context.Context, clusterName string) (ids []string, err error)
 	// GetExpired returns all resources of the type that were provisioned before the expirationTime
-	GetExpired(ctx context.Context, expirationTime time.Time) (ids []string, err error)
+	GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error)
 	// Cleanup deletes all resources of the type by id and returns the resource ids it succeeded to delete
 	// In general, if all resources can't be deleted by id with a single API call (like with DeleteInstances)
 	// you should call the requests synchronously to avoid rate limiting against the number of requests made

--- a/test/hack/resource/pkg/resourcetypes/securitygroup.go
+++ b/test/hack/resource/pkg/resourcetypes/securitygroup.go
@@ -23,6 +23,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	"golang.org/x/exp/slices"
 )
 
 type SecurityGroup struct {
@@ -41,7 +42,7 @@ func (sg *SecurityGroup) Global() bool {
 	return false
 }
 
-func (sg *SecurityGroup) GetExpired(ctx context.Context, expirationTime time.Time) (ids []string, err error) {
+func (sg *SecurityGroup) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
 	var nextToken *string
 	for {
 		out, err := sg.ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
@@ -58,6 +59,12 @@ func (sg *SecurityGroup) GetExpired(ctx context.Context, expirationTime time.Tim
 		}
 
 		for _, sgroup := range out.SecurityGroups {
+			clusterName, found := lo.Find(sgroup.Tags, func(tag ec2types.Tag) bool {
+				return *tag.Key == k8sClusterTag
+			})
+			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+				continue
+			}
 			creationDate, found := lo.Find(sgroup.Tags, func(tag ec2types.Tag) bool {
 				return *tag.Key == "creation-date"
 			})

--- a/test/hack/soak/get_clusters.go
+++ b/test/hack/soak/get_clusters.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -34,6 +35,10 @@ type cluster struct {
 }
 
 const expirationTTL = time.Hour * 168 // 7 days
+
+var excludedClustersCleanup = []string{
+	"soak-periodic-46287782",
+}
 
 func main() {
 	ctx := context.Background()
@@ -54,9 +59,14 @@ func main() {
 
 		if strings.HasPrefix(c, "soak-periodic-") {
 			outputList = append(outputList, &cluster{
-				Name:    c,
-				GitRef:  clusterDetails.Cluster.Tags["test/git_ref"],
-				Cleanup: clusterDetails.Cluster.CreatedAt.Before(expirationTime)})
+				Name:   c,
+				GitRef: clusterDetails.Cluster.Tags["test/git_ref"],
+				Cleanup: lo.Ternary(
+					slices.Contains(excludedClustersCleanup, c),
+					false,
+					clusterDetails.Cluster.CreatedAt.Before(expirationTime),
+				),
+			})
 		}
 	}
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds an exclusion list to our cleanup script to keep clusters around for investigation purposes. Motivated by ongoing SQS failures in our soak tests.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.