### PR TITLE
docs: add information about consolidateAfter not working with WhenUnderutilized

### DIFF
--- a/website/content/en/docs/concepts/disruption.md
+++ b/website/content/en/docs/concepts/disruption.md
@@ -84,6 +84,10 @@ spec:
 ```
 {{% /alert %}}
 
+{{% alert title="Warning" color="warning" %}}
+`consolidateAfter` can **not** be set if `consolidationPolicy` is `WhenUnderutilized`. See [kubernetes-sigs/karpenter#735](https://github.com/kubernetes-sigs/karpenter/issues/735) for more information.
+{{% /alert %}}
+
 ### Consolidation
 
 Karpenter has two mechanisms for cluster consolidation:

--- a/website/content/en/docs/concepts/disruption.md
+++ b/website/content/en/docs/concepts/disruption.md
@@ -85,7 +85,7 @@ spec:
 {{% /alert %}}
 
 {{% alert title="Warning" color="warning" %}}
-`consolidateAfter` can **not** be set if `consolidationPolicy` is `WhenUnderutilized`. See [kubernetes-sigs/karpenter#735](https://github.com/kubernetes-sigs/karpenter/issues/735) for more information.
+`consolidateAfter` **cannot** be set if `consolidationPolicy` is set to `WhenUnderutilized`. See [kubernetes-sigs/karpenter#735](https://github.com/kubernetes-sigs/karpenter/issues/735) for more information.
 {{% /alert %}}
 
 ### Consolidation

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -84,6 +84,10 @@ spec:
 ```
 {{% /alert %}}
 
+{{% alert title="Warning" color="warning" %}}
+`consolidateAfter` can **not** be set if `consolidationPolicy` is `WhenUnderutilized`. See [kubernetes-sigs/karpenter#735](https://github.com/kubernetes-sigs/karpenter/issues/735) for more information.
+{{% /alert %}}
+
 ### Consolidation
 
 Karpenter has two mechanisms for cluster consolidation:

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -85,7 +85,7 @@ spec:
 {{% /alert %}}
 
 {{% alert title="Warning" color="warning" %}}
-`consolidateAfter` can **not** be set if `consolidationPolicy` is `WhenUnderutilized`. See [kubernetes-sigs/karpenter#735](https://github.com/kubernetes-sigs/karpenter/issues/735) for more information.
+`consolidateAfter` **cannot** be set if `consolidationPolicy` is set to `WhenUnderutilized`. See [kubernetes-sigs/karpenter#735](https://github.com/kubernetes-sigs/karpenter/issues/735) for more information.
 {{% /alert %}}
 
 ### Consolidation

--- a/website/content/en/v0.36/concepts/disruption.md
+++ b/website/content/en/v0.36/concepts/disruption.md
@@ -84,6 +84,10 @@ spec:
 ```
 {{% /alert %}}
 
+{{% alert title="Warning" color="warning" %}}
+`consolidateAfter` **cannot** be set if `consolidationPolicy` is set to `WhenUnderutilized`. See [kubernetes-sigs/karpenter#735](https://github.com/kubernetes-sigs/karpenter/issues/735) for more information.
+{{% /alert %}}
+
 ### Consolidation
 
 Karpenter has two mechanisms for cluster consolidation:


### PR DESCRIPTION
**Description**

This adds documentation about the `consolidateAfter` configuration for `NodePool`s not being available when `consolidationPolicy: WhenUnderutilized` is set.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
