### PR TITLE
fix: Fix InstanceType cache invalidation on ICE eviction 

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -36,4 +36,8 @@ const (
 const (
 	// DefaultCleanupInterval triggers cache cleanup (lazy eviction) at this interval.
 	DefaultCleanupInterval = time.Minute
+	// UnavailableOfferingsCleanupInterval triggers cache cleanup (lazy eviction) at this interval.
+	// We drop the cleanup interval down for the ICE cache to get quicker reactivity to offerings
+	// that become available after they get evicted from the cache
+	UnavailableOfferingsCleanupInterval = time.Second * 10
 )

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -35,10 +35,14 @@ type UnavailableOfferings struct {
 }
 
 func NewUnavailableOfferings() *UnavailableOfferings {
-	return &UnavailableOfferings{
-		cache:  cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
+	uo := &UnavailableOfferings{
+		cache:  cache.New(UnavailableOfferingsTTL, UnavailableOfferingsCleanupInterval),
 		SeqNum: 0,
 	}
+	uo.cache.OnEvicted(func(_ string, _ interface{}) {
+		atomic.AddUint64(&uo.SeqNum, 1)
+	})
+	return uo
 }
 
 // IsUnavailable returns true if the offering appears in the cache


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change fixes a bug that causes us to keep ICEd offerings in the cache for beyond their unavailability cache interval (up to 8m using the current code [3m unavailable offering expiry + 5m instance type expiry]). The current code handles the addition of unavailable offerings to the cache, but it doesn't handle the eviction from the cache. This update ensures that cache eviction triggers the sequence number to increase. 

This also drops the cleanup interval for the cache so that we react quicker to this eviction.

### Before PR (no cache eviction handling) ~4.5m re-availability

```
{"level":"INFO","time":"2024-03-12T07:02:54.767Z","logger":"controller.interruption","message":"initiating delete from interruption message","commit":"1d7f91c-dirty","queue":"joinnis-karpenter-demo","messageKind":"SpotInterruptionKind","nodeclaim":"default-7qs7l","action":"CordonAndDrain","node":"ip-192-168-133-190.us-west-2.compute.internal"}
{"level":"INFO","time":"2024-03-12T07:02:54.992Z","logger":"controller.node.termination","message":"got new cache key","commit":"1d7f91c-dirty","node":"ip-192-168-133-190.us-west-2.compute.internal","id":"i-05671079e1e807cc0","key":"1-1-1-55e10a19da109e52-a8c7f832281a39c5-0000000000000000-AL2"}
{"level":"DEBUG","time":"2024-03-12T07:03:22.176Z","logger":"controller.disruption","message":"discovered subnets","commit":"1d7f91c-dirty","subnets":["subnet-01095f4c202083b01 (us-west-2a)","subnet-01a75589aa6237be1 (us-west-2b)","subnet-060f9fb17941d125c (us-west-2c)","subnet-0e60f26cf52c5a6df (us-west-2c)","subnet-0c89532267e680e6f (us-west-2a)","subnet-09d3d3e0bd7f68ee9 (us-west-2b)"]}
{"level":"INFO","time":"2024-03-12T07:03:22.176Z","logger":"controller.disruption","message":"got new cache key","commit":"1d7f91c-dirty","key":"1-1-1-6f0db7749c51be05-a8c7f832281a39c5-0000000000000000-AL2"}
{"level":"INFO","time":"2024-03-12T07:06:22.521Z","logger":"controller.disruption","message":"got new cache key","commit":"1d7f91c-dirty","key":"1-1-1-92036e12e424db69-a8c7f832281a39c5-0000000000000000-AL2"}
{"level":"INFO","time":"2024-03-12T07:06:25.991Z","logger":"controller.provisioner","message":"found provisionable pod(s)","commit":"1d7f91c-dirty","pods":"default/inflate-6cf94b79ff-jqhxw","duration":"9.652202ms"}
{"level":"INFO","time":"2024-03-12T07:06:25.991Z","logger":"controller.provisioner","message":"computed new nodeclaim(s) to fit pod(s)","commit":"1d7f91c-dirty","nodeclaims":1,"pods":1}
{"level":"INFO","time":"2024-03-12T07:06:26.019Z","logger":"controller.provisioner","message":"created nodeclaim","commit":"1d7f91c-dirty","nodepool":"default","nodeclaim":"default-t6nxg","requests":{"cpu":"1150m","memory":"100Mi","pods":"4"},"instance-types":"c5.large"}
```

### After PR (with cache eviction handling) - ~3m re-availability

```
{"level":"DEBUG","time":"2024-03-12T07:34:23.039Z","logger":"controller.interruption","message":"removing offering from offerings","commit":"4b5d79b-dirty","queue":"joinnis-karpenter-demo","messageKind":"SpotInterruptionKind","nodeclaim":"default-dzrj9","action":"CordonAndDrain","node":"ip-192-168-42-5.us-west-2.compute.internal","reason":"SpotInterruptionKind","instance-type":"c5.xlarge","zone":"us-west-2a","capacity-type":"spot","ttl":"3m0s"}
{"level":"INFO","time":"2024-03-12T07:34:23.061Z","logger":"controller.interruption","message":"initiating delete from interruption message","commit":"4b5d79b-dirty","queue":"joinnis-karpenter-demo","messageKind":"SpotInterruptionKind","nodeclaim":"default-dzrj9","action":"CordonAndDrain","node":"ip-192-168-42-5.us-west-2.compute.internal"}
{"level":"INFO","time":"2024-03-12T07:34:23.297Z","logger":"controller.node.termination","message":"got new cache key","commit":"4b5d79b-dirty","node":"ip-192-168-42-5.us-west-2.compute.internal","id":"i-05aa6eb54c305cb52","key":"1-1-2-ed61da4234eb805d-a8c7f832281a39c5-0000000000000000--AL2-cbf29ce484222325-0000000000000000-0000000000000000"}
{"level":"INFO","time":"2024-03-12T07:37:31.167Z","logger":"controller.disruption","message":"got new cache key","commit":"4b5d79b-dirty","key":"1-1-4-ed61da4234eb805d-a8c7f832281a39c5-0000000000000000--AL2-cbf29ce484222325-0000000000000000-0000000000000000"}
{"level":"INFO","time":"2024-03-12T07:37:34.979Z","logger":"controller.provisioner","message":"found provisionable pod(s)","commit":"4b5d79b-dirty","pods":"default/inflate-6cf94b79ff-mgwm5","duration":"19.0521ms"}
{"level":"INFO","time":"2024-03-12T07:37:34.979Z","logger":"controller.provisioner","message":"computed new nodeclaim(s) to fit pod(s)","commit":"4b5d79b-dirty","nodeclaims":1,"pods":1}
```

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.