### PR TITLE
docs: fix topology zone list value quote issue in docs

### DIFF
--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -214,7 +214,7 @@ All examples below assume that the NodePool doesn't have constraints to prevent 
          - matchExpressions:
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "In"
              values: ["us-west-2b"]
@@ -225,7 +225,7 @@ Changing the second operator to `NotIn` would allow the pod to run in `us-west-2
 ```yaml
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "NotIn"
              values: ["us-west-2b"]
@@ -243,7 +243,7 @@ Here, if `us-west-2a` is not available, the second term will cause the pod to ru
          - matchExpressions: # OR
            - key: "topology.kubernetes.io/zone" # AND
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone" # AND
              operator: "NotIn"
              values: ["us-west-2b"]

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -215,7 +215,7 @@ All examples below assume that the NodePool doesn't have constraints to prevent 
          - matchExpressions:
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "In"
              values: ["us-west-2b"]
@@ -226,7 +226,7 @@ Changing the second operator to `NotIn` would allow the pod to run in `us-west-2
 ```yaml
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "NotIn"
              values: ["us-west-2b"]
@@ -244,7 +244,7 @@ Here, if `us-west-2a` is not available, the second term will cause the pod to ru
          - matchExpressions: # OR
            - key: "topology.kubernetes.io/zone" # AND
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone" # AND
              operator: "NotIn"
              values: ["us-west-2b"]

--- a/website/content/en/v0.32/concepts/scheduling.md
+++ b/website/content/en/v0.32/concepts/scheduling.md
@@ -213,7 +213,7 @@ All examples below assume that the NodePool doesn't have constraints to prevent 
          - matchExpressions:
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "In"
              values: ["us-west-2b"]
@@ -224,7 +224,7 @@ Changing the second operator to `NotIn` would allow the pod to run in `us-west-2
 ```yaml
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "NotIn"
              values: ["us-west-2b"]
@@ -242,7 +242,7 @@ Here, if `us-west-2a` is not available, the second term will cause the pod to ru
          - matchExpressions: # OR
            - key: "topology.kubernetes.io/zone" # AND
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone" # AND
              operator: "NotIn"
              values: ["us-west-2b"]

--- a/website/content/en/v0.33/concepts/scheduling.md
+++ b/website/content/en/v0.33/concepts/scheduling.md
@@ -214,7 +214,7 @@ All examples below assume that the NodePool doesn't have constraints to prevent 
          - matchExpressions:
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "In"
              values: ["us-west-2b"]
@@ -225,7 +225,7 @@ Changing the second operator to `NotIn` would allow the pod to run in `us-west-2
 ```yaml
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "NotIn"
              values: ["us-west-2b"]
@@ -243,7 +243,7 @@ Here, if `us-west-2a` is not available, the second term will cause the pod to ru
          - matchExpressions: # OR
            - key: "topology.kubernetes.io/zone" # AND
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone" # AND
              operator: "NotIn"
              values: ["us-west-2b"]

--- a/website/content/en/v0.34/concepts/scheduling.md
+++ b/website/content/en/v0.34/concepts/scheduling.md
@@ -214,7 +214,7 @@ All examples below assume that the NodePool doesn't have constraints to prevent 
          - matchExpressions:
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "In"
              values: ["us-west-2b"]
@@ -225,7 +225,7 @@ Changing the second operator to `NotIn` would allow the pod to run in `us-west-2
 ```yaml
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "NotIn"
              values: ["us-west-2b"]
@@ -243,7 +243,7 @@ Here, if `us-west-2a` is not available, the second term will cause the pod to ru
          - matchExpressions: # OR
            - key: "topology.kubernetes.io/zone" # AND
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone" # AND
              operator: "NotIn"
              values: ["us-west-2b"]

--- a/website/content/en/v0.35/concepts/scheduling.md
+++ b/website/content/en/v0.35/concepts/scheduling.md
@@ -214,7 +214,7 @@ All examples below assume that the NodePool doesn't have constraints to prevent 
          - matchExpressions:
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "In"
              values: ["us-west-2b"]
@@ -225,7 +225,7 @@ Changing the second operator to `NotIn` would allow the pod to run in `us-west-2
 ```yaml
            - key: "topology.kubernetes.io/zone"
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone"
              operator: "NotIn"
              values: ["us-west-2b"]
@@ -243,7 +243,7 @@ Here, if `us-west-2a` is not available, the second term will cause the pod to ru
          - matchExpressions: # OR
            - key: "topology.kubernetes.io/zone" # AND
              operator: "In"
-             values: ["us-west-2a, us-west-2b"]
+             values: ["us-west-2a", "us-west-2b"]
            - key: "topology.kubernetes.io/zone" # AND
              operator: "NotIn"
              values: ["us-west-2b"]


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This change is to fix the quote mistake in topology zone value list in docs.
Different zone values need to be separate strings, thus should be quoted separately in the list.

**How was this change tested?**
This only includes the docs change. 

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.