### PR TITLE
docs: Revert PR #5774 (Hugo version bump)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "devDependencies": {
         "ansi-regex": ">=5.0.1",
-        "autoprefixer": "^10.4.18",
-        "hugo-extended": "0.123.7",
+        "autoprefixer": "^10.4.17",
+        "hugo-extended": "0.122.0",
         "postcss": "^8.4.35",
         "postcss-cli": "^11.0.0"
       }
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.123.7",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.123.7.tgz",
-      "integrity": "sha512-sxI5Us+O2t2CI9oDK/Li/VYl2gd0TdkPxKW+CQYefSN/BgSuyMSvsDNBcVfIxGs35+I3qShagt37vE0JIIcqig==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.122.0.tgz",
+      "integrity": "sha512-f9kPVSKxk5mq62wmw1tbhg5CV7n93Tbt7jZoy+C3yfRlEZhGqBlxaEJ3MeeNoilz3IPy5STHB7R0Bdhuap7mHA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "devDependencies": {
     "ansi-regex": ">=5.0.1",
-    "autoprefixer": "^10.4.18",
+    "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",
-    "hugo-extended": "0.123.7"
+    "hugo-extended": "0.122.0"
   },
 
   "scripts": {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Revet Hugo Version bump 
- https://github.com/aws/karpenter-provider-aws/pull/5774

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.