### PR TITLE
docs: drop 1.29 Ubuntu warning

### DIFF
--- a/website/content/en/docs/upgrading/compatibility.md
+++ b/website/content/en/docs/upgrading/compatibility.md
@@ -22,10 +22,6 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 [comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
 
 {{% alert title="Note" color="warning" %}}
-The Ubuntu EKS optimized AMI has moved from 20.04 to 22.04 for Kubernetes 1.29+. This new AMI version is __not currently__ supported for users relying on AMI auto-discovery with the Ubuntu AMI family. More details can be found in this [GitHub issue](https://github.com/aws/karpenter-provider-aws/issues/5572). Please review this issue before upgrading to Kubernetes 1.29 if you are using the Ubuntu AMI family. Upgrading to 1.29 without making any changes to your EC2NodeClass will result in Karpenter being unable to create new nodes.
-{{% /alert %}}
-
-{{% alert title="Note" color="warning" %}}
 Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
 - `matchLabelKeys`
 - `nodeAffinityPolicy`

--- a/website/content/en/preview/upgrading/compatibility.md
+++ b/website/content/en/preview/upgrading/compatibility.md
@@ -22,10 +22,6 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 [comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
 
 {{% alert title="Note" color="warning" %}}
-The Ubuntu EKS optimized AMI has moved from 20.04 to 22.04 for Kubernetes 1.29+. This new AMI version is __not currently__ supported for users relying on AMI auto-discovery with the Ubuntu AMI family. More details can be found in this [GitHub issue](https://github.com/aws/karpenter-provider-aws/issues/5572). Please review this issue before upgrading to Kubernetes 1.29 if you are using the Ubuntu AMI family. Upgrading to 1.29 without making any changes to your EC2NodeClass will result in Karpenter being unable to create new nodes.
-{{% /alert %}}
-
-{{% alert title="Note" color="warning" %}}
 Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
 - `matchLabelKeys`
 - `nodeAffinityPolicy`

--- a/website/content/en/v0.34/upgrading/compatibility.md
+++ b/website/content/en/v0.34/upgrading/compatibility.md
@@ -22,10 +22,6 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 [comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
 
 {{% alert title="Note" color="warning" %}}
-The Ubuntu EKS optimized AMI has moved from 20.04 to 22.04 for Kubernetes 1.29+. This new AMI version is __not currently__ supported for users relying on AMI auto-discovery with the Ubuntu AMI family. More details can be found in this [GitHub issue](https://github.com/aws/karpenter-provider-aws/issues/5572). Please review this issue before upgrading to Kubernetes 1.29 if you are using the Ubuntu AMI family. Upgrading to 1.29 without making any changes to your EC2NodeClass will result in Karpenter being unable to create new nodes.
-{{% /alert %}}
-
-{{% alert title="Note" color="warning" %}}
 Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
 - `matchLabelKeys`
 - `nodeAffinityPolicy`

--- a/website/content/en/v0.35/upgrading/compatibility.md
+++ b/website/content/en/v0.35/upgrading/compatibility.md
@@ -22,10 +22,6 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 [comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
 
 {{% alert title="Note" color="warning" %}}
-The Ubuntu EKS optimized AMI has moved from 20.04 to 22.04 for Kubernetes 1.29+. This new AMI version is __not currently__ supported for users relying on AMI auto-discovery with the Ubuntu AMI family. More details can be found in this [GitHub issue](https://github.com/aws/karpenter-provider-aws/issues/5572). Please review this issue before upgrading to Kubernetes 1.29 if you are using the Ubuntu AMI family. Upgrading to 1.29 without making any changes to your EC2NodeClass will result in Karpenter being unable to create new nodes.
-{{% /alert %}}
-
-{{% alert title="Note" color="warning" %}}
 Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
 - `matchLabelKeys`
 - `nodeAffinityPolicy`


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Removes the warning for the Ubuntu AMI family and EKS 1.29. Ubuntu has since made 20.04 available on EKS 1.29 so users can upgrade safely from 1.28. 

**How was this change tested?**
N/A

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.