### PR TITLE
ci: Excluded cluster should not be run for Soak Testing

### DIFF
--- a/test/hack/soak/get_clusters.go
+++ b/test/hack/soak/get_clusters.go
@@ -57,15 +57,11 @@ func main() {
 			createNewCluster = false
 		}
 
-		if strings.HasPrefix(c, "soak-periodic-") {
+		if strings.HasPrefix(c, "soak-periodic-") && !slices.Contains(excludedClustersCleanup, c) {
 			outputList = append(outputList, &cluster{
-				Name:   c,
-				GitRef: clusterDetails.Cluster.Tags["test/git_ref"],
-				Cleanup: lo.Ternary(
-					slices.Contains(excludedClustersCleanup, c),
-					false,
-					clusterDetails.Cluster.CreatedAt.Before(expirationTime),
-				),
+				Name:    c,
+				GitRef:  clusterDetails.Cluster.Tags["test/git_ref"],
+				Cleanup: clusterDetails.Cluster.CreatedAt.Before(expirationTime),
 			})
 		}
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Prevent Excluded cluster from running in soak testing suite 

**How was this change tested?**
- N/A 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.