### PR TITLE
chore: Use "${KarpenterNodeRole.Arn}" in policy definition

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -202,7 +202,7 @@ Resources:
             {
               "Sid": "AllowPassingInstanceRole",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+              "Resource": "${KarpenterNodeRole.Arn}",
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -363,7 +363,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 {
   "Sid": "AllowPassingInstanceRole",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+  "Resource": "${KarpenterNodeRole.Arn}",
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -202,7 +202,7 @@ Resources:
             {
               "Sid": "AllowPassingInstanceRole",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+              "Resource": "${KarpenterNodeRole.Arn}",
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -363,7 +363,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 {
   "Sid": "AllowPassingInstanceRole",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+  "Resource": "${KarpenterNodeRole.Arn}",
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -185,7 +185,7 @@ Resources:
             {
               "Sid": "AllowPassingInstanceRole",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+              "Resource": "${KarpenterNodeRole.Arn}",
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {

--- a/website/content/en/v0.32/reference/cloudformation.md
+++ b/website/content/en/v0.32/reference/cloudformation.md
@@ -337,7 +337,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 {
   "Sid": "AllowPassingInstanceRole",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+  "Resource": "${KarpenterNodeRole.Arn}",
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {

--- a/website/content/en/v0.33/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.33/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -186,7 +186,7 @@ Resources:
             {
               "Sid": "AllowPassingInstanceRole",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+              "Resource": "${KarpenterNodeRole.Arn}",
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {

--- a/website/content/en/v0.33/reference/cloudformation.md
+++ b/website/content/en/v0.33/reference/cloudformation.md
@@ -338,7 +338,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 {
   "Sid": "AllowPassingInstanceRole",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+  "Resource": "${KarpenterNodeRole.Arn}",
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {

--- a/website/content/en/v0.34/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.34/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -202,7 +202,7 @@ Resources:
             {
               "Sid": "AllowPassingInstanceRole",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+              "Resource": "${KarpenterNodeRole.Arn}",
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {

--- a/website/content/en/v0.34/reference/cloudformation.md
+++ b/website/content/en/v0.34/reference/cloudformation.md
@@ -363,7 +363,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 {
   "Sid": "AllowPassingInstanceRole",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+  "Resource": "${KarpenterNodeRole.Arn}",
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {

--- a/website/content/en/v0.35/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.35/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -202,7 +202,7 @@ Resources:
             {
               "Sid": "AllowPassingInstanceRole",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+              "Resource": "${KarpenterNodeRole.Arn}",
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {

--- a/website/content/en/v0.35/reference/cloudformation.md
+++ b/website/content/en/v0.35/reference/cloudformation.md
@@ -363,7 +363,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 {
   "Sid": "AllowPassingInstanceRole",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+  "Resource": "${KarpenterNodeRole.Arn}",
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {


### PR DESCRIPTION
**Description**

Use reference to `${KarpenterNodeRole.Arn}` for `"Sid": "AllowPassingInstanceRole"` in CloudFormation (like it is already done in case of `"Sid": "AllowInterruptionQueueActions"` definition)

**How was this change tested?**

Deploy CloudFormation...

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.