### PR TITLE
fix(chart): Correct fix for ServiceMonitor indentation

### DIFF
--- a/charts/karpenter/templates/servicemonitor.yaml
+++ b/charts/karpenter/templates/servicemonitor.yaml
@@ -21,9 +21,9 @@ spec:
     matchLabels:
       {{- include "karpenter.selectorLabels" . | nindent 6 }}
   endpoints:
-  - port: http-metrics
-    path: /metrics
+    - port: http-metrics
+      path: /metrics
     {{- with .Values.serviceMonitor.endpointConfig }}
-      {{- toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
 {{- end -}}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This fixes the pattern in the Helm `ServiceMonitor` template where the code was broken by #5571 (I have no idea why it was merged, but I suspect it was a fix for the pre-refactored chart version) and incorrectly fixed by #5624; the `nindent` value should match the indentation of the `{{}}` block.

**How was this change tested?**
I've tested this locally.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.