### PR TITLE
chore: Added ArtifactHub Helm metadata

### DIFF
--- a/charts/karpenter-crd/artifacthub-repo.yaml
+++ b/charts/karpenter-crd/artifacthub-repo.yaml
@@ -1,0 +1,7 @@
+repositoryID: fda7ffc4-4672-4218-8264-321ec3b4e3cc
+owners: []
+#   - name: awsadmin1
+#     email: artifacthub1@aws.com
+ignore:
+  - name: karpenter-crd
+    version: (?:^\d+$)|(?:^v?0\.0\.0)|(?:^v?\d+\-)

--- a/charts/karpenter/artifacthub-repo.yaml
+++ b/charts/karpenter/artifacthub-repo.yaml
@@ -1,0 +1,7 @@
+repositoryID: 356cb63f-9ee3-4956-9c20-003e416715c7
+owners: []
+#   - name: awsadmin1
+#     email: artifacthub1@aws.com
+ignore:
+  - name: karpenter
+    version: (?:^\d+$)|(?:^v?0\.0\.0)|(?:^v?\d+\-)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR adds Artifact Hub metadata to the Helm charts which will flag them as being verified and will support removing the invalid releases from being processed (this could/should also be handled manually or with a cleanup rule?). It also adds the placeholder to set the email address of the person claiming the repository for AWS (see #5306).

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.