### PR TITLE
chore: Add event on nodeClaim for instance type filtering

### DIFF
--- a/pkg/cloudprovider/events/events.go
+++ b/pkg/cloudprovider/events/events.go
@@ -15,7 +15,11 @@ limitations under the License.
 package events
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter-provider-aws/pkg/utils"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/events"
@@ -36,5 +40,15 @@ func NodeClaimFailedToResolveNodeClass(nodeClaim *v1beta1.NodeClaim) events.Even
 		Type:           v1.EventTypeWarning,
 		Message:        "Failed resolving NodeClass",
 		DedupeValues:   []string{string(nodeClaim.UID)},
+	}
+}
+
+func FilteredInstanceTypes(nodeClaim *v1beta1.NodeClaim, filteredITsRequirement int, filteredExoticITs int, filteredExpensiveSpot int, filteredITs []string) events.Event {
+	return events.Event{
+		InvolvedObject: nodeClaim,
+		Type:           v1.EventTypeNormal,
+		Message: fmt.Sprintf("Filtered %d instance types on requirements, filtered %d instance types from exotic instance types, filtered %d instance types with spot offerings more expensive than cheapest on-demand. Remaining instance types:: %s",
+			filteredITsRequirement, filteredExoticITs, filteredExpensiveSpot, utils.PrettySlice(filteredITs, 5)),
+		DedupeValues: []string{string(nodeClaim.UID)},
 	}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -175,6 +175,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		instanceTypeProvider,
 		subnetProvider,
 		launchTemplateProvider,
+		operator.EventRecorder,
 	)
 
 	lo.Must0(operator.Manager.GetFieldIndexer().IndexField(ctx, &corev1beta1.NodeClaim{}, "spec.nodeClassRef.name", func(o client.Object) []string {

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"net"
 
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/karpenter/pkg/events"
+
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -130,6 +133,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 			instanceTypesProvider,
 			subnetProvider,
 			launchTemplateProvider,
+			events.NewRecorder(&record.FakeRecorder{}),
 		)
 
 	return &Environment{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
We filter instance types at various levels but currently don't log it which makes it difficult to debug in case of any errors. In this PR we instead added an event that would describe the filtering that we do.

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.