### PR TITLE
chore: Update launch template provider to leverage interfaces

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -144,7 +144,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	versionProvider := version.NewDefaultProvider(operator.KubernetesInterface, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	amiProvider := amifamily.NewDefaultProvider(versionProvider, ssm.New(sess), ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	amiResolver := amifamily.NewResolver(amiProvider)
-	launchTemplateProvider := launchtemplate.NewProvider(
+	launchTemplateProvider := launchtemplate.NewDefaultProvider(
 		ctx,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 		ec2api,

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -77,9 +77,9 @@ type DefaultProvider struct {
 	ec2api                  ec2iface.EC2API
 	eksapi                  eksiface.EKSAPI
 	amiFamily               *amifamily.Resolver
-	securityGroupProvider   *securitygroup.DefaultProvider
-	subnetProvider          *subnet.DefaultProvider
-	instanceProfileProvider *instanceprofile.DefaultProvider
+	securityGroupProvider   securitygroup.Provider
+	subnetProvider          subnet.Provider
+	instanceProfileProvider instanceprofile.Provider
 	cache                   *cache.Cache
 	cm                      *pretty.ChangeMonitor
 	KubeDNSIP               net.IP
@@ -88,8 +88,8 @@ type DefaultProvider struct {
 	ClusterCIDR             atomic.Pointer[string]
 }
 
-func NewProvider(ctx context.Context, cache *cache.Cache, ec2api ec2iface.EC2API, eksapi eksiface.EKSAPI, amiFamily *amifamily.Resolver,
-	securityGroupProvider *securitygroup.DefaultProvider, subnetProvider *subnet.DefaultProvider, instanceProfileProvider *instanceprofile.DefaultProvider,
+func NewDefaultProvider(ctx context.Context, cache *cache.Cache, ec2api ec2iface.EC2API, eksapi eksiface.EKSAPI, amiFamily *amifamily.Resolver,
+	securityGroupProvider securitygroup.Provider, subnetProvider subnet.Provider, instanceProfileProvider instanceprofile.Provider,
 	caBundle *string, startAsync <-chan struct{}, kubeDNSIP net.IP, clusterEndpoint string) *DefaultProvider {
 	l := &DefaultProvider{
 		ec2api:                  ec2api,

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -108,7 +108,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	amiResolver := amifamily.NewResolver(amiProvider)
 	instanceTypesProvider := instancetype.NewDefaultProvider(fake.DefaultRegion, instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)
 	launchTemplateProvider :=
-		launchtemplate.NewProvider(
+		launchtemplate.NewDefaultProvider(
 			ctx,
 			launchTemplateCache,
 			ec2api,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fix missed launch template provider using the `DefaultProvider` instead of the Provider interfaces.

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.