### PR TITLE
docs: Add more scheduling examples

### DIFF
--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -532,6 +532,94 @@ Based on the way that Karpenter performs pod batching and bin packing, it is not
 
 ## Advanced Scheduling Techniques
 
+### Scheduling based on Node Resources
+
+You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource natively or that are aspects of certain nodes like
+High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this. These can further be applied at the NodePool or Workload level
+using Requirements, NodeSelectors or Affinities
+
+Pod example of requiring any NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+           - key: "karpenter.k8s.aws/instance-local-nvme"
+             operator: "Exists"
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: "Exists"
+...
+```
+
+Pod example of requiring at least 100GB of NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-local-nvme"
+              operator: Gt
+              values: ["99"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: Gt
+    values: ["99"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+Karpenter cannot yet take into account ephemeral-storage requests while scheduling pods, we're purely requesting attributes of nodes and getting X amount of resources
+as a side effect. You may need to tweak schedulable resources to achieve desired fit.
+
+Your NodeClass will also need to support automatically formatting and mounting NVME Instance Storage if available.
+{{% /alert %}}
+
+Pod example of requiring at least 50 Gbps of network bandwidth:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-network-bandwidth"
+              operator: Gt
+              values: ["49999"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-network-bandwidth"
+    operator: Gt
+    values: ["49999"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
+{{% /alert %}}
+
+
 ### `Exists` Operator
 
 The `Exists` operator can be used on a NodePool to provide workload segregation across nodes.

--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -534,9 +534,10 @@ Based on the way that Karpenter performs pod batching and bin packing, it is not
 
 ### Scheduling based on Node Resources
 
-You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource natively or that are aspects of certain nodes like
-High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this. These can further be applied at the NodePool or Workload level
-using Requirements, NodeSelectors or Affinities
+You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource or that are aspects of certain nodes like
+High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this.
+
+These can further be applied at the NodePool or Workload level using Requirements, NodeSelectors or Affinities
 
 Pod example of requiring any NVME disk:
 ```yaml
@@ -586,7 +587,7 @@ requirement:
 
 {{% alert title="Note" color="primary" %}}
 Karpenter cannot yet take into account ephemeral-storage requests while scheduling pods, we're purely requesting attributes of nodes and getting X amount of resources
-as a side effect. You may need to tweak schedulable resources to achieve desired fit.
+as a side effect. You may need to tweak schedulable resources like CPU or Memory to achieve desired fit, especially if Consolidation is enabled.
 
 Your NodeClass will also need to support automatically formatting and mounting NVME Instance Storage if available.
 {{% /alert %}}
@@ -618,7 +619,6 @@ requirement:
 {{% alert title="Note" color="primary" %}}
 If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
 {{% /alert %}}
-
 
 ### `Exists` Operator
 

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -533,6 +533,94 @@ Based on the way that Karpenter performs pod batching and bin packing, it is not
 
 ## Advanced Scheduling Techniques
 
+### Scheduling based on Node Resources
+
+You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource or that are aspects of certain nodes like
+High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this.
+
+These can further be applied at the NodePool or Workload level using Requirements, NodeSelectors or Affinities
+
+Pod example of requiring any NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+           - key: "karpenter.k8s.aws/instance-local-nvme"
+             operator: "Exists"
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: "Exists"
+...
+```
+
+Pod example of requiring at least 100GB of NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-local-nvme"
+              operator: Gt
+              values: ["99"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: Gt
+    values: ["99"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+Karpenter cannot yet take into account ephemeral-storage requests while scheduling pods, we're purely requesting attributes of nodes and getting X amount of resources
+as a side effect. You may need to tweak schedulable resources like CPU or Memory to achieve desired fit, especially if Consolidation is enabled.
+
+Your NodeClass will also need to support automatically formatting and mounting NVME Instance Storage if available.
+{{% /alert %}}
+
+Pod example of requiring at least 50 Gbps of network bandwidth:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-network-bandwidth"
+              operator: Gt
+              values: ["49999"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-network-bandwidth"
+    operator: Gt
+    values: ["49999"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
+{{% /alert %}}
+
 ### `Exists` Operator
 
 The `Exists` operator can be used on a NodePool to provide workload segregation across nodes.

--- a/website/content/en/v0.32/concepts/scheduling.md
+++ b/website/content/en/v0.32/concepts/scheduling.md
@@ -532,6 +532,94 @@ Based on the way that Karpenter performs pod batching and bin packing, it is not
 
 ## Advanced Scheduling Techniques
 
+### Scheduling based on Node Resources
+
+You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource or that are aspects of certain nodes like
+High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this.
+
+These can further be applied at the NodePool or Workload level using Requirements, NodeSelectors or Affinities
+
+Pod example of requiring any NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+           - key: "karpenter.k8s.aws/instance-local-nvme"
+             operator: "Exists"
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: "Exists"
+...
+```
+
+Pod example of requiring at least 100GB of NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-local-nvme"
+              operator: Gt
+              values: ["99"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: Gt
+    values: ["99"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+Karpenter cannot yet take into account ephemeral-storage requests while scheduling pods, we're purely requesting attributes of nodes and getting X amount of resources
+as a side effect. You may need to tweak schedulable resources like CPU or Memory to achieve desired fit, especially if Consolidation is enabled.
+
+Your NodeClass will also need to support automatically formatting and mounting NVME Instance Storage if available.
+{{% /alert %}}
+
+Pod example of requiring at least 50 Gbps of network bandwidth:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-network-bandwidth"
+              operator: Gt
+              values: ["49999"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-network-bandwidth"
+    operator: Gt
+    values: ["49999"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
+{{% /alert %}}
+
 ### `Exists` Operator
 
 The `Exists` operator can be used on a NodePool to provide workload segregation across nodes.

--- a/website/content/en/v0.33/concepts/scheduling.md
+++ b/website/content/en/v0.33/concepts/scheduling.md
@@ -533,6 +533,94 @@ Based on the way that Karpenter performs pod batching and bin packing, it is not
 
 ## Advanced Scheduling Techniques
 
+### Scheduling based on Node Resources
+
+You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource or that are aspects of certain nodes like
+High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this.
+
+These can further be applied at the NodePool or Workload level using Requirements, NodeSelectors or Affinities
+
+Pod example of requiring any NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+           - key: "karpenter.k8s.aws/instance-local-nvme"
+             operator: "Exists"
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: "Exists"
+...
+```
+
+Pod example of requiring at least 100GB of NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-local-nvme"
+              operator: Gt
+              values: ["99"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: Gt
+    values: ["99"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+Karpenter cannot yet take into account ephemeral-storage requests while scheduling pods, we're purely requesting attributes of nodes and getting X amount of resources
+as a side effect. You may need to tweak schedulable resources like CPU or Memory to achieve desired fit, especially if Consolidation is enabled.
+
+Your NodeClass will also need to support automatically formatting and mounting NVME Instance Storage if available.
+{{% /alert %}}
+
+Pod example of requiring at least 50 Gbps of network bandwidth:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-network-bandwidth"
+              operator: Gt
+              values: ["49999"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-network-bandwidth"
+    operator: Gt
+    values: ["49999"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
+{{% /alert %}}
+
 ### `Exists` Operator
 
 The `Exists` operator can be used on a NodePool to provide workload segregation across nodes.

--- a/website/content/en/v0.34/concepts/scheduling.md
+++ b/website/content/en/v0.34/concepts/scheduling.md
@@ -532,6 +532,94 @@ Based on the way that Karpenter performs pod batching and bin packing, it is not
 
 ## Advanced Scheduling Techniques
 
+### Scheduling based on Node Resources
+
+You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource or that are aspects of certain nodes like
+High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this.
+
+These can further be applied at the NodePool or Workload level using Requirements, NodeSelectors or Affinities
+
+Pod example of requiring any NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+           - key: "karpenter.k8s.aws/instance-local-nvme"
+             operator: "Exists"
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: "Exists"
+...
+```
+
+Pod example of requiring at least 100GB of NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-local-nvme"
+              operator: Gt
+              values: ["99"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: Gt
+    values: ["99"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+Karpenter cannot yet take into account ephemeral-storage requests while scheduling pods, we're purely requesting attributes of nodes and getting X amount of resources
+as a side effect. You may need to tweak schedulable resources like CPU or Memory to achieve desired fit, especially if Consolidation is enabled.
+
+Your NodeClass will also need to support automatically formatting and mounting NVME Instance Storage if available.
+{{% /alert %}}
+
+Pod example of requiring at least 50 Gbps of network bandwidth:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-network-bandwidth"
+              operator: Gt
+              values: ["49999"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-network-bandwidth"
+    operator: Gt
+    values: ["49999"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
+{{% /alert %}}
+
 ### `Exists` Operator
 
 The `Exists` operator can be used on a NodePool to provide workload segregation across nodes.

--- a/website/content/en/v0.35/concepts/scheduling.md
+++ b/website/content/en/v0.35/concepts/scheduling.md
@@ -532,6 +532,94 @@ Based on the way that Karpenter performs pod batching and bin packing, it is not
 
 ## Advanced Scheduling Techniques
 
+### Scheduling based on Node Resources
+
+You may want pods to be able to request resources of nodes that Kubernetes natively does not provide as a schedulable resource or that are aspects of certain nodes like
+High Performance Networking or NVME Local Storage. You can use Karpenter's Well-Known Labels to accomplish this.
+
+These can further be applied at the NodePool or Workload level using Requirements, NodeSelectors or Affinities
+
+Pod example of requiring any NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+           - key: "karpenter.k8s.aws/instance-local-nvme"
+             operator: "Exists"
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: "Exists"
+...
+```
+
+Pod example of requiring at least 100GB of NVME disk:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-local-nvme"
+              operator: Gt
+              values: ["99"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-local-nvme"
+    operator: Gt
+    values: ["99"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+Karpenter cannot yet take into account ephemeral-storage requests while scheduling pods, we're purely requesting attributes of nodes and getting X amount of resources
+as a side effect. You may need to tweak schedulable resources like CPU or Memory to achieve desired fit, especially if Consolidation is enabled.
+
+Your NodeClass will also need to support automatically formatting and mounting NVME Instance Storage if available.
+{{% /alert %}}
+
+Pod example of requiring at least 50 Gbps of network bandwidth:
+```yaml
+...
+ affinity:
+   nodeAffinity:
+     requiredDuringSchedulingIgnoredDuringExecution:
+       nodeSelectorTerms:
+         - matchExpressions:
+            - key: "karpenter.k8s.aws/instance-network-bandwidth"
+              operator: Gt
+              values: ["49999"]
+...
+```
+
+NodePool Example:
+```yaml
+...
+requirement:
+  - key: "karpenter.k8s.aws/instance-network-bandwidth"
+    operator: Gt
+    values: ["49999"]
+...
+```
+
+{{% alert title="Note" color="primary" %}}
+If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
+{{% /alert %}}
+
 ### `Exists` Operator
 
 The `Exists` operator can be used on a NodePool to provide workload segregation across nodes.


### PR DESCRIPTION
Fixes #5238

**Description**

Add more documentation examples of how to schedule based on node attributes

**How was this change tested?**

Documentation change

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.