### PR TITLE
feat: support multiple clusterDNS

### DIFF
--- a/pkg/providers/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/eksbootstrap.go
@@ -119,6 +119,14 @@ func (e EKS) isIPv6() bool {
 	if e.KubeletConfig == nil || len(e.KubeletConfig.ClusterDNS) == 0 {
 		return false
 	}
+
+	ips := strings.Split(e.KubeletConfig.ClusterDNS[0], ",")
+	for _, ip := range ips {
+		if net.ParseIP(strings.TrimSpace(ip)).To4() == nil {
+			return true
+		}
+	}
+
 	return net.ParseIP(e.KubeletConfig.ClusterDNS[0]).To4() == nil
 }
 

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1252,6 +1252,15 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectLaunchTemplatesCreatedWithUserDataContaining("--dns-cluster-ip 'fd4b:121b:812b::a'")
 			ExpectLaunchTemplatesCreatedWithUserDataContaining("--ip-family ipv6")
 		})
+		It("should specify --dns-cluster-ip and not --ip-family when running in an ipv4 cluster with multiple clusterDNS", func() {
+			awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("10.0.100.10,10.0.100.11")
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+			ExpectLaunchTemplatesCreatedWithUserDataContaining("--dns-cluster-ip '10.0.100.10,10.0.100.11'")
+			ExpectLaunchTemplatesCreatedWithUserDataNotContaining("--ip-family ipv6")
+		})
 		It("should specify --dns-cluster-ip when running in an ipv4 cluster", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #4934

**Description**
This change will support us bypass multiple clusterDNS with comma separated IP list and not being treated as IPv6

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.