### PR TITLE
test: Fix flake in patching out finalizers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.17.2
-	sigs.k8s.io/karpenter v0.35.1-0.20240307191015-7ab5eca34e53
+	sigs.k8s.io/karpenter v0.35.1-0.20240311230445-343eb7580913
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -757,8 +757,8 @@ sigs.k8s.io/controller-runtime v0.17.2 h1:FwHwD1CTUemg0pW2otk7/U5/i5m2ymzvOXdbeG
 sigs.k8s.io/controller-runtime v0.17.2/go.mod h1:+MngTvIQQQhfXtwfdGw/UOQ/aIaqsYywfCINOtwMO/s=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.35.1-0.20240307191015-7ab5eca34e53 h1:B2Hwd9cIdVg26iFUGG4H8ieqlYx8OMv172GZ26sOv9o=
-sigs.k8s.io/karpenter v0.35.1-0.20240307191015-7ab5eca34e53/go.mod h1:HcZ33DJe0gATRfcPoA+/9+bq6dTtkBbo/BoPQ3AImcM=
+sigs.k8s.io/karpenter v0.35.1-0.20240311230445-343eb7580913 h1:ldnc5SBfq/5lMXt1NSQMPr/ONvGwfoD6Cf/uCptFEGY=
+sigs.k8s.io/karpenter v0.35.1-0.20240311230445-343eb7580913/go.mod h1:DYnwDaoy2AhZwL2Ie96RGVu15+K6P5AJkSAtpPCRy8k=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -135,7 +135,7 @@ func (env *Environment) ExpectSettingsReplaced(vars ...v1.EnvVar) {
 
 	if !equality.Semantic.DeepEqual(d, stored) {
 		By("replacing environment variables for karpenter deployment")
-		Expect(env.Client.Patch(env.Context, d, client.MergeFrom(stored))).To(Succeed())
+		Expect(env.Client.Patch(env.Context, d, client.StrategicMergeFrom(stored))).To(Succeed())
 		env.EventuallyExpectKarpenterRestarted()
 	}
 }
@@ -159,7 +159,7 @@ func (env *Environment) ExpectSettingsOverridden(vars ...v1.EnvVar) {
 	}
 	if !equality.Semantic.DeepEqual(d, stored) {
 		By("overriding environment variables for karpenter deployment")
-		Expect(env.Client.Patch(env.Context, d, client.MergeFrom(stored))).To(Succeed())
+		Expect(env.Client.Patch(env.Context, d, client.StrategicMergeFrom(stored))).To(Succeed())
 		env.EventuallyExpectKarpenterRestarted()
 	}
 }
@@ -179,7 +179,7 @@ func (env *Environment) ExpectSettingsRemoved(vars ...v1.EnvVar) {
 	})
 	if !equality.Semantic.DeepEqual(d, stored) {
 		By("removing environment variables for karpenter deployment")
-		Expect(env.Client.Patch(env.Context, d, client.MergeFrom(stored))).To(Succeed())
+		Expect(env.Client.Patch(env.Context, d, client.StrategicMergeFrom(stored))).To(Succeed())
 		env.EventuallyExpectKarpenterRestarted()
 	}
 }
@@ -329,7 +329,7 @@ func (env *Environment) EventuallyExpectRollout(name, namespace string) {
 		"kubectl.kubernetes.io/restartedAt": time.Now().Format(time.RFC3339),
 	}
 	deploy.Spec.Template.Annotations = lo.Assign(deploy.Spec.Template.Annotations, restartedAtAnnotation)
-	Expect(env.Client.Patch(env.Context, deploy, client.MergeFrom(stored))).To(Succeed())
+	Expect(env.Client.Patch(env.Context, deploy, client.StrategicMergeFrom(stored))).To(Succeed())
 
 	By("waiting for the newly generated deployment to rollout")
 	Eventually(func(g Gomega) {
@@ -777,7 +777,7 @@ func (env *Environment) ExpectDaemonSetEnvironmentVariableUpdated(obj client.Obj
 		Expect(len(ds.Spec.Template.Spec.Containers)).To(BeNumerically("==", 1))
 		containers = append(containers, ds.Spec.Template.Spec.Containers[0].Name)
 	}
-	patch := client.MergeFrom(ds.DeepCopy())
+	patch := client.StrategicMergeFrom(ds.DeepCopy())
 	containerNames := sets.New(containers...)
 	for ci := range ds.Spec.Template.Spec.Containers {
 		c := &ds.Spec.Template.Spec.Containers[ci]
@@ -824,7 +824,7 @@ func (env *Environment) ForcePodsToSpread(nodes ...*v1.Node) {
 		Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).To(Succeed())
 		stored := node.DeepCopy()
 		node.Spec.Unschedulable = true
-		Expect(env.Client.Patch(env.Context, node, client.MergeFrom(stored))).To(Succeed())
+		Expect(env.Client.Patch(env.Context, node, client.StrategicMergeFrom(stored))).To(Succeed())
 		for _, pod := range nodePods[maxPodsPerNode:] {
 			env.ExpectDeleted(pod)
 		}
@@ -842,7 +842,7 @@ func (env *Environment) ForcePodsToSpread(nodes ...*v1.Node) {
 	for _, n := range nodes {
 		stored := n.DeepCopy()
 		n.Spec.Unschedulable = false
-		Expect(env.Client.Patch(env.Context, n, client.MergeFrom(stored))).To(Succeed())
+		Expect(env.Client.Patch(env.Context, n, client.StrategicMergeFrom(stored))).To(Succeed())
 	}
 }
 

--- a/test/suites/chaos/suite_test.go
+++ b/test/suites/chaos/suite_test.go
@@ -150,7 +150,7 @@ func (t *taintAdder) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err := t.kubeClient.Get(ctx, req.NamespacedName, node); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	mergeFrom := client.MergeFrom(node.DeepCopy())
+	mergeFrom := client.StrategicMergeFrom(node.DeepCopy())
 	taint := v1.Taint{
 		Key:    "test",
 		Value:  "true",

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -615,7 +615,7 @@ var _ = Describe("Drift", func() {
 				g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeTwo), nodeTwo)).To(Succeed())
 				stored := nodeTwo.DeepCopy()
 				nodeTwo.Spec.Taints = lo.Reject(nodeTwo.Spec.Taints, func(t v1.Taint, _ int) bool { return t.Key == "example.com/another-taint-2" })
-				g.Expect(env.Client.Patch(env.Context, nodeTwo, client.MergeFrom(stored))).To(Succeed())
+				g.Expect(env.Client.Patch(env.Context, nodeTwo, client.StrategicMergeFrom(stored))).To(Succeed())
 			}).Should(Succeed())
 		}
 		env.EventuallyExpectNotFound(pod, node)

--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -660,7 +660,7 @@ var _ = Describe("Expiration", func() {
 					g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).To(Succeed())
 					stored := node.DeepCopy()
 					node.Spec.Taints = lo.Reject(node.Spec.Taints, func(t v1.Taint, _ int) bool { return t.Key == "example.com/taint" })
-					g.Expect(env.Client.Patch(env.Context, node, client.MergeFrom(stored))).To(Succeed())
+					g.Expect(env.Client.Patch(env.Context, node, client.StrategicMergeFrom(stored))).To(Succeed())
 				}
 			}).Should(Succeed())
 

--- a/test/suites/integration/emptiness_test.go
+++ b/test/suites/integration/emptiness_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Emptiness", func() {
 		By("making the nodeclaim empty")
 		persisted := deployment.DeepCopy()
 		deployment.Spec.Replicas = ptr.Int32(0)
-		Expect(env.Client.Patch(env, deployment, client.MergeFrom(persisted))).To(Succeed())
+		Expect(env.Client.Patch(env, deployment, client.StrategicMergeFrom(persisted))).To(Succeed())
 
 		env.EventuallyExpectEmpty(nodeClaim)
 

--- a/test/suites/integration/storage_test.go
+++ b/test/suites/integration/storage_test.go
@@ -241,7 +241,7 @@ func ExpectSetEBSDriverLimit(limit int) {
 		containers[i].Args = append(containers[i].Args, fmt.Sprintf("--volume-attach-limit=%d", limit))
 		break
 	}
-	Expect(env.Client.Patch(env.Context, ds, client.MergeFrom(stored))).To(Succeed())
+	Expect(env.Client.Patch(env.Context, ds, client.StrategicMergeFrom(stored))).To(Succeed())
 }
 
 func ExpectRemoveEBSDriverLimit() {
@@ -260,5 +260,5 @@ func ExpectRemoveEBSDriverLimit() {
 		})
 		break
 	}
-	Expect(env.Client.Patch(env.Context, ds, client.MergeFrom(stored))).To(Succeed())
+	Expect(env.Client.Patch(env.Context, ds, client.StrategicMergeFrom(stored))).To(Succeed())
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change converts all `client.MergeFrom` calls in the Karpenter E2E testing to `client.StrategicMergeFrom`. This [doc](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-strategic-merge-patch-to-update-a-deployment) in the upstream Kubernetes documentation details how using this patch strategy improves consistency of calls for lists. 

E2E tests were failing (like [here](https://github.com/aws/karpenter-provider-aws/actions/runs/8223237781/job/22485698904)) 

```
[FAILED] Expected success, but got an error:
      <*errors.StatusError | 0xc00182c6e0>: 
      Node "ip-192-168-1-200.us-east-2.compute.internal" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{"karpenter.sh/termination"}
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Node \"ip-192-168-1-200.us-east-2.compute.internal\" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{\"karpenter.sh/termination\"}",
              Reason: "Invalid",
              Details: {
                  Name: "ip-192-168-1-200.us-east-2.compute.internal",
                  Group: "",
                  Kind: "Node",
                  UID: "",
                  Causes: [
                      {
                          Type: "FieldValueForbidden",
                          Message: "Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{\"karpenter.sh/termination\"}",
                          Field: "metadata.finalizers",
                      },
                      {
                          Type: "FieldValueForbidden",
                          Message: "Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{\"karpenter.sh/termination\"}",
                          Field: "metadata.finalizers",
                      },
                  ],
                  RetryAfterSeconds: 0,
              },
              Code: 422,
          },
      }
  In [It] at: /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/expiration/suite_test.go:257 @ 03/10/24 16:45:43.159
  < Exit [It] should respect budgets for empty expiration - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/expiration/suite_test.go:181 @ 03/10/24 16:45:43.159 (1m9.272s)
```

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.