### PR TITLE
fix: filter out a1 instance types for AL2023

### DIFF
--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -46,7 +46,7 @@ instanceTypeTestData() {
   GENERATED_FILE="pkg/fake/zz_generated.describe_instance_types.go"
 
   go run hack/code/instancetype_testdata_gen/main.go --out-file ${GENERATED_FILE} \
-    --instance-types t3.large,m5.large,m5.xlarge,p3.8xlarge,g4dn.8xlarge,c6g.large,inf1.2xlarge,inf1.6xlarge,trn1.2xlarge,m5.metal,dl1.24xlarge,m6idn.32xlarge,t4g.small,t4g.xlarge,t4g.medium
+    --instance-types t3.large,m5.large,m5.xlarge,p3.8xlarge,g4dn.8xlarge,c6g.large,inf1.2xlarge,inf1.6xlarge,trn1.2xlarge,m5.metal,dl1.24xlarge,m6idn.32xlarge,t4g.small,t4g.xlarge,t4g.medium,a1.large
 
   checkForUpdates "${GENERATED_FILE}"
 }

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -551,6 +551,18 @@ func (e *EC2API) DescribeInstanceTypeOfferingsWithContext(_ context.Context, _ *
 	return &ec2.DescribeInstanceTypeOfferingsOutput{
 		InstanceTypeOfferings: []*ec2.InstanceTypeOffering{
 			{
+				InstanceType: aws.String("a1.large"),
+				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("a1.large"),
+				Location:     aws.String("test-zone-1b"),
+			},
+			{
+				InstanceType: aws.String("a1.large"),
+				Location:     aws.String("test-zone-1c"),
+			},
+			{
 				InstanceType: aws.String("m5.large"),
 				Location:     aws.String("test-zone-1a"),
 			},

--- a/pkg/fake/zz_generated.describe_instance_types.go
+++ b/pkg/fake/zz_generated.describe_instance_types.go
@@ -28,6 +28,37 @@ import (
 var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 	InstanceTypes: []*ec2.InstanceTypeInfo{
 		{
+			InstanceType:                  aws.String("a1.large"),
+			SupportedUsageClasses:         aws.StringSlice([]string{"on-demand", "spot"}),
+			SupportedVirtualizationTypes:  aws.StringSlice([]string{"hvm"}),
+			BurstablePerformanceSupported: aws.Bool(false),
+			BareMetal:                     aws.Bool(false),
+			Hypervisor:                    aws.String("nitro"),
+			ProcessorInfo: &ec2.ProcessorInfo{
+				Manufacturer:           aws.String("AWS"),
+				SupportedArchitectures: aws.StringSlice([]string{"arm64"}),
+			},
+			VCpuInfo: &ec2.VCpuInfo{
+				DefaultCores: aws.Int64(2),
+				DefaultVCpus: aws.Int64(2),
+			},
+			MemoryInfo: &ec2.MemoryInfo{
+				SizeInMiB: aws.Int64(4096),
+			},
+			NetworkInfo: &ec2.NetworkInfo{
+				MaximumNetworkInterfaces:     aws.Int64(3),
+				Ipv4AddressesPerInterface:    aws.Int64(10),
+				EncryptionInTransitSupported: aws.Bool(false),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(3),
+					},
+				},
+			},
+		},
+		{
 			InstanceType:                  aws.String("c6g.large"),
 			SupportedUsageClasses:         aws.StringSlice([]string{"on-demand", "spot"}),
 			SupportedVirtualizationTypes:  aws.StringSlice([]string{"hvm"}),

--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -166,6 +166,10 @@ Refer to the [NodePool docs]({{<ref "./nodepools" >}}) for settings applicable t
 
 AMIFamily is a required field, dictating both the default bootstrapping logic for nodes provisioned through this `EC2NodeClass` but also selecting a group of recommended, latest AMIs by default. Currently, Karpenter supports `amiFamily` values `AL2`, `AL2023`, `Bottlerocket`, `Ubuntu`, `Windows2019`, `Windows2022` and `Custom`. GPUs are only supported by default with `AL2` and `Bottlerocket`. The `AL2` amiFamily does not support ARM64 GPU instance types unless you specify custom [`amiSelectorTerms`]({{<ref "#specamiselectorterms" >}}). Default bootstrapping logic is shown below for each of the supported families.
 
+{{% alert title="Note" color="primary" %}}
+AL2023 AMIs do not support the `a1` instance family. These instances are automatically filtered out when the `AL2023` AMI family is selected. Refer to the [AL2023 System Requirements Doc](https://docs.aws.amazon.com/linux/al2023/ug/system-requirements.html) for more details.
+{{% /alert %}}
+
 ### AL2
 
 ```bash

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -166,6 +166,10 @@ Refer to the [NodePool docs]({{<ref "./nodepools" >}}) for settings applicable t
 
 AMIFamily is a required field, dictating both the default bootstrapping logic for nodes provisioned through this `EC2NodeClass` but also selecting a group of recommended, latest AMIs by default. Currently, Karpenter supports `amiFamily` values `AL2`, `AL2023`, `Bottlerocket`, `Ubuntu`, `Windows2019`, `Windows2022` and `Custom`. GPUs are only supported by default with `AL2` and `Bottlerocket`. The `AL2` amiFamily does not support ARM64 GPU instance types unless you specify custom [`amiSelectorTerms`]({{<ref "#specamiselectorterms" >}}). Default bootstrapping logic is shown below for each of the supported families.
 
+{{% alert title="Note" color="primary" %}}
+AL2023 AMIs do not support the `a1` instance family. These instances are automatically filtered out when the `AL2023` AMI family is selected. Refer to the [AL2023 System Requirements Doc](https://docs.aws.amazon.com/linux/al2023/ug/system-requirements.html) for more details.
+{{% /alert %}}
+
 ### AL2
 
 ```bash

--- a/website/content/en/v0.35/concepts/nodeclasses.md
+++ b/website/content/en/v0.35/concepts/nodeclasses.md
@@ -166,6 +166,10 @@ Refer to the [NodePool docs]({{<ref "./nodepools" >}}) for settings applicable t
 
 AMIFamily is a required field, dictating both the default bootstrapping logic for nodes provisioned through this `EC2NodeClass` but also selecting a group of recommended, latest AMIs by default. Currently, Karpenter supports `amiFamily` values `AL2`, `AL2023`, `Bottlerocket`, `Ubuntu`, `Windows2019`, `Windows2022` and `Custom`. GPUs are only supported by default with `AL2` and `Bottlerocket`. The `AL2` amiFamily does not support ARM64 GPU instance types unless you specify custom [`amiSelectorTerms`]({{<ref "#specamiselectorterms" >}}). Default bootstrapping logic is shown below for each of the supported families.
 
+{{% alert title="Note" color="primary" %}}
+AL2023 AMIs do not support the `a1` instance family. These instances are automatically filtered out when the `AL2023` AMI family is selected. Refer to the [AL2023 System Requirements Doc](https://docs.aws.amazon.com/linux/al2023/ug/system-requirements.html) for more details.
+{{% /alert %}}
+
 ### AL2
 
 ```bash


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a filter in the instance type provider to remove incompatible instance types from the cloudprovider GetInstanceTypes call. Specifically, this PR adds a filter for the a1 instance family when the EC2NodeClass is using the AL2023 AMI family. AL2023 AMIs are explicitly incompatible with the instance family, and due to it being an architectural requirement this will not change in the future. 

ref: https://docs.aws.amazon.com/linux/al2023/ug/system-requirements.html

**How was this change tested?**
`make test`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.