### PR TITLE
feat: Add annotations only to the karpenter service

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -41,6 +41,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:0.36.0 \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalAnnotations | object | `{}` | Additional annotations to add into metadata. |
+| serviceAnnotations | object | `{}` | Additional annotations to add into service metadata. |
 | additionalClusterRoleRules | list | `[]` | Specifies additional rules for the core ClusterRole. |
 | additionalLabels | object | `{}` | Additional labels to add into metadata. |
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"karpenter.sh/nodepool","operator":"DoesNotExist"}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity rules for scheduling the pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |

--- a/charts/karpenter/templates/service.yaml
+++ b/charts/karpenter/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
+  {{- with .Values.serviceAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -8,6 +8,8 @@ additionalLabels: {}
 
 # -- Additional annotations to add into metadata.
 additionalAnnotations: {}
+# -- Additional annotations to add into service metadata.
+serviceAnnotations: {}
 # -- Image pull policy for Docker images.
 imagePullPolicy: IfNotPresent
 # -- Image pull secrets for Docker images.


### PR DESCRIPTION
**Description**
Allow to put some annotations only for the service. It's useful when we have some prometheus operator and I don't want to put my prometheus annotations on every resources.
**How was this change tested?**
I deployed it using the chart locally. As it's a very small change it's ok :)
**Does this change impact docs?**

- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.