### PR TITLE
docs: Drop note on budget schedules sometimes being in utc

### DIFF
--- a/website/content/en/docs/concepts/disruption.md
+++ b/website/content/en/docs/concepts/disruption.md
@@ -227,7 +227,7 @@ spec:
 
 #### Schedule
 Schedule is a cronjob schedule. Generally, the cron syntax is five space-delimited values with options below, with additional special macros like `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax.
+Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax. Timezones are not currently supported. Schedules are always in UTC.
 
 ```bash
 # ┌───────────── minute (0 - 59)
@@ -240,10 +240,6 @@ Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/worklo
 # │ │ │ │ │
 # * * * * *
 ```
-
-{{% alert title="Note" color="primary" %}}
-Timezones are not supported. Most images default to UTC, but it is best practice to ensure this is the case when considering how to define your budgets.
-{{% /alert %}}
 
 #### Duration
 Duration allows compound durations with minutes and hours values such as `10h5m` or `30m` or `160h`. Since cron syntax does not accept denominations smaller than minutes, users can only define minutes or hours.

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -227,7 +227,7 @@ spec:
 
 #### Schedule
 Schedule is a cronjob schedule. Generally, the cron syntax is five space-delimited values with options below, with additional special macros like `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax.
+Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax. Timezones are not currently supported. Schedules are always in UTC.
 
 ```bash
 # ┌───────────── minute (0 - 59)
@@ -240,10 +240,6 @@ Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/worklo
 # │ │ │ │ │
 # * * * * *
 ```
-
-{{% alert title="Note" color="primary" %}}
-Timezones are not supported. Most images default to UTC, but it is best practice to ensure this is the case when considering how to define your budgets.
-{{% /alert %}}
 
 #### Duration
 Duration allows compound durations with minutes and hours values such as `10h5m` or `30m` or `160h`. Since cron syntax does not accept denominations smaller than minutes, users can only define minutes or hours.

--- a/website/content/en/v0.35/concepts/disruption.md
+++ b/website/content/en/v0.35/concepts/disruption.md
@@ -223,7 +223,7 @@ spec:
 
 #### Schedule
 Schedule is a cronjob schedule. Generally, the cron syntax is five space-delimited values with options below, with additional special macros like `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax.
+Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax. Timezones are not currently supported. Schedules are always in UTC.
 
 ```bash
 # ┌───────────── minute (0 - 59)
@@ -236,10 +236,6 @@ Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/worklo
 # │ │ │ │ │
 # * * * * *
 ```
-
-{{% alert title="Note" color="primary" %}}
-Timezones are not supported. Most images default to UTC, but it is best practice to ensure this is the case when considering how to define your budgets.
-{{% /alert %}}
 
 #### Duration
 Duration allows compound durations with minutes and hours values such as `10h5m` or `30m` or `160h`. Since cron syntax does not accept denominations smaller than minutes, users can only define minutes or hours.

--- a/website/content/en/v0.36/concepts/disruption.md
+++ b/website/content/en/v0.36/concepts/disruption.md
@@ -227,7 +227,7 @@ spec:
 
 #### Schedule
 Schedule is a cronjob schedule. Generally, the cron syntax is five space-delimited values with options below, with additional special macros like `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
-Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax.
+Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) for more information on how to follow the cron syntax. Timezones are not currently supported. Schedules are always in UTC.
 
 ```bash
 # ┌───────────── minute (0 - 59)
@@ -240,10 +240,6 @@ Follow the [Kubernetes documentation](https://kubernetes.io/docs/concepts/worklo
 # │ │ │ │ │
 # * * * * *
 ```
-
-{{% alert title="Note" color="primary" %}}
-Timezones are not supported. Most images default to UTC, but it is best practice to ensure this is the case when considering how to define your budgets.
-{{% /alert %}}
 
 #### Duration
 Duration allows compound durations with minutes and hours values such as `10h5m` or `30m` or `160h`. Since cron syntax does not accept denominations smaller than minutes, users can only define minutes or hours.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change clarifies a note around whether budget schedules are UTC or not depending on the image. Since the latest patch on v0.35, budgets are _always_ treated as UTC.

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.