### PR TITLE
chore: Convert all AWS providers to interfaces

### DIFF
--- a/hack/code/prices_gen/main.go
+++ b/hack/code/prices_gen/main.go
@@ -108,7 +108,7 @@ func main() {
 	// record prices for each region we are interested in
 	for _, region := range getAWSRegions(opts.partition) {
 		log.Println("fetching for", region)
-		pricingProvider := pricing.NewProvider(ctx, pricing.NewAPI(sess, region), ec2, region)
+		pricingProvider := pricing.NewDefaultProvider(ctx, pricing.NewAPI(sess, region), ec2, region)
 		controller := controllerspricing.NewController(pricingProvider)
 		_, err := controller.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{}})
 		if err != nil {

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -54,17 +54,18 @@ import (
 var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)
 
 type CloudProvider struct {
-	instanceTypeProvider  *instancetype.Provider
-	instanceProvider      *instance.Provider
-	kubeClient            client.Client
-	amiProvider           *amifamily.Provider
-	securityGroupProvider *securitygroup.Provider
-	subnetProvider        *subnet.Provider
-	recorder              events.Recorder
+	kubeClient client.Client
+	recorder   events.Recorder
+
+	instanceTypeProvider  instancetype.Provider
+	instanceProvider      instance.Provider
+	amiProvider           amifamily.Provider
+	securityGroupProvider securitygroup.Provider
+	subnetProvider        subnet.Provider
 }
 
-func New(instanceTypeProvider *instancetype.Provider, instanceProvider *instance.Provider, recorder events.Recorder,
-	kubeClient client.Client, amiProvider *amifamily.Provider, securityGroupProvider *securitygroup.Provider, subnetProvider *subnet.Provider) *CloudProvider {
+func New(instanceTypeProvider instancetype.Provider, instanceProvider instance.Provider, recorder events.Recorder,
+	kubeClient client.Client, amiProvider amifamily.Provider, securityGroupProvider securitygroup.Provider, subnetProvider subnet.Provider) *CloudProvider {
 	return &CloudProvider{
 		instanceTypeProvider:  instanceTypeProvider,
 		instanceProvider:      instanceProvider,

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -47,9 +47,9 @@ import (
 )
 
 func NewControllers(ctx context.Context, sess *session.Session, clk clock.Clock, kubeClient client.Client, recorder events.Recorder,
-	unavailableOfferings *cache.UnavailableOfferings, cloudProvider cloudprovider.CloudProvider, subnetProvider *subnet.Provider,
-	securityGroupProvider *securitygroup.Provider, instanceProfileProvider *instanceprofile.Provider, instanceProvider *instance.Provider,
-	pricingProvider *pricing.Provider, amiProvider *amifamily.Provider, launchTemplateProvider *launchtemplate.Provider) []controller.Controller {
+	unavailableOfferings *cache.UnavailableOfferings, cloudProvider cloudprovider.CloudProvider, subnetProvider subnet.Provider,
+	securityGroupProvider securitygroup.Provider, instanceProfileProvider instanceprofile.Provider, instanceProvider instance.Provider,
+	pricingProvider pricing.Provider, amiProvider amifamily.Provider, launchTemplateProvider launchtemplate.Provider) []controller.Controller {
 
 	controllers := []controller.Controller{
 		nodeclass.NewController(kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, launchTemplateProvider),

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -60,14 +60,14 @@ type Controller struct {
 	kubeClient                client.Client
 	clk                       clock.Clock
 	recorder                  events.Recorder
-	sqsProvider               *sqs.Provider
+	sqsProvider               sqs.Provider
 	unavailableOfferingsCache *cache.UnavailableOfferings
 	parser                    *EventParser
 	cm                        *pretty.ChangeMonitor
 }
 
 func NewController(kubeClient client.Client, clk clock.Clock, recorder events.Recorder,
-	sqsProvider *sqs.Provider, unavailableOfferingsCache *cache.UnavailableOfferings) *Controller {
+	sqsProvider sqs.Provider, unavailableOfferingsCache *cache.UnavailableOfferings) *Controller {
 
 	return &Controller{
 		kubeClient:                kubeClient,

--- a/pkg/controllers/interruption/interruption_benchmark_test.go
+++ b/pkg/controllers/interruption/interruption_benchmark_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	servicesqs "github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -161,8 +162,8 @@ func benchmarkNotificationController(b *testing.B, messageCount int) {
 
 type providerSet struct {
 	kubeClient  client.Client
-	sqsAPI      *servicesqs.SQS
-	sqsProvider *sqs.Provider
+	sqsAPI      sqsiface.SQSAPI
+	sqsProvider sqs.Provider
 }
 
 func newProviders(ctx context.Context, kubeClient client.Client) providerSet {

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -66,7 +66,7 @@ const (
 var ctx context.Context
 var env *coretest.Environment
 var sqsapi *fake.SQSAPI
-var sqsProvider *sqs.Provider
+var sqsProvider *sqs.DefaultProvider
 var unavailableOfferingsCache *awscache.UnavailableOfferings
 var fakeClock *clock.FakeClock
 var controller *interruption.Controller

--- a/pkg/controllers/nodeclaim/tagging/controller.go
+++ b/pkg/controllers/nodeclaim/tagging/controller.go
@@ -40,10 +40,10 @@ import (
 
 type Controller struct {
 	kubeClient       client.Client
-	instanceProvider *instance.Provider
+	instanceProvider instance.Provider
 }
 
-func NewController(kubeClient client.Client, instanceProvider *instance.Provider) corecontroller.Controller {
+func NewController(kubeClient client.Client, instanceProvider instance.Provider) corecontroller.Controller {
 	return corecontroller.Typed[*corev1beta1.NodeClaim](kubeClient, &Controller{
 		kubeClient:       kubeClient,
 		instanceProvider: instanceProvider,

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -56,21 +56,23 @@ import (
 var _ corecontroller.FinalizingTypedController[*v1beta1.EC2NodeClass] = (*Controller)(nil)
 
 type Controller struct {
-	kubeClient              client.Client
-	recorder                events.Recorder
-	subnetProvider          *subnet.Provider
-	securityGroupProvider   *securitygroup.Provider
-	amiProvider             *amifamily.Provider
-	instanceProfileProvider *instanceprofile.Provider
-	launchTemplateProvider  *launchtemplate.Provider
+	kubeClient client.Client
+	recorder   events.Recorder
+
+	subnetProvider          subnet.Provider
+	securityGroupProvider   securitygroup.Provider
+	amiProvider             amifamily.Provider
+	instanceProfileProvider instanceprofile.Provider
+	launchTemplateProvider  launchtemplate.Provider
 }
 
-func NewController(kubeClient client.Client, recorder events.Recorder, subnetProvider *subnet.Provider, securityGroupProvider *securitygroup.Provider,
-	amiProvider *amifamily.Provider, instanceProfileProvider *instanceprofile.Provider, launchTemplateProvider *launchtemplate.Provider) corecontroller.Controller {
+func NewController(kubeClient client.Client, recorder events.Recorder, subnetProvider subnet.Provider, securityGroupProvider securitygroup.Provider,
+	amiProvider amifamily.Provider, instanceProfileProvider instanceprofile.Provider, launchTemplateProvider launchtemplate.Provider) corecontroller.Controller {
 
 	return corecontroller.Typed[*v1beta1.EC2NodeClass](kubeClient, &Controller{
-		kubeClient:              kubeClient,
-		recorder:                recorder,
+		kubeClient: kubeClient,
+		recorder:   recorder,
+
 		subnetProvider:          subnetProvider,
 		securityGroupProvider:   securityGroupProvider,
 		amiProvider:             amiProvider,
@@ -137,7 +139,7 @@ func (c *Controller) Finalize(ctx context.Context, nodeClass *v1beta1.EC2NodeCla
 			return reconcile.Result{}, fmt.Errorf("deleting instance profile, %w", err)
 		}
 	}
-	if err := c.launchTemplateProvider.DeleteLaunchTemplates(ctx, nodeClass); err != nil {
+	if err := c.launchTemplateProvider.DeleteAll(ctx, nodeClass); err != nil {
 		return reconcile.Result{}, fmt.Errorf("deleting launch templates, %w", err)
 	}
 	controllerutil.RemoveFinalizer(nodeClass, v1beta1.TerminationFinalizer)

--- a/pkg/controllers/pricing/controller.go
+++ b/pkg/controllers/pricing/controller.go
@@ -30,10 +30,10 @@ import (
 )
 
 type Controller struct {
-	pricingProvider *pricing.Provider
+	pricingProvider pricing.Provider
 }
 
-func NewController(pricingProvider *pricing.Provider) *Controller {
+func NewController(pricingProvider pricing.Provider) *Controller {
 	return &Controller{
 		pricingProvider: pricingProvider,
 	}

--- a/pkg/controllers/pricing/suite_test.go
+++ b/pkg/controllers/pricing/suite_test.go
@@ -51,7 +51,7 @@ var controller *controllerspricing.Controller
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Provider/AWS")
+	RunSpecs(t, "Pricing")
 }
 
 var _ = BeforeSuite(func() {
@@ -84,7 +84,7 @@ var _ = Describe("Pricing", func() {
 		"should return correct static data for all partitions",
 		func(staticPricing map[string]map[string]float64) {
 			for region, prices := range staticPricing {
-				provider := pricing.NewProvider(ctx, awsEnv.PricingAPI, awsEnv.EC2API, region)
+				provider := pricing.NewDefaultProvider(ctx, awsEnv.PricingAPI, awsEnv.EC2API, region)
 				for instance, price := range prices {
 					val, ok := provider.OnDemandPrice(instance)
 					Expect(ok).To(BeTrue())
@@ -298,7 +298,7 @@ var _ = Describe("Pricing", func() {
 		Expect(price).To(BeNumerically("==", 1.10))
 	})
 	It("should update on-demand pricing with response from the pricing API when in the CN partition", func() {
-		tmpPricingProvider := pricing.NewProvider(ctx, awsEnv.PricingAPI, awsEnv.EC2API, "cn-anywhere-1")
+		tmpPricingProvider := pricing.NewDefaultProvider(ctx, awsEnv.PricingAPI, awsEnv.EC2API, "cn-anywhere-1")
 		tmpController := controllerspricing.NewController(tmpPricingProvider)
 
 		now := time.Now()

--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -166,7 +166,7 @@ func MakeInstances() []*ec2.InstanceTypeInfo {
 	ctx := options.ToContext(context.Background(), &options.Options{IsolatedVPC: true})
 	// Use keys from the static pricing data so that we guarantee pricing for the data
 	// Create uniform instance data so all of them schedule for a given pod
-	for _, it := range pricing.NewProvider(ctx, nil, nil, "us-east-1").InstanceTypes() {
+	for _, it := range pricing.NewDefaultProvider(ctx, nil, nil, "us-east-1").InstanceTypes() {
 		instanceTypes = append(instanceTypes, &ec2.InstanceTypeInfo{
 			InstanceType: aws.String(it),
 			ProcessorInfo: &ec2.ProcessorInfo{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -76,16 +76,16 @@ type Operator struct {
 	Session                   *session.Session
 	UnavailableOfferingsCache *awscache.UnavailableOfferings
 	EC2API                    ec2iface.EC2API
-	SubnetProvider            *subnet.Provider
-	SecurityGroupProvider     *securitygroup.Provider
-	InstanceProfileProvider   *instanceprofile.Provider
-	AMIProvider               *amifamily.Provider
+	SubnetProvider            subnet.Provider
+	SecurityGroupProvider     securitygroup.Provider
+	InstanceProfileProvider   instanceprofile.Provider
+	AMIProvider               amifamily.Provider
 	AMIResolver               *amifamily.Resolver
-	LaunchTemplateProvider    *launchtemplate.Provider
-	PricingProvider           *pricing.Provider
-	VersionProvider           *version.Provider
-	InstanceTypesProvider     *instancetype.Provider
-	InstanceProvider          *instance.Provider
+	LaunchTemplateProvider    launchtemplate.Provider
+	PricingProvider           pricing.Provider
+	VersionProvider           version.Provider
+	InstanceTypesProvider     instancetype.Provider
+	InstanceProvider          instance.Provider
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
@@ -132,18 +132,18 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	}
 
 	unavailableOfferingsCache := awscache.NewUnavailableOfferings()
-	subnetProvider := subnet.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	securityGroupProvider := securitygroup.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	subnetProvider := subnet.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	securityGroupProvider := securitygroup.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	instanceProfileProvider := instanceprofile.NewProvider(*sess.Config.Region, iam.New(sess), cache.New(awscache.InstanceProfileTTL, awscache.DefaultCleanupInterval))
-	pricingProvider := pricing.NewProvider(
+	pricingProvider := pricing.NewDefaultProvider(
 		ctx,
 		pricing.NewAPI(sess, *sess.Config.Region),
 		ec2api,
 		*sess.Config.Region,
 	)
-	versionProvider := version.NewProvider(operator.KubernetesInterface, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	amiProvider := amifamily.NewProvider(versionProvider, ssm.New(sess), ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	amiResolver := amifamily.New(amiProvider)
+	versionProvider := version.NewDefaultProvider(operator.KubernetesInterface, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	amiProvider := amifamily.NewDefaultProvider(versionProvider, ssm.New(sess), ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	amiResolver := amifamily.NewResolver(amiProvider)
 	launchTemplateProvider := launchtemplate.NewProvider(
 		ctx,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
@@ -158,7 +158,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		kubeDNSIP,
 		clusterEndpoint,
 	)
-	instanceTypeProvider := instancetype.NewProvider(
+	instanceTypeProvider := instancetype.NewDefaultProvider(
 		*sess.Config.Region,
 		cache.New(awscache.InstanceTypesAndZonesTTL, awscache.DefaultCleanupInterval),
 		ec2api,
@@ -166,7 +166,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		unavailableOfferingsCache,
 		pricingProvider,
 	)
-	instanceProvider := instance.NewProvider(
+	instanceProvider := instance.NewDefaultProvider(
 		ctx,
 		aws.StringValue(sess.Config.Region),
 		ec2api,

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -43,7 +43,7 @@ var DefaultEBS = v1beta1.BlockDevice{
 
 // Resolver is able to fill-in dynamic launch template parameters
 type Resolver struct {
-	amiProvider *Provider
+	amiProvider Provider
 }
 
 // Options define the static launch template parameters
@@ -111,8 +111,8 @@ func (d DefaultFamily) FeatureFlags() FeatureFlags {
 	}
 }
 
-// New constructs a new launch template Resolver
-func New(amiProvider *Provider) *Resolver {
+// NewResolver constructs a new launch template Resolver
+func NewResolver(amiProvider Provider) *Resolver {
 	return &Resolver{
 		amiProvider: amiProvider,
 	}

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -55,7 +55,7 @@ var cloudProvider *cloudprovider.CloudProvider
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Provider/AWS")
+	RunSpecs(t, "InstanceProvider")
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -70,7 +70,7 @@ var cloudProvider *cloudprovider.CloudProvider
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Provider/AWS")
+	RunSpecs(t, "InstanceTypeProvider")
 }
 
 var _ = BeforeSuite(func() {
@@ -102,7 +102,7 @@ var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 })
 
-var _ = Describe("InstanceTypes", func() {
+var _ = Describe("InstanceTypeProvider", func() {
 	var nodeClass, windowsNodeClass *v1beta1.EC2NodeClass
 	var nodePool, windowsNodePool *corev1beta1.NodePool
 	BeforeEach(func() {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -77,7 +77,7 @@ var cloudProvider *cloudprovider.CloudProvider
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Provider/AWS")
+	RunSpecs(t, "LaunchTemplateProvider")
 }
 
 var _ = BeforeSuite(func() {
@@ -114,7 +114,7 @@ var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 })
 
-var _ = Describe("LaunchTemplates", func() {
+var _ = Describe("LaunchTemplate Provider", func() {
 	var nodePool *corev1beta1.NodePool
 	var nodeClass *v1beta1.EC2NodeClass
 	BeforeEach(func() {

--- a/pkg/providers/securitygroup/suite_test.go
+++ b/pkg/providers/securitygroup/suite_test.go
@@ -46,7 +46,7 @@ var nodeClass *v1beta1.EC2NodeClass
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Provider/AWS")
+	RunSpecs(t, "SecurityGroupProvider")
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -46,7 +46,7 @@ var nodeClass *v1beta1.EC2NodeClass
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Provider/AWS")
+	RunSpecs(t, "SubnetProvider")
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/providers/version/version.go
+++ b/pkg/providers/version/version.go
@@ -36,24 +36,27 @@ const (
 	MaxK8sVersion = "1.29"
 )
 
-// Provider get the APIServer version. This will be initialized at start up and allows karpenter to have an understanding of the cluster version
-// for decision making. The version is cached to help reduce the amount of calls made to the API Server
+type Provider interface {
+	Get(ctx context.Context) (string, error)
+}
 
-type Provider struct {
+// DefaultProvider get the APIServer version. This will be initialized at start up and allows karpenter to have an understanding of the cluster version
+// for decision making. The version is cached to help reduce the amount of calls made to the API Server
+type DefaultProvider struct {
 	cache               *cache.Cache
 	cm                  *pretty.ChangeMonitor
 	kubernetesInterface kubernetes.Interface
 }
 
-func NewProvider(kubernetesInterface kubernetes.Interface, cache *cache.Cache) *Provider {
-	return &Provider{
+func NewDefaultProvider(kubernetesInterface kubernetes.Interface, cache *cache.Cache) *DefaultProvider {
+	return &DefaultProvider{
 		cm:                  pretty.NewChangeMonitor(),
 		cache:               cache,
 		kubernetesInterface: kubernetesInterface,
 	}
 }
 
-func (p *Provider) Get(ctx context.Context) (string, error) {
+func (p *DefaultProvider) Get(ctx context.Context) (string, error) {
 	if version, ok := p.cache.Get(kubernetesVersionCacheKey); ok {
 		return version.(string), nil
 	}

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -68,16 +68,16 @@ type Environment struct {
 	InstanceProfileCache      *cache.Cache
 
 	// Providers
-	InstanceTypesProvider   *instancetype.Provider
-	InstanceProvider        *instance.Provider
-	SubnetProvider          *subnet.Provider
-	SecurityGroupProvider   *securitygroup.Provider
-	InstanceProfileProvider *instanceprofile.Provider
-	PricingProvider         *pricing.Provider
-	AMIProvider             *amifamily.Provider
+	InstanceTypesProvider   *instancetype.DefaultProvider
+	InstanceProvider        *instance.DefaultProvider
+	SubnetProvider          *subnet.DefaultProvider
+	SecurityGroupProvider   *securitygroup.DefaultProvider
+	InstanceProfileProvider *instanceprofile.DefaultProvider
+	PricingProvider         *pricing.DefaultProvider
+	AMIProvider             *amifamily.DefaultProvider
 	AMIResolver             *amifamily.Resolver
-	VersionProvider         *version.Provider
-	LaunchTemplateProvider  *launchtemplate.Provider
+	VersionProvider         *version.DefaultProvider
+	LaunchTemplateProvider  *launchtemplate.DefaultProvider
 }
 
 func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment {
@@ -99,14 +99,14 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	fakePricingAPI := &fake.PricingAPI{}
 
 	// Providers
-	pricingProvider := pricing.NewProvider(ctx, fakePricingAPI, ec2api, fake.DefaultRegion)
-	subnetProvider := subnet.NewProvider(ec2api, subnetCache)
-	securityGroupProvider := securitygroup.NewProvider(ec2api, securityGroupCache)
-	versionProvider := version.NewProvider(env.KubernetesInterface, kubernetesVersionCache)
+	pricingProvider := pricing.NewDefaultProvider(ctx, fakePricingAPI, ec2api, fake.DefaultRegion)
+	subnetProvider := subnet.NewDefaultProvider(ec2api, subnetCache)
+	securityGroupProvider := securitygroup.NewDefaultProvider(ec2api, securityGroupCache)
+	versionProvider := version.NewDefaultProvider(env.KubernetesInterface, kubernetesVersionCache)
 	instanceProfileProvider := instanceprofile.NewProvider(fake.DefaultRegion, iamapi, instanceProfileCache)
-	amiProvider := amifamily.NewProvider(versionProvider, ssmapi, ec2api, ec2Cache)
-	amiResolver := amifamily.New(amiProvider)
-	instanceTypesProvider := instancetype.NewProvider(fake.DefaultRegion, instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)
+	amiProvider := amifamily.NewDefaultProvider(versionProvider, ssmapi, ec2api, ec2Cache)
+	amiResolver := amifamily.NewResolver(amiProvider)
+	instanceTypesProvider := instancetype.NewDefaultProvider(fake.DefaultRegion, instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)
 	launchTemplateProvider :=
 		launchtemplate.NewProvider(
 			ctx,
@@ -123,7 +123,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 			"https://test-cluster",
 		)
 	instanceProvider :=
-		instance.NewProvider(ctx,
+		instance.NewDefaultProvider(ctx,
 			"",
 			ec2api,
 			unavailableOfferingsCache,

--- a/test/pkg/environment/aws/environment.go
+++ b/test/pkg/environment/aws/environment.go
@@ -76,7 +76,7 @@ type Environment struct {
 	EKSAPI        *eks.EKS
 	TimeStreamAPI timestreamwriteiface.TimestreamWriteAPI
 
-	SQSProvider *sqs.Provider
+	SQSProvider sqs.Provider
 
 	ClusterName       string
 	ClusterEndpoint   string


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds interfaces for all of the provider clients to allow for mocking of the Providers to ease some of the testing burden for mocking out the underlying data.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.