### PR TITLE
ci: Exclude `soak-periodic-2213793` Cluster from cleanup for Windows investigation

### DIFF
--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -34,7 +34,9 @@ import (
 
 const sweeperCleanedResourcesTableName = "sweeperCleanedResources"
 
-var excludedClusters = []string{}
+var excludedClusters = []string{
+	"soak-periodic-2213793",
+}
 
 func main() {
 	expiration := flag.String("expiration", "12h", "define the expirationTTL of the resources")
@@ -82,7 +84,7 @@ func main() {
 		// If there's no cluster defined, clean up all expired resources. otherwise, only cleanup the resources associated with the cluster
 		if lo.FromPtr(clusterName) == "" {
 			ids, err = resourceTypes[i].GetExpired(ctx, expirationTime, excludedClusters)
-		} else if !slices.Contains(excludedClusters, *clusterName) {
+		} else if !slices.Contains(excludedClusters, lo.FromPtr(clusterName)) {
 			ids, err = resourceTypes[i].Get(ctx, lo.FromPtr(clusterName))
 		}
 		if err != nil {

--- a/test/hack/resource/pkg/resourcetypes/instance.go
+++ b/test/hack/resource/pkg/resourcetypes/instance.go
@@ -63,7 +63,7 @@ func (i *Instance) GetExpired(ctx context.Context, expirationTime time.Time, exc
 		for _, res := range out.Reservations {
 			for _, instance := range res.Instances {
 				clusterName, found := lo.Find(instance.Tags, func(tag ec2types.Tag) bool {
-					return *tag.Key == k8sClusterTag
+					return *tag.Key == karpenterTestingTag
 				})
 				if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
 					continue

--- a/test/hack/resource/pkg/resourcetypes/securitygroup.go
+++ b/test/hack/resource/pkg/resourcetypes/securitygroup.go
@@ -60,7 +60,7 @@ func (sg *SecurityGroup) GetExpired(ctx context.Context, expirationTime time.Tim
 
 		for _, sgroup := range out.SecurityGroups {
 			clusterName, found := lo.Find(sgroup.Tags, func(tag ec2types.Tag) bool {
-				return *tag.Key == k8sClusterTag
+				return *tag.Key == karpenterTestingTag
 			})
 			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
 				continue

--- a/test/hack/resource/pkg/resourcetypes/stack.go
+++ b/test/hack/resource/pkg/resourcetypes/stack.go
@@ -57,7 +57,7 @@ func (s *Stack) GetExpired(ctx context.Context, expirationTime time.Time, exclud
 		})
 		for _, stack := range stacks {
 			clusterName, found := lo.Find(stack.Tags, func(tag cloudformationtypes.Tag) bool {
-				return *tag.Key == k8sClusterTag
+				return *tag.Key == karpenterTestingTag
 			})
 			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
 				continue


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- We need to some investigation on flakey windows test failures, so we will leave the cluster around.

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.