### PR TITLE
feat: Add nodepool label to karpenter_interruption_actions_performed

### DIFF
--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -194,7 +194,6 @@ func (c *Controller) handleNodeClaim(ctx context.Context, msg messages.Message, 
 			metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 		},
 	).Inc()
-	actionsPerformed.WithLabelValues(string(action)).Inc()
 
 	// Mark the offering as unavailable in the ICE cache since we got a spot interruption warning
 	if msg.Kind() == messages.SpotInterruptionKind {

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -188,6 +188,12 @@ func (c *Controller) handleNodeClaim(ctx context.Context, msg messages.Message, 
 
 	// Record metric and event for this action
 	c.notifyForMessage(msg, nodeClaim, node)
+	actionsPerformed.With(
+		prometheus.Labels{
+			actionTypeLabel:       string(action),
+			metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		},
+	).Inc()
 	actionsPerformed.WithLabelValues(string(action)).Inc()
 
 	// Mark the offering as unavailable in the ICE cache since we got a spot interruption warning

--- a/pkg/controllers/interruption/metrics.go
+++ b/pkg/controllers/interruption/metrics.go
@@ -25,6 +25,7 @@ const (
 	interruptionSubsystem  = "interruption"
 	messageTypeLabel       = "message_type"
 	actionTypeLabel        = "action_type"
+	nodePoolLabel          = "nodepool"
 	terminationReasonLabel = "interruption"
 )
 
@@ -62,7 +63,10 @@ var (
 			Name:      "actions_performed",
 			Help:      "Number of notification actions performed. Labeled by action",
 		},
-		[]string{actionTypeLabel},
+		[]string{
+			actionTypeLabel,
+			metrics.NodePoolLabel,
+		},
 	)
 )
 

--- a/pkg/controllers/interruption/metrics.go
+++ b/pkg/controllers/interruption/metrics.go
@@ -25,7 +25,6 @@ const (
 	interruptionSubsystem  = "interruption"
 	messageTypeLabel       = "message_type"
 	actionTypeLabel        = "action_type"
-	nodePoolLabel          = "nodepool"
 	terminationReasonLabel = "interruption"
 )
 

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -37,7 +37,7 @@ import (
 type Provider interface {
 	LivenessProbe(*http.Request) error
 	List(context.Context, *v1beta1.EC2NodeClass) ([]*ec2.Subnet, error)
-	AssociatePublicIPAddressValue( *v1beta1.EC2NodeClass) (*bool)
+	AssociatePublicIPAddressValue(*v1beta1.EC2NodeClass) *bool
 	ZonalSubnetsForLaunch(context.Context, *v1beta1.EC2NodeClass, []*cloudprovider.InstanceType, string) (map[string]*Subnet, error)
 	UpdateInflightIPs(*ec2.CreateFleetInput, *ec2.CreateFleetOutput, []*cloudprovider.InstanceType, []*Subnet, string)
 }


### PR DESCRIPTION
Fixes #6093 

Understanding/Filtering actions being performed by interruption message based on what nodepool is useful, especially if a lot of different nodepools are used. Some of the nodepools need are more important than other, so viewing just specific events helps debugging events in cluster.

**How was this change tested?**

Tested in personal cluster.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.