### PR TITLE
chore: Fix the website to correctly point to the latest release

### DIFF
--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -79,10 +79,10 @@ params:
   latest_release_version: 0.36.0
   latest_k8s_version: 1.29
   versions:
-    - v0.32
-    - v0.34
-    - v0.35
     - v0.36
+    - v0.35
+    - v0.34
+    - v0.32
     - preview
 menu:
   main:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Karpenter website currently says v0.32 is the latest version when it should ideally be v0.36.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.