### PR TITLE
docs: Fix reference to total cluster size constraint

### DIFF
--- a/website/content/en/docs/concepts/nodepools.md
+++ b/website/content/en/docs/concepts/nodepools.md
@@ -157,7 +157,7 @@ spec:
       duration: 8h
       nodes: "0"
 
-  # Resource limits constrain the total size of the cluster.
+  # Resource limits constrain the total size of the pool.
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     cpu: "1000"

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -157,7 +157,7 @@ spec:
       duration: 8h
       nodes: "0"
 
-  # Resource limits constrain the total size of the cluster.
+  # Resource limits constrain the total size of the pool.
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     cpu: "1000"

--- a/website/content/en/v0.32/concepts/nodepools.md
+++ b/website/content/en/v0.32/concepts/nodepools.md
@@ -140,7 +140,7 @@ spec:
     # You can choose to disable expiration entirely by setting the string value 'Never' here
     expireAfter: 720h
 
-  # Resource limits constrain the total size of the cluster.
+  # Resource limits constrain the total size of the pool.
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     cpu: "1000"

--- a/website/content/en/v0.34/concepts/nodepools.md
+++ b/website/content/en/v0.34/concepts/nodepools.md
@@ -150,7 +150,7 @@ spec:
       duration: 8h
       nodes: "0"
 
-  # Resource limits constrain the total size of the cluster.
+  # Resource limits constrain the total size of the pool.
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     cpu: "1000"

--- a/website/content/en/v0.35/concepts/nodepools.md
+++ b/website/content/en/v0.35/concepts/nodepools.md
@@ -157,7 +157,7 @@ spec:
       duration: 8h
       nodes: "0"
 
-  # Resource limits constrain the total size of the cluster.
+  # Resource limits constrain the total size of the pool.
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     cpu: "1000"

--- a/website/content/en/v0.36/concepts/nodepools.md
+++ b/website/content/en/v0.36/concepts/nodepools.md
@@ -157,7 +157,7 @@ spec:
       duration: 8h
       nodes: "0"
 
-  # Resource limits constrain the total size of the cluster.
+  # Resource limits constrain the total size of the pool.
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     cpu: "1000"


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
Node pool `limits` field is incorrectly commented in the example as constraining the total size of the cluster

**How was this change tested?**
N/A

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.