### PR TITLE
docs: Ensure that every nodeClassRef uses all fields

### DIFF
--- a/examples/v1beta1/100-cpu-limit.yaml
+++ b/examples/v1beta1/100-cpu-limit.yaml
@@ -28,6 +28,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 100

--- a/examples/v1beta1/al2-custom-ami.yaml
+++ b/examples/v1beta1/al2-custom-ami.yaml
@@ -28,6 +28,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: al2
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/al2-custom-userdata.yaml
+++ b/examples/v1beta1/al2-custom-userdata.yaml
@@ -28,6 +28,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: al2
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/al2-kubelet-log-query.yaml
+++ b/examples/v1beta1/al2-kubelet-log-query.yaml
@@ -27,6 +27,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: al2
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/al2023-custom-userdata.yaml
+++ b/examples/v1beta1/al2023-custom-userdata.yaml
@@ -26,6 +26,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: al2023
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/bottlerocket.yaml
+++ b/examples/v1beta1/bottlerocket.yaml
@@ -27,6 +27,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: bottlerocket
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/br-custom-userdata.yaml
+++ b/examples/v1beta1/br-custom-userdata.yaml
@@ -28,6 +28,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: bottlerocket
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/custom-family.yaml
+++ b/examples/v1beta1/custom-family.yaml
@@ -27,6 +27,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: custom-family
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -26,6 +26,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/instance-store-ephemeral-storage.yaml
+++ b/examples/v1beta1/instance-store-ephemeral-storage.yaml
@@ -30,6 +30,8 @@ spec:
           operator: Gt
           values: ["300"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: instance-store-ephemeral-storage
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/large-instances.yaml
+++ b/examples/v1beta1/large-instances.yaml
@@ -18,6 +18,8 @@ spec:
           operator: Gt
           values: ["8191"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/multiple-arch.yaml
+++ b/examples/v1beta1/multiple-arch.yaml
@@ -28,6 +28,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 ---
 apiVersion: karpenter.sh/v1beta1
@@ -56,6 +58,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/multiple-ebs.yaml
+++ b/examples/v1beta1/multiple-ebs.yaml
@@ -27,6 +27,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: multiple-ebs
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/node-ttls.yaml
+++ b/examples/v1beta1/node-ttls.yaml
@@ -28,6 +28,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   disruption:
     consolidationPolicy: WhenEmpty

--- a/examples/v1beta1/spot.yaml
+++ b/examples/v1beta1/spot.yaml
@@ -27,6 +27,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/ubuntu-kubelet-log-query.yaml
+++ b/examples/v1beta1/ubuntu-kubelet-log-query.yaml
@@ -27,6 +27,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: ubuntu
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/windows-custom-userdata.yaml
+++ b/examples/v1beta1/windows-custom-userdata.yaml
@@ -29,6 +29,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: windows2022
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/windows2019.yaml
+++ b/examples/v1beta1/windows2019.yaml
@@ -26,6 +26,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: windows2019
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/examples/v1beta1/windows2022.yaml
+++ b/examples/v1beta1/windows2022.yaml
@@ -26,6 +26,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: windows2022
 ---
 apiVersion: karpenter.k8s.aws/v1beta1

--- a/website/content/en/docs/concepts/nodepools.md
+++ b/website/content/en/docs/concepts/nodepools.md
@@ -46,6 +46,8 @@ spec:
     spec:
       # References the Cloud Provider's NodeClass resource, see your cloud provider specific documentation
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 
       # Provisioned nodes will have these taints

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/docs/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/docs/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -46,6 +46,8 @@ spec:
     spec:
       # References the Cloud Provider's NodeClass resource, see your cloud provider specific documentation
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 
       # Provisioned nodes will have these taints

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.32/concepts/nodepools.md
+++ b/website/content/en/v0.32/concepts/nodepools.md
@@ -46,6 +46,8 @@ spec:
     spec:
       # References the Cloud Provider's NodeClass resource, see your cloud provider specific documentation
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 
       # Provisioned nodes will have these taints

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.32/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/v0.32/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.32/upgrading/v1beta1-migration.md
+++ b/website/content/en/v0.32/upgrading/v1beta1-migration.md
@@ -321,6 +321,8 @@ apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 ...
 nodeClassRef:
+  apiVersion: karpenter.k8s.aws/v1beta1
+  kind: EC2NodeClass
   name: default
 ```
 

--- a/website/content/en/v0.33/concepts/nodepools.md
+++ b/website/content/en/v0.33/concepts/nodepools.md
@@ -46,6 +46,8 @@ spec:
     spec:
       # References the Cloud Provider's NodeClass resource, see your cloud provider specific documentation
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 
       # Provisioned nodes will have these taints

--- a/website/content/en/v0.33/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/v0.33/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.33/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/v0.33/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.34/concepts/nodepools.md
+++ b/website/content/en/v0.34/concepts/nodepools.md
@@ -46,6 +46,8 @@ spec:
     spec:
       # References the Cloud Provider's NodeClass resource, see your cloud provider specific documentation
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 
       # Provisioned nodes will have these taints

--- a/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/v0.34/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.34/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/v0.34/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.35/concepts/nodepools.md
+++ b/website/content/en/v0.35/concepts/nodepools.md
@@ -46,6 +46,8 @@ spec:
     spec:
       # References the Cloud Provider's NodeClass resource, see your cloud provider specific documentation
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
 
       # Provisioned nodes will have these taints

--- a/website/content/en/v0.35/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/v0.35/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000

--- a/website/content/en/v0.35/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/v0.35/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,6 +23,8 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
         name: default
   limits:
     cpu: 1000


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Ensure that every `nodeClassRef` that is used in the docs uses the full `nodeClassRef` field set with `apiVersion`, `kind`, and `name`

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.