### PR TITLE
test: Pinning Karpenter version for upgrade test suite

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -95,9 +95,7 @@ jobs:
       statuses: write # ./.github/actions/commit-status/start
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      # This version includes the IRSA changes to support k8s 1.23
-      # https://github.com/aws/karpenter-provider-aws/pull/5445
-      from_git_ref: 6934ef58e8e13686d4f57c2d336dd165cbf3e759
+      from_git_ref: 283e7b2a51ec73903a6d3f9362fc3009b898ef33
       to_git_ref: ${{ inputs.git_ref }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Upgrade test suite is failing because it is trying to look for Karpenter snapshot that was deleted due to the cleanup policy. 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.