### PR TITLE
chore: Correct security context to use `nonroot` user

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -59,8 +59,8 @@ spec:
       containers:
         - name: controller
           securityContext:
-            runAsUser: 65536
-            runAsGroup: 65536
+            runAsUser: 65532
+            runAsGroup: 65532
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -46,7 +46,7 @@ podDisruptionBudget:
   maxUnavailable: 1
 # -- SecurityContext for the pod.
 podSecurityContext:
-  fsGroup: 65536
+  fsGroup: 65532
 # -- PriorityClass name for the pod.
 priorityClassName: system-cluster-critical
 # -- Override the default termination grace period for the pod.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change corrects the `runAsUser` and `runAsGroup` to run using the `nonroot` user. This was previously mapping to another non-root, random user, but [wasn't within the valid set of UIDs on older linux kernels (65535)](https://www.baeldung.com/linux/user-ids-reserved-values#:~:text=integer.%20After%20the-,Linux%20kernel%20version%202.4,-%2C%20the%20upper%20limit). Additionally, distroless and scratch images use a standard "nonroot" user (65532) by default and give permission to certain filepaths on the image. Karpenter uses the `public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base` image by default, [which assigns file permission to user `65532`](https://github.com/aws/eks-distro-build-tooling/blob/main/eks-distro-base/Dockerfile.minimal-base#L57)

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.