### PR TITLE
docs: fix kompat tools to support semantic versioning correctly

### DIFF
--- a/tools/kompat/pkg/kompat/kompat.go
+++ b/tools/kompat/pkg/kompat/kompat.go
@@ -195,7 +195,7 @@ func (k Kompat) Markdown(_ ...Options) string {
 		if c.MaxK8sVersion == "" || c.MinK8sVersion == c.MaxK8sVersion {
 			headers = append(headers, fmt.Sprintf("\\>= `%s`", c.MinK8sVersion))
 		} else {
-			headers = append(headers, fmt.Sprintf("`%s` - `%s`", c.MinK8sVersion, c.MaxK8sVersion))
+			headers = append(headers, fmt.Sprintf("\\>= `%s` \\<= `%s`", c.MinK8sVersion, c.MaxK8sVersion))
 		}
 		data = append(data, c.AppVersion)
 	}
@@ -368,7 +368,7 @@ func semverRange(semvers []string, allSemvers ...string) string {
 			return fmt.Sprintf("\\>= %s", strings.ReplaceAll(semvers[0], ".x", ""))
 		}
 	}
-	return fmt.Sprintf("%s - %s", semvers[0], semvers[len(semvers)-1])
+	return fmt.Sprintf("\\>= %s \\<= %s", strings.ReplaceAll(semvers[0], ".x", ""), strings.ReplaceAll(semvers[len(semvers)-1], ".x", ""))
 }
 
 func sortSemvers(semvers []string) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5841  <!-- issue number -->

**Description**
Fix kompat tool to generate correct semantic versioning for Karpenter/Kubernetes compatibility matrix

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [x] Yes, issue opened: #5841  <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.