### PR TITLE
test: Add unit cache tests for subnets

### DIFF
--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -240,6 +240,52 @@ var _ = Describe("SubnetProvider", func() {
 			Expect(onlyPrivate).To(BeTrue())
 		})
 	})
+	Context("Provider Cache", func() {
+		It("should resolve subnets from cache that are filtered by id", func() {
+			expectedSubnets := awsEnv.EC2API.DescribeSubnetsOutput.Clone().Subnets
+			for _, subnet := range expectedSubnets {
+				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+					{
+						ID: *subnet.SubnetId,
+					},
+				}
+				// Call list to request from aws and store in the cache
+				_, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
+				Expect(err).To(BeNil())
+			}
+
+			for _, cachedObject := range awsEnv.SubnetCache.Items() {
+				cachedSubnet := cachedObject.Object.([]*ec2.Subnet)
+				Expect(cachedSubnet).To(HaveLen(1))
+				lo.Contains(expectedSubnets, cachedSubnet[0])
+			}
+		})
+		It("should resolve subnets from cache that are filtered by tags", func() {
+			expectedSubnets := awsEnv.EC2API.DescribeSubnetsOutput.Clone().Subnets
+			tagSet := lo.Map(expectedSubnets, func(subnet *ec2.Subnet, _ int) map[string]string {
+				tag, _ := lo.Find(subnet.Tags, func(tag *ec2.Tag) bool {
+					return lo.FromPtr(tag.Key) == "Name"
+				})
+				return map[string]string{"Name": lo.FromPtr(tag.Value)}
+			})
+			for _, tag := range tagSet {
+				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+					{
+						Tags: tag,
+					},
+				}
+				// Call list to request from aws and store in the cache
+				_, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
+				Expect(err).To(BeNil())
+			}
+
+			for _, cachedObject := range awsEnv.SubnetCache.Items() {
+				cachedSubnet := cachedObject.Object.([]*ec2.Subnet)
+				Expect(cachedSubnet).To(HaveLen(1))
+				lo.Contains(expectedSubnets, cachedSubnet[0])
+			}
+		})
+	})
 })
 
 func ExpectConsistsOfSubnets(expected, actual []*ec2.Subnet) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Adding testing to validate the subnets cache is caching expected values

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.