### PR TITLE
cherrypick(v0.32): fix: include resource.Quantity in launch template cache key

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -145,7 +145,20 @@ func (p *Provider) Invalidate(ctx context.Context, ltName string, ltID string) {
 }
 
 func launchTemplateName(options *amifamily.LaunchTemplate) string {
-	hash, err := hashstructure.Hash(options, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	// TODO: jmdeal@ remove custom hash struct once BlockDeviceMapping and KubeletConfiguration hashing is fixed, only hash Options
+	volumeSizeHash, _ := hashstructure.Hash(lo.Reduce(options.BlockDeviceMappings, func(agg string, block *v1beta1.BlockDeviceMapping, _ int) string {
+		return fmt.Sprintf("%s/%s", agg, block.EBS.VolumeSize)
+	}, ""), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	hashStruct := struct {
+		Options               *amifamily.LaunchTemplate
+		VolumeSizeHash        string
+		ReservedResourcesHash string
+	}{
+		Options:               options,
+		VolumeSizeHash:        fmt.Sprint(volumeSizeHash),
+		ReservedResourcesHash: options.UserData.HashReservedResources(),
+	}
+	hash, err := hashstructure.Hash(hashStruct, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	if err != nil {
 		panic(fmt.Sprintf("hashing launch template, %s", err))
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Cherry pick of https://github.com/aws/karpenter-provider-aws/pull/5882. Drops the capacity type caching since https://github.com/aws/karpenter-provider-aws/pull/4911 isn't included in v0.32.x.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.