### PR TITLE
test: fix daemonset sensitive tests

### DIFF
--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -560,7 +560,14 @@ var _ = Describe("Consolidation", func() {
 						},
 					},
 					ResourceRequirements: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1.5")},
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: func() resource.Quantity {
+								dsOverhead := env.GetDaemonSetOverhead(nodePool)
+								base := lo.ToPtr(resource.MustParse("1800m"))
+								base.Sub(*dsOverhead.Cpu())
+								return *base
+							}(),
+						},
 					},
 				},
 			})
@@ -673,7 +680,13 @@ var _ = Describe("Consolidation", func() {
 					},
 				},
 				ResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1.5")},
+					Requests: v1.ResourceList{v1.ResourceCPU: func() resource.Quantity {
+						dsOverhead := env.GetDaemonSetOverhead(nodePool)
+						base := lo.ToPtr(resource.MustParse("1800m"))
+						base.Sub(*dsOverhead.Cpu())
+						return *base
+					}(),
+					},
 				},
 			},
 		})

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -272,13 +272,6 @@ var _ = Describe("Drift", func() {
 						Values:   []string{"xlarge"},
 					},
 				},
-				// Add an Exists operator so that we can select on a fake partition later
-				corev1beta1.NodeSelectorRequirementWithMinValues{
-					NodeSelectorRequirement: v1.NodeSelectorRequirement{
-						Key:      "test-partition",
-						Operator: v1.NodeSelectorOpExists,
-					},
-				},
 			)
 			nodePool.Labels = appLabels
 			// We're expecting to create 5 nodes, so we'll expect to see at most 3 nodes deleting at one time.
@@ -286,36 +279,29 @@ var _ = Describe("Drift", func() {
 				Nodes: "3",
 			}}
 
-			// Make 5 pods all with different deployments and different test partitions, so that each pod can be put
-			// on a separate node.
-			selector = labels.SelectorFromSet(appLabels)
-			numPods = 5
-			deployments := make([]*appsv1.Deployment, numPods)
-			for i := range lo.Range(numPods) {
-				deployments[i] = coretest.Deployment(coretest.DeploymentOptions{
-					Replicas: 1,
-					PodOptions: coretest.PodOptions{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: appLabels,
-						},
-						NodeSelector: map[string]string{"test-partition": fmt.Sprintf("%d", i)},
-						// Each xlarge has 4 cpu, so each node should fit no more than 1 pod.
-						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceCPU: resource.MustParse("3"),
-							},
-						},
+			// Create a 5 pod deployment with hostname inter-pod anti-affinity to ensure each pod is placed on a unique node
+			deployment := coretest.Deployment(coretest.DeploymentOptions{
+				Replicas: 5,
+				PodOptions: coretest.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: appLabels,
 					},
-				})
-			}
+					PodAntiRequirements: []v1.PodAffinityTerm{{
+						TopologyKey: v1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: appLabels,
+						},
+					}},
+				},
+			})
 
-			env.ExpectCreated(nodeClass, nodePool, deployments[0], deployments[1], deployments[2], deployments[3], deployments[4])
+			env.ExpectCreated(nodeClass, nodePool, deployment)
 
 			originalNodeClaims := env.EventuallyExpectCreatedNodeClaimCount("==", 5)
 			originalNodes := env.EventuallyExpectCreatedNodeCount("==", 5)
 
 			// Check that all deployment pods are online
-			env.EventuallyExpectHealthyPodCount(selector, numPods)
+			env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(appLabels), numPods)
 
 			By("cordoning and adding finalizer to the nodes")
 			// Add a finalizer to each node so that we can stop termination disruptions

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -450,11 +450,37 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 				if version, err := env.GetK8sMinorVersion(0); err != nil || version < 29 {
 					Skip("native sidecar containers are only enabled on EKS 1.29+")
 				}
+
+				labels := map[string]string{"test": test.RandomName()}
+				// Create a buffer pod to even out the total resource requests regardless of the daemonsets on the cluster. Assumes
+				// CPU is the resource in contention and that total daemonset CPU requests <= 3.
+				dsBufferPod := test.Pod(test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					PodRequirements: []v1.PodAffinityTerm{{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: labels,
+						},
+						TopologyKey: v1.LabelHostname,
+					}},
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: func() resource.Quantity {
+								dsOverhead := env.GetDaemonSetOverhead(nodePool)
+								base := lo.ToPtr(resource.MustParse("3"))
+								base.Sub(*dsOverhead.Cpu())
+								return *base
+							}(),
+						},
+					},
+				})
+
 				test.ReplaceRequirements(nodePool, corev1beta1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: v1.NodeSelectorRequirement{
 						Key:      v1beta1.LabelInstanceCPU,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{"1", "2"},
+						Values:   []string{"4", "8"},
 					},
 				}, corev1beta1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: v1.NodeSelectorRequirement{
@@ -464,15 +490,24 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 					},
 				})
 				pod := test.Pod(test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					PodRequirements: []v1.PodAffinityTerm{{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: labels,
+						},
+						TopologyKey: v1.LabelHostname,
+					}},
 					InitContainers:       initContainers,
 					ResourceRequirements: containerRequirements,
 				})
-				env.ExpectCreated(nodePool, nodeClass, pod)
+				env.ExpectCreated(nodePool, nodeClass, dsBufferPod, pod)
 				env.EventuallyExpectHealthy(pod)
 				node := env.ExpectCreatedNodeCount("==", 1)[0]
 				Expect(node.ObjectMeta.GetLabels()[v1beta1.LabelInstanceCPU]).To(Equal(expectedNodeCPU))
 			},
-			Entry("sidecar requirements + later init requirements do exceed container requirements", "2", v1.ResourceRequirements{
+			Entry("sidecar requirements + later init requirements do exceed container requirements", "8", v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("400m")},
 			}, ephemeralInitContainer(v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("300m")},
@@ -484,7 +519,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 			}, ephemeralInitContainer(v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
 			})),
-			Entry("sidecar requirements + later init requirements do not exceed container requirements", "1", v1.ResourceRequirements{
+			Entry("sidecar requirements + later init requirements do not exceed container requirements", "4", v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("400m")},
 			}, ephemeralInitContainer(v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("300m")},
@@ -496,7 +531,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 			}, ephemeralInitContainer(v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("300m")},
 			})),
-			Entry("init container requirements exceed all later requests", "2", v1.ResourceRequirements{
+			Entry("init container requirements exceed all later requests", "8", v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("400m")},
 			}, v1.Container{
 				RestartPolicy: lo.ToPtr(v1.ContainerRestartPolicyAlways),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes several tests which are sensitive to the number of daemonsets in the test environment. This is due to assumptions about the size of node a given pod would fit on. This assumption was broken by #5982 which added an additional daemonset.

**How was this change tested?**
`karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.