### PR TITLE
chore: Remove instanceProfileProvider from the launchTemplateProvider

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -152,7 +152,6 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		amiResolver,
 		securityGroupProvider,
 		subnetProvider,
-		instanceProfileProvider,
 		lo.Must(GetCABundle(ctx, operator.GetConfig())),
 		operator.Elected(),
 		kubeDNSIP,

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -44,7 +44,6 @@ import (
 	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/securitygroup"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/subnet"
 	"github.com/aws/karpenter-provider-aws/pkg/utils"
@@ -74,35 +73,33 @@ type LaunchTemplate struct {
 
 type DefaultProvider struct {
 	sync.Mutex
-	ec2api                  ec2iface.EC2API
-	eksapi                  eksiface.EKSAPI
-	amiFamily               *amifamily.Resolver
-	securityGroupProvider   securitygroup.Provider
-	subnetProvider          subnet.Provider
-	instanceProfileProvider instanceprofile.Provider
-	cache                   *cache.Cache
-	cm                      *pretty.ChangeMonitor
-	KubeDNSIP               net.IP
-	CABundle                *string
-	ClusterEndpoint         string
-	ClusterCIDR             atomic.Pointer[string]
+	ec2api                ec2iface.EC2API
+	eksapi                eksiface.EKSAPI
+	amiFamily             *amifamily.Resolver
+	securityGroupProvider securitygroup.Provider
+	subnetProvider        subnet.Provider
+	cache                 *cache.Cache
+	cm                    *pretty.ChangeMonitor
+	KubeDNSIP             net.IP
+	CABundle              *string
+	ClusterEndpoint       string
+	ClusterCIDR           atomic.Pointer[string]
 }
 
 func NewDefaultProvider(ctx context.Context, cache *cache.Cache, ec2api ec2iface.EC2API, eksapi eksiface.EKSAPI, amiFamily *amifamily.Resolver,
-	securityGroupProvider securitygroup.Provider, subnetProvider subnet.Provider, instanceProfileProvider instanceprofile.Provider,
+	securityGroupProvider securitygroup.Provider, subnetProvider subnet.Provider,
 	caBundle *string, startAsync <-chan struct{}, kubeDNSIP net.IP, clusterEndpoint string) *DefaultProvider {
 	l := &DefaultProvider{
-		ec2api:                  ec2api,
-		eksapi:                  eksapi,
-		amiFamily:               amiFamily,
-		securityGroupProvider:   securityGroupProvider,
-		subnetProvider:          subnetProvider,
-		instanceProfileProvider: instanceProfileProvider,
-		cache:                   cache,
-		CABundle:                caBundle,
-		cm:                      pretty.NewChangeMonitor(),
-		KubeDNSIP:               kubeDNSIP,
-		ClusterEndpoint:         clusterEndpoint,
+		ec2api:                ec2api,
+		eksapi:                eksapi,
+		amiFamily:             amiFamily,
+		securityGroupProvider: securityGroupProvider,
+		subnetProvider:        subnetProvider,
+		cache:                 cache,
+		CABundle:              caBundle,
+		cm:                    pretty.NewChangeMonitor(),
+		KubeDNSIP:             kubeDNSIP,
+		ClusterEndpoint:       clusterEndpoint,
 	}
 	l.cache.OnEvicted(l.cachedEvictedFunc(ctx))
 	go func() {

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -116,7 +116,6 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 			amiResolver,
 			securityGroupProvider,
 			subnetProvider,
-			instanceProfileProvider,
 			ptr.String("ca-bundle"),
 			make(chan struct{}),
 			net.ParseIP("10.0.100.10"),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Remove instanceProfileProvider from launchTemplateProvider, since it's not used in the provider 

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.