### PR TITLE
fix:  create tag script  error (InvalidID) when multiple sunbets for eks nodegroup

### DIFF
--- a/website/content/en/docs/getting-started/migrating-from-cas/scripts/step05-tag-subnets.sh
+++ b/website/content/en/docs/getting-started/migrating-from-cas/scripts/step05-tag-subnets.sh
@@ -1,6 +1,6 @@
 for NODEGROUP in $(aws eks list-nodegroups --cluster-name "${CLUSTER_NAME}" --query 'nodegroups' --output text); do
     aws ec2 create-tags \
         --tags "Key=karpenter.sh/discovery,Value=${CLUSTER_NAME}" \
-        --resources "$(aws eks describe-nodegroup --cluster-name "${CLUSTER_NAME}" \
-        --nodegroup-name "${NODEGROUP}" --query 'nodegroup.subnets' --output text )"
+        --resources $(aws eks describe-nodegroup --cluster-name "${CLUSTER_NAME}" \
+        --nodegroup-name "${NODEGROUP}" --query 'nodegroup.subnets' --output text )
 done

--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step05-tag-subnets.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step05-tag-subnets.sh
@@ -1,6 +1,6 @@
 for NODEGROUP in $(aws eks list-nodegroups --cluster-name "${CLUSTER_NAME}" --query 'nodegroups' --output text); do
     aws ec2 create-tags \
         --tags "Key=karpenter.sh/discovery,Value=${CLUSTER_NAME}" \
-        --resources "$(aws eks describe-nodegroup --cluster-name "${CLUSTER_NAME}" \
-        --nodegroup-name "${NODEGROUP}" --query 'nodegroup.subnets' --output text )"
+        --resources $(aws eks describe-nodegroup --cluster-name "${CLUSTER_NAME}" \
+        --nodegroup-name "${NODEGROUP}" --query 'nodegroup.subnets' --output text )
 done

--- a/website/content/en/v0.35/getting-started/migrating-from-cas/scripts/step05-tag-subnets.sh
+++ b/website/content/en/v0.35/getting-started/migrating-from-cas/scripts/step05-tag-subnets.sh
@@ -1,6 +1,6 @@
 for NODEGROUP in $(aws eks list-nodegroups --cluster-name "${CLUSTER_NAME}" --query 'nodegroups' --output text); do
     aws ec2 create-tags \
         --tags "Key=karpenter.sh/discovery,Value=${CLUSTER_NAME}" \
-        --resources "$(aws eks describe-nodegroup --cluster-name "${CLUSTER_NAME}" \
-        --nodegroup-name "${NODEGROUP}" --query 'nodegroup.subnets' --output text )"
+        --resources $(aws eks describe-nodegroup --cluster-name "${CLUSTER_NAME}" \
+        --nodegroup-name "${NODEGROUP}" --query 'nodegroup.subnets' --output text )
 done


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

The output of the subcommand should not be wrapped in `$()`. This means that the output of the subcommand will be treated as multiple separate arguments. Therefore, if the subcommand outputs multiple subnet IDs separated by spaces, they will be treated as separate arguments passed to `--resources`. This resolves the previous "InvalidID" error if we have multiple subnets for eks nodegroup.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.