### PR TITLE
docs: add kubeReserved default note

### DIFF
--- a/website/content/en/docs/concepts/nodepools.md
+++ b/website/content/en/docs/concepts/nodepools.md
@@ -301,6 +301,7 @@ If you have specific requirements or know that you will have additional capacity
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/docs/concepts/nodepools.md
+++ b/website/content/en/docs/concepts/nodepools.md
@@ -301,7 +301,7 @@ If you have specific requirements or know that you will have additional capacity
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
-You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
+You should be aware of the CPU and memory default calculation when using Custom AMI Families. If they don't align, there may be a difference in Karpenter's computed allocatable ephemeral storage and the actually ephemeral storage available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/docs/concepts/nodepools.md
+++ b/website/content/en/docs/concepts/nodepools.md
@@ -127,12 +127,12 @@ spec:
     # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
     consolidationPolicy: WhenUnderutilized | WhenEmpty
-    
+
     # The amount of time Karpenter should wait after discovering a consolidation decision
     # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
     # You can choose to disable consolidation entirely by setting the string value 'Never' here
     consolidateAfter: 30s
-    
+
     # The amount of time a Node can live on the cluster before being removed
     # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
     # You can choose to disable expiration entirely by setting the string value 'Never' here
@@ -140,8 +140,8 @@ spec:
 
     # Budgets control the speed Karpenter can scale down nodes.
     # Karpenter will respect the minimum of the currently active budgets, and will round up
-    # when considering percentages. Duration and Schedule must be set together. 
-    budgets: 
+    # when considering percentages. Duration and Schedule must be set together.
+    budgets:
     - nodes: 10%
     # On Weekdays during business hours, don't do any deprovisioning.
     - schedule: "0 9 * * mon-fri"
@@ -293,9 +293,15 @@ kubelet:
 
 ### Reserved Resources
 
-Karpenter will automatically configure the system and kube reserved resource requests on the fly on your behalf. These requests are used to configure your node and to make scheduling decisions for your pods. If you have specific requirements or know that you will have additional capacity requirements, you can optionally override the `--system-reserved` configuration defaults with the `.spec.template.spec.kubelet.systemReserved` values and the `--kube-reserved` configuration defaults with the `.spec.template.spec.kubelet.kubeReserved` values.
+Karpenter will automatically configure the system and kube reserved resource requests on the fly on your behalf.
+These requests are used to configure your node and to make scheduling decisions for your pods.
+If you have specific requirements or know that you will have additional capacity requirements, you can optionally override the `--system-reserved` configuration defaults with the `.spec.template.spec.kubelet.systemReserved` values and the `--kube-reserved` configuration defaults with the `.spec.template.spec.kubelet.kubeReserved` values.
 
-For more information on the default `--system-reserved` and `--kube-reserved` configuration refer to the [Kubelet Docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved)
+{{% alert title="Note" color="primary" %}}
+Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
+If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
+These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+{{% /alert %}}
 
 ### Eviction Thresholds
 

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -299,7 +299,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
-You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
+You should be aware of the CPU and memory default calculation when using Custom AMI Families. If they don't align, there may be a difference in Karpenter's computed allocatable ephemeral storage and the actually ephemeral storage available on the node.
 {{% /alert %}}
 
 

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -127,12 +127,12 @@ spec:
     # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
     consolidationPolicy: WhenUnderutilized | WhenEmpty
-    
+
     # The amount of time Karpenter should wait after discovering a consolidation decision
     # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
     # You can choose to disable consolidation entirely by setting the string value 'Never' here
     consolidateAfter: 30s
-    
+
     # The amount of time a Node can live on the cluster before being removed
     # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
     # You can choose to disable expiration entirely by setting the string value 'Never' here
@@ -140,8 +140,8 @@ spec:
 
     # Budgets control the speed Karpenter can scale down nodes.
     # Karpenter will respect the minimum of the currently active budgets, and will round up
-    # when considering percentages. Duration and Schedule must be set together. 
-    budgets: 
+    # when considering percentages. Duration and Schedule must be set together.
+    budgets:
     - nodes: 10%
     # On Weekdays during business hours, don't do any deprovisioning.
     - schedule: "0 9 * * mon-fri"
@@ -295,7 +295,12 @@ kubelet:
 
 Karpenter will automatically configure the system and kube reserved resource requests on the fly on your behalf. These requests are used to configure your node and to make scheduling decisions for your pods. If you have specific requirements or know that you will have additional capacity requirements, you can optionally override the `--system-reserved` configuration defaults with the `.spec.template.spec.kubelet.systemReserved` values and the `--kube-reserved` configuration defaults with the `.spec.template.spec.kubelet.kubeReserved` values.
 
-For more information on the default `--system-reserved` and `--kube-reserved` configuration refer to the [Kubelet Docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved)
+{{% alert title="Note" color="primary" %}}
+Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
+If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
+These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+{{% /alert %}}
+
 
 ### Eviction Thresholds
 

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -299,6 +299,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
 {{% /alert %}}
 
 

--- a/website/content/en/v0.32/concepts/nodepools.md
+++ b/website/content/en/v0.32/concepts/nodepools.md
@@ -289,7 +289,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
-You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
+You should be aware of the CPU and memory default calculation when using Custom AMI Families. If they don't align, there may be a difference in Karpenter's computed allocatable ephemeral storage and the actually ephemeral storage available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/v0.32/concepts/nodepools.md
+++ b/website/content/en/v0.32/concepts/nodepools.md
@@ -127,12 +127,12 @@ spec:
     # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
     consolidationPolicy: WhenUnderutilized | WhenEmpty
-    
+
     # The amount of time Karpenter should wait after discovering a consolidation decision
     # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
     # You can choose to disable consolidation entirely by setting the string value 'Never' here
     consolidateAfter: 30s
-    
+
     # The amount of time a Node can live on the cluster before being removed
     # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
     # You can choose to disable expiration entirely by setting the string value 'Never' here
@@ -285,7 +285,11 @@ kubelet:
 
 Karpenter will automatically configure the system and kube reserved resource requests on the fly on your behalf. These requests are used to configure your node and to make scheduling decisions for your pods. If you have specific requirements or know that you will have additional capacity requirements, you can optionally override the `--system-reserved` configuration defaults with the `.spec.template.spec.kubelet.systemReserved` values and the `--kube-reserved` configuration defaults with the `.spec.template.spec.kubelet.kubeReserved` values.
 
-For more information on the default `--system-reserved` and `--kube-reserved` configuration refer to the [Kubelet Docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved)
+{{% alert title="Note" color="primary" %}}
+Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
+If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
+These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+{{% /alert %}}
 
 ### Eviction Thresholds
 

--- a/website/content/en/v0.32/concepts/nodepools.md
+++ b/website/content/en/v0.32/concepts/nodepools.md
@@ -289,6 +289,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/v0.33/concepts/nodepools.md
+++ b/website/content/en/v0.33/concepts/nodepools.md
@@ -289,7 +289,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
-You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
+You should be aware of the CPU and memory default calculation when using Custom AMI Families. If they don't align, there may be a difference in Karpenter's computed allocatable ephemeral storage and the actually ephemeral storage available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/v0.33/concepts/nodepools.md
+++ b/website/content/en/v0.33/concepts/nodepools.md
@@ -127,12 +127,12 @@ spec:
     # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
     consolidationPolicy: WhenUnderutilized | WhenEmpty
-    
+
     # The amount of time Karpenter should wait after discovering a consolidation decision
     # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
     # You can choose to disable consolidation entirely by setting the string value 'Never' here
     consolidateAfter: 30s
-    
+
     # The amount of time a Node can live on the cluster before being removed
     # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
     # You can choose to disable expiration entirely by setting the string value 'Never' here
@@ -285,7 +285,11 @@ kubelet:
 
 Karpenter will automatically configure the system and kube reserved resource requests on the fly on your behalf. These requests are used to configure your node and to make scheduling decisions for your pods. If you have specific requirements or know that you will have additional capacity requirements, you can optionally override the `--system-reserved` configuration defaults with the `.spec.template.spec.kubelet.systemReserved` values and the `--kube-reserved` configuration defaults with the `.spec.template.spec.kubelet.kubeReserved` values.
 
-For more information on the default `--system-reserved` and `--kube-reserved` configuration refer to the [Kubelet Docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved)
+{{% alert title="Note" color="primary" %}}
+Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
+If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
+These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+{{% /alert %}}
 
 ### Eviction Thresholds
 

--- a/website/content/en/v0.33/concepts/nodepools.md
+++ b/website/content/en/v0.33/concepts/nodepools.md
@@ -289,6 +289,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/v0.34/concepts/nodepools.md
+++ b/website/content/en/v0.34/concepts/nodepools.md
@@ -299,7 +299,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
-You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
+You should be aware of the CPU and memory default calculation when using Custom AMI Families. If they don't align, there may be a difference in Karpenter's computed allocatable ephemeral storage and the actually ephemeral storage available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/v0.34/concepts/nodepools.md
+++ b/website/content/en/v0.34/concepts/nodepools.md
@@ -127,12 +127,12 @@ spec:
     # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
     consolidationPolicy: WhenUnderutilized | WhenEmpty
-    
+
     # The amount of time Karpenter should wait after discovering a consolidation decision
     # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
     # You can choose to disable consolidation entirely by setting the string value 'Never' here
     consolidateAfter: 30s
-    
+
     # The amount of time a Node can live on the cluster before being removed
     # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
     # You can choose to disable expiration entirely by setting the string value 'Never' here
@@ -140,8 +140,8 @@ spec:
 
     # Budgets control the speed Karpenter can scale down nodes.
     # Karpenter will respect the minimum of the currently active budgets, and will round up
-    # when considering percentages. Duration and Schedule must be set together. 
-    budgets: 
+    # when considering percentages. Duration and Schedule must be set together.
+    budgets:
     - nodes: 10%
     # On Weekdays during business hours, don't do any deprovisioning.
     - schedule: "0 9 * * mon-fri"
@@ -295,7 +295,11 @@ kubelet:
 
 Karpenter will automatically configure the system and kube reserved resource requests on the fly on your behalf. These requests are used to configure your node and to make scheduling decisions for your pods. If you have specific requirements or know that you will have additional capacity requirements, you can optionally override the `--system-reserved` configuration defaults with the `.spec.template.spec.kubelet.systemReserved` values and the `--kube-reserved` configuration defaults with the `.spec.template.spec.kubelet.kubeReserved` values.
 
-For more information on the default `--system-reserved` and `--kube-reserved` configuration refer to the [Kubelet Docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved)
+{{% alert title="Note" color="primary" %}}
+Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
+If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
+These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+{{% /alert %}}
 
 ### Eviction Thresholds
 

--- a/website/content/en/v0.34/concepts/nodepools.md
+++ b/website/content/en/v0.34/concepts/nodepools.md
@@ -299,6 +299,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/v0.35/concepts/nodepools.md
+++ b/website/content/en/v0.35/concepts/nodepools.md
@@ -299,7 +299,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
-You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
+You should be aware of the CPU and memory default calculation when using Custom AMI Families. If they don't align, there may be a difference in Karpenter's computed allocatable ephemeral storage and the actually ephemeral storage available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds

--- a/website/content/en/v0.35/concepts/nodepools.md
+++ b/website/content/en/v0.35/concepts/nodepools.md
@@ -127,12 +127,12 @@ spec:
     # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
     consolidationPolicy: WhenUnderutilized | WhenEmpty
-    
+
     # The amount of time Karpenter should wait after discovering a consolidation decision
     # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
     # You can choose to disable consolidation entirely by setting the string value 'Never' here
     consolidateAfter: 30s
-    
+
     # The amount of time a Node can live on the cluster before being removed
     # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
     # You can choose to disable expiration entirely by setting the string value 'Never' here
@@ -140,8 +140,8 @@ spec:
 
     # Budgets control the speed Karpenter can scale down nodes.
     # Karpenter will respect the minimum of the currently active budgets, and will round up
-    # when considering percentages. Duration and Schedule must be set together. 
-    budgets: 
+    # when considering percentages. Duration and Schedule must be set together.
+    budgets:
     - nodes: 10%
     # On Weekdays during business hours, don't do any deprovisioning.
     - schedule: "0 9 * * mon-fri"
@@ -295,7 +295,11 @@ kubelet:
 
 Karpenter will automatically configure the system and kube reserved resource requests on the fly on your behalf. These requests are used to configure your node and to make scheduling decisions for your pods. If you have specific requirements or know that you will have additional capacity requirements, you can optionally override the `--system-reserved` configuration defaults with the `.spec.template.spec.kubelet.systemReserved` values and the `--kube-reserved` configuration defaults with the `.spec.template.spec.kubelet.kubeReserved` values.
 
-For more information on the default `--system-reserved` and `--kube-reserved` configuration refer to the [Kubelet Docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved)
+{{% alert title="Note" color="primary" %}}
+Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
+If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
+These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+{{% /alert %}}
 
 ### Eviction Thresholds
 

--- a/website/content/en/v0.35/concepts/nodepools.md
+++ b/website/content/en/v0.35/concepts/nodepools.md
@@ -299,6 +299,7 @@ Karpenter will automatically configure the system and kube reserved resource req
 Karpenter considers these reserved resources when computing the allocatable ephemeral storage on a given instance type.
 If `kubeReserved` is not specified, Karpenter will compute the default reserved [CPU](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L251) and [memory](https://github.com/awslabs/amazon-eks-ami/blob/db28da15d2b696bc08ac3aacc9675694f4a69933/files/bootstrap.sh#L235) resources for the purpose of ephemeral storage computation.
 These defaults are based on the defaults on Karpenter's supported AMI families, which are not the same as the kubelet defaults.
+You should be aware of these defaults when using Custom AMI Families, since if they don't align there may be a difference in Karpenter's computed allocated ephemeral storage and what is actually available on the node.
 {{% /alert %}}
 
 ### Eviction Thresholds


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5676 
**Description**
Adds a note about how kubeReserved defaults effect ephemeral storage calculation

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.