### PR TITLE
ci: revert MNG and SQS diagnostic changes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -172,21 +172,9 @@ jobs:
           role: ${{ vars.CI_ROLE_NAME }}
           region: ${{ inputs.region }}
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
-      # In the case of failure, check if the managed node group is unhealthy. If so, do not clean up cluster for further investigation.
-      # TODO: @jmdeal remove after investigation is complete
-      - name: detect unhealthy mng
-        id: detect-unhealthy-mng
-        shell: bash
-        if: failure() || cancelled()
-        run: |
-          if ! kubectl get nodes -l eks.amazonaws.com/nodegroup -oyaml | yq ".items[].status.conditions" | grep -q "KubeletNotReady"; then
-            echo UNHEALTHY="false" >> "$GITHUB_OUTPUT"
-          else
-            echo UNHEALTHY="true" >> "$GITHUB_OUTPUT"
-          fi
       - name: cleanup karpenter and cluster '${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}' resources
         uses: ./.github/actions/e2e/cleanup
-        if: always() && inputs.cleanup && (steps.detect-unhealthy-mng.conclusion == 'skipped' || steps.detect-unhealthy-mng.outputs.UNHEALTHY == 'false')
+        if: always() && inputs.cleanup
         with:
           account_id: ${{ vars.CI_ACCOUNT_ID }}
           role: ${{ vars.CI_ROLE_NAME }}

--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -34,10 +34,7 @@ import (
 
 const sweeperCleanedResourcesTableName = "sweeperCleanedResources"
 
-var excludedClusters = []string{
-	// TODO: @jmdeal remove after SQS investigation
-	"soak-periodic-46287782",
-}
+var excludedClusters = []string{}
 
 func main() {
 	expiration := flag.String("expiration", "12h", "define the expirationTTL of the resources")

--- a/test/hack/soak/get_clusters.go
+++ b/test/hack/soak/get_clusters.go
@@ -36,9 +36,7 @@ type cluster struct {
 
 const expirationTTL = time.Hour * 168 // 7 days
 
-var excludedClustersCleanup = []string{
-	"soak-periodic-46287782",
-}
+var excludedClustersCleanup = []string{}
 
 func main() {
 	ctx := context.Background()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Reverts the changes for the MNG creation failure investigation and removes the soak cluster from the cleanup cluster exclusion list.

Explicitly reverts the following PR:
- https://github.com/aws/karpenter-provider-aws/pull/5746

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.