### PR TITLE
docs: add note in amiSelectorTerms documentation for clarity when used with amiFamily

### DIFF
--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -431,6 +431,7 @@ spec:
 
 AMI Selector Terms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). **When you specify `amiSelectorTerms`, you fully override the default AMIs that are selected on by your EC2NodeClass [`amiFamily`]({{< ref "#specamifamily" >}}).**
 
+Keep in mind that amiFamily determines the bootstrapping mode, while amiSelectorTerms specifies the specific AMI to be used. Therefore, ensure consistency between amiFamily and amiSelectorTerms to avoid conflicts.
 This selection logic is modeled as terms, where each term contains multiple conditions that must all be satisfied for the selector to match. Effectively, all requirements within a single term are ANDed together. It's possible that you may want to select on two different AMIs that have unrelated requirements. In this case, you can specify multiple terms which will be ORed together to form your selection logic. The example below shows how this selection logic is fulfilled.
 
 ```yaml

--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -431,7 +431,8 @@ spec:
 
 AMI Selector Terms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). **When you specify `amiSelectorTerms`, you fully override the default AMIs that are selected on by your EC2NodeClass [`amiFamily`]({{< ref "#specamifamily" >}}).**
 
-Keep in mind that amiFamily determines the bootstrapping mode, while amiSelectorTerms specifies the specific AMI to be used. Therefore, ensure consistency between amiFamily and amiSelectorTerms to avoid conflicts.
+Keep in mind that amiFamily determines the bootstrapping mode, while amiSelectorTerms specifies the specific AMI to be used.Therefore, ensure consistency between amiFamily and amiSelectorTerms to avoid conflicts.
+
 This selection logic is modeled as terms, where each term contains multiple conditions that must all be satisfied for the selector to match. Effectively, all requirements within a single term are ANDed together. It's possible that you may want to select on two different AMIs that have unrelated requirements. In this case, you can specify multiple terms which will be ORed together to form your selection logic. The example below shows how this selection logic is fulfilled.
 
 ```yaml


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

**Description**
This add documentation about `amiSelectorTerms` .It emphasizes the importance of users ensuring they select the appropriate amiFamily when utilizing amiSelectorTerms.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.