### PR TITLE
[wip]feat: publish ICE events with involved object of NodeClaim

### DIFF
--- a/pkg/cache/events.go
+++ b/pkg/cache/events.go
@@ -16,17 +16,19 @@ package cache
 
 import (
 	"fmt"
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 
 	v1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/karpenter/pkg/events"
 )
 
-func UnavailableOfferingEvent(instanceType, availabilityZone, capacityType string) events.Event {
+func UnavailableOfferingEvent(nodeClaim *v1beta1.NodeClaim, instanceType, availabilityZone, capacityType string) events.Event {
 	return events.Event{
-		Type:         v1.EventTypeWarning,
-		Reason:       "UnavailableOffering",
-		Message:      fmt.Sprintf(`UnavailableOffering for {"instanceType": %q, "availabilityZone": %q, "capacityType": %q}`, instanceType, availabilityZone, capacityType),
-		DedupeValues: []string{instanceType, availabilityZone, capacityType},
+		InvolvedObject: nodeClaim,
+		Type:           v1.EventTypeWarning,
+		Reason:         "UnavailableOffering",
+		Message:        fmt.Sprintf(`UnavailableOffering for {"instanceType": %q, "availabilityZone": %q, "capacityType": %q}`, instanceType, availabilityZone, capacityType),
+		DedupeValues:   []string{instanceType, availabilityZone, capacityType},
 	}
 }

--- a/pkg/cache/events.go
+++ b/pkg/cache/events.go
@@ -1,0 +1,32 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/karpenter/pkg/events"
+)
+
+func UnavailableOfferingEvent(instanceType, availabilityZone, capacityType string) events.Event {
+	return events.Event{
+		Type:         v1.EventTypeWarning,
+		Reason:       "UnavailableOffering",
+		Message:      fmt.Sprintf(`UnavailableOffering for {"instanceType": %q, "availabilityZone": %q, "capacityType": %q}`, instanceType, availabilityZone, capacityType),
+		DedupeValues: []string{instanceType, availabilityZone, capacityType},
+	}
+}

--- a/pkg/cache/suite_test.go
+++ b/pkg/cache/suite_test.go
@@ -1,0 +1,33 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "knative.dev/pkg/logging/testing"
+	_ "knative.dev/pkg/system/testing"
+)
+
+var ctx context.Context
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cache")
+}

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -24,6 +24,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"knative.dev/pkg/logging"
 
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/events"
 )
 
@@ -52,7 +53,7 @@ func (u *UnavailableOfferings) IsUnavailable(instanceType, zone, capacityType st
 }
 
 // MarkUnavailable communicates recently observed temporary capacity shortages in the provided offerings
-func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableReason, instanceType, zone, capacityType string) {
+func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, nodeClaim *v1beta1.NodeClaim, unavailableReason, instanceType, zone, capacityType string) {
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
 	logging.FromContext(ctx).With(
 		"reason", unavailableReason,
@@ -64,13 +65,13 @@ func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableR
 	atomic.AddUint64(&u.SeqNum, 1)
 
 	// Add a k8s event for the instance type and zone without the involved object which has an ICE error
-	u.recorder.Publish(UnavailableOfferingEvent(instanceType, zone, capacityType))
+	u.recorder.Publish(UnavailableOfferingEvent(nodeClaim, instanceType, zone, capacityType))
 }
 
-func (u *UnavailableOfferings) MarkUnavailableForFleetErr(ctx context.Context, fleetErr *ec2.CreateFleetError, capacityType string) {
+func (u *UnavailableOfferings) MarkUnavailableForFleetErr(ctx context.Context, nodeClaim *v1beta1.NodeClaim, fleetErr *ec2.CreateFleetError, capacityType string) {
 	instanceType := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.InstanceType)
 	zone := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.AvailabilityZone)
-	u.MarkUnavailable(ctx, aws.StringValue(fleetErr.ErrorCode), instanceType, zone, capacityType)
+	u.MarkUnavailable(ctx, nodeClaim, aws.StringValue(fleetErr.ErrorCode), instanceType, zone, capacityType)
 }
 
 func (u *UnavailableOfferings) Delete(instanceType string, zone string, capacityType string) {

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -23,6 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/patrickmn/go-cache"
 	"knative.dev/pkg/logging"
+
+	"sigs.k8s.io/karpenter/pkg/events"
 )
 
 // UnavailableOfferings stores any offerings that return ICE (insufficient capacity errors) when
@@ -30,14 +32,16 @@ import (
 // GetInstanceTypes responses
 type UnavailableOfferings struct {
 	// key: <capacityType>:<instanceType>:<zone>, value: struct{}{}
-	cache  *cache.Cache
-	SeqNum uint64
+	cache    *cache.Cache
+	SeqNum   uint64
+	recorder events.Recorder
 }
 
-func NewUnavailableOfferings() *UnavailableOfferings {
+func NewUnavailableOfferings(recorder events.Recorder) *UnavailableOfferings {
 	return &UnavailableOfferings{
-		cache:  cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
-		SeqNum: 0,
+		cache:    cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
+		SeqNum:   0,
+		recorder: recorder,
 	}
 }
 
@@ -58,6 +62,9 @@ func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableR
 		"ttl", UnavailableOfferingsTTL).Debugf("removing offering from offerings")
 	u.cache.SetDefault(u.key(instanceType, zone, capacityType), struct{}{})
 	atomic.AddUint64(&u.SeqNum, 1)
+
+	// Add a k8s event for the instance type and zone without the involved object which has an ICE error
+	u.recorder.Publish(UnavailableOfferingEvent(instanceType, zone, capacityType))
 }
 
 func (u *UnavailableOfferings) MarkUnavailableForFleetErr(ctx context.Context, fleetErr *ec2.CreateFleetError, capacityType string) {

--- a/pkg/cache/unavailableofferings_test.go
+++ b/pkg/cache/unavailableofferings_test.go
@@ -1,0 +1,97 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache_test
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	_ "knative.dev/pkg/system/testing"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/test"
+	"github.com/aws/karpenter/pkg/cache"
+)
+
+var unavailableOfferingsCache *cache.UnavailableOfferings
+var recorder *test.EventRecorder
+
+var _ = Describe("UnavailableOfferings", func() {
+	BeforeEach(func() {
+		ctx = context.Background()
+		recorder = test.NewEventRecorder()
+		unavailableOfferingsCache = cache.NewUnavailableOfferings(recorder)
+	})
+
+	AfterEach(func() {
+		recorder.Reset()
+	})
+
+	It("should create an UnavailableOfferingEvent when receiving a CreateFleet error", func() {
+		unavailableOfferingsCache.MarkUnavailableForFleetErr(ctx, &ec2.CreateFleetError{
+			LaunchTemplateAndOverrides: &ec2.LaunchTemplateAndOverridesResponse{
+				Overrides: &ec2.FleetLaunchTemplateOverrides{
+					InstanceType:     aws.String("c5.large"),
+					AvailabilityZone: aws.String("test-zone-1a"),
+				},
+			},
+		}, v1alpha5.CapacityTypeSpot)
+		Expect(recorder.Calls("UnavailableOffering")).To(BeNumerically("==", 1))
+		Expect(recorder.DetectedEvent(`UnavailableOffering for {"instanceType": "c5.large", "availabilityZone": "test-zone-1a", "capacityType": "spot"}`))
+	})
+	It("should create an UnavailableOfferingEvent when marking an offering as unavailable", func() {
+		unavailableOfferingsCache.MarkUnavailable(ctx, "offering is unavailable", "c5.large", "test-zone-1a", v1alpha5.CapacityTypeSpot)
+		Expect(recorder.Calls("UnavailableOffering")).To(BeNumerically("==", 1))
+		Expect(recorder.DetectedEvent(`UnavailableOffering for {"instanceType": "c5.large", "availabilityZone": "test-zone-1a", "capacityType": "spot"}`))
+	})
+	It("should create multiple UnavailableOfferingEvent when marking multiple offerings as unavailable", func() {
+		type offering struct {
+			instanceType     string
+			availabilityZone string
+			capacityType     string
+		}
+
+		offerings := []offering{
+			{
+				instanceType:     "c5.large",
+				availabilityZone: "test-zone-1a",
+				capacityType:     v1alpha5.CapacityTypeSpot,
+			},
+			{
+				instanceType:     "g4dn.xlarge",
+				availabilityZone: "test-zone-1b",
+				capacityType:     v1alpha5.CapacityTypeOnDemand,
+			},
+			{
+				instanceType:     "inf1.24xlarge",
+				availabilityZone: "test-zone-1d",
+				capacityType:     v1alpha5.CapacityTypeSpot,
+			},
+			{
+				instanceType:     "t3.nano",
+				availabilityZone: "test-zone-1b",
+				capacityType:     v1alpha5.CapacityTypeOnDemand,
+			},
+		}
+
+		for _, of := range offerings {
+			unavailableOfferingsCache.MarkUnavailable(ctx, "offering is unavailable", of.instanceType, of.availabilityZone, of.capacityType)
+		}
+		Expect(recorder.Calls("UnavailableOffering")).To(BeNumerically("==", len(offerings)))
+	})
+})

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -195,7 +195,7 @@ func (c *Controller) handleNodeClaim(ctx context.Context, msg messages.Message, 
 		zone := nodeClaim.Labels[v1.LabelTopologyZone]
 		instanceType := nodeClaim.Labels[v1.LabelInstanceTypeStable]
 		if zone != "" && instanceType != "" {
-			c.unavailableOfferingsCache.MarkUnavailable(ctx, string(msg.Kind()), instanceType, zone, v1beta1.CapacityTypeSpot)
+			c.unavailableOfferingsCache.MarkUnavailable(ctx, nodeClaim, string(msg.Kind()), instanceType, zone, v1beta1.CapacityTypeSpot)
 		}
 	}
 	if action != NoAction {

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -80,7 +80,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
 	fakeClock = &clock.FakeClock{}
-	unavailableOfferingsCache = awscache.NewUnavailableOfferings()
+	unavailableOfferingsCache = awscache.NewUnavailableOfferings(events.NewRecorder(&record.FakeRecorder{}))
 	sqsapi = &fake.SQSAPI{}
 	sqsProvider = lo.Must(sqs.NewProvider(ctx, sqsapi, "test-cluster"))
 	controller = interruption.NewController(env.Client, fakeClock, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, unavailableOfferingsCache)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -132,7 +132,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		logging.FromContext(ctx).With("kube-dns-ip", kubeDNSIP).Debugf("discovered kube dns")
 	}
 
-	unavailableOfferingsCache := awscache.NewUnavailableOfferings()
+	unavailableOfferingsCache := awscache.NewUnavailableOfferings(operator.EventRecorder)
 	subnetProvider := subnet.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	securityGroupProvider := securitygroup.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	instanceProfileProvider := instanceprofile.NewProvider(*sess.Config.Region, iam.New(sess), cache.New(awscache.InstanceProfileTTL, awscache.DefaultCleanupInterval))

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -236,7 +236,7 @@ func (p *Provider) launchInstance(ctx context.Context, nodeClass *v1beta1.EC2Nod
 		}
 		return nil, fmt.Errorf("creating fleet %w", err)
 	}
-	p.updateUnavailableOfferingsCache(ctx, createFleetOutput.Errors, capacityType)
+	p.updateUnavailableOfferingsCache(ctx, nodeClaim, createFleetOutput.Errors, capacityType)
 	if len(createFleetOutput.Instances) == 0 || len(createFleetOutput.Instances[0].InstanceIds) == 0 {
 		return nil, combineFleetErrors(createFleetOutput.Errors)
 	}
@@ -345,10 +345,10 @@ func (p *Provider) getOverrides(instanceTypes []*cloudprovider.InstanceType, zon
 	return overrides
 }
 
-func (p *Provider) updateUnavailableOfferingsCache(ctx context.Context, errors []*ec2.CreateFleetError, capacityType string) {
+func (p *Provider) updateUnavailableOfferingsCache(ctx context.Context, nodeClaim *corev1beta1.NodeClaim, errors []*ec2.CreateFleetError, capacityType string) {
 	for _, err := range errors {
 		if awserrors.IsUnfulfillableCapacity(err) {
-			p.unavailableOfferings.MarkUnavailableForFleetErr(ctx, err, capacityType)
+			p.unavailableOfferings.MarkUnavailableForFleetErr(ctx, nodeClaim, err, capacityType)
 		}
 	}
 }

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -21,6 +21,9 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/client-go/tools/record"
+
 	"knative.dev/pkg/ptr"
 
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -40,6 +43,8 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
 
 	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	"sigs.k8s.io/karpenter/pkg/events"
 
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -91,7 +96,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	ec2Cache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	kubernetesVersionCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	instanceTypeCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
-	unavailableOfferingsCache := awscache.NewUnavailableOfferings()
+	unavailableOfferingsCache := awscache.NewUnavailableOfferings(events.NewRecorder(&record.FakeRecorder{}))
 	launchTemplateCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	subnetCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	securityGroupCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes https://github.com/aws/karpenter/issues/5004, follow up of PR https://github.com/aws/karpenter-provider-aws/pull/5093

This PR adds support for publishing ICE events along with the ec2nodeClass involved object. 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.