### PR TITLE
pref: Reduce the number of `DescribeImages` calls

### DIFF
--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -45,6 +46,7 @@ type Provider interface {
 }
 
 type DefaultProvider struct {
+	sync.RWMutex
 	cache           *cache.Cache
 	ssm             ssmiface.SSMAPI
 	ec2api          ec2iface.EC2API
@@ -117,6 +119,9 @@ func NewDefaultProvider(versionProvider version.Provider, ssm ssmiface.SSMAPI, e
 
 // Get Returning a list of AMIs with its associated requirements
 func (p *DefaultProvider) Get(ctx context.Context, nodeClass *v1beta1.EC2NodeClass, options *Options) (AMIs, error) {
+	p.Lock()
+	defer p.Unlock()
+
 	var err error
 	var amis AMIs
 	if len(nodeClass.Spec.AMISelectorTerms) == 0 {

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -46,7 +46,7 @@ type Provider interface {
 }
 
 type DefaultProvider struct {
-	sync.RWMutex
+	sync.Mutex
 	cache           *cache.Cache
 	ssm             ssmiface.SSMAPI
 	ec2api          ec2iface.EC2API
@@ -204,7 +204,7 @@ func (p *DefaultProvider) getAMIs(ctx context.Context, terms []v1beta1.AMISelect
 			// Don't include filters in the Describe Images call as EC2 API doesn't allow empty filters.
 			Filters:    lo.Ternary(len(filtersAndOwners.Filters) > 0, filtersAndOwners.Filters, nil),
 			Owners:     lo.Ternary(len(filtersAndOwners.Owners) > 0, aws.StringSlice(filtersAndOwners.Owners), nil),
-			MaxResults: aws.Int64(500),
+			MaxResults: aws.Int64(1000),
 		}, func(page *ec2.DescribeImagesOutput, _ bool) bool {
 			for i := range page.Images {
 				reqs := p.getRequirementsFromImage(page.Images[i])

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -43,7 +43,7 @@ type Provider interface {
 }
 
 type DefaultProvider struct {
-	sync.RWMutex
+	sync.Mutex
 	ec2api                        ec2iface.EC2API
 	cache                         *cache.Cache
 	availableIPAddressCache       *cache.Cache


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5997

**Description**
- Karpenter currently does not have any locking mechanism during its read and write operation for AMIs that are stored in the cache. Adding in locks to synchronize the cache for identical AMISelectorTerms
- The DescribeImages API does not filter out AMIs before fetching AMIs by tags. This will result in the DescribeImages API sending empty pages(This is currently expected behavior). The best mitigation here will for Karpenter to increases page sizes to reduce the number of request that are made.

**How was this change tested?**
- Result from testing 
- I had 20 EC2NodeClass with Identical AMISelectorTerms set 
```
  amiSelectorTerms:
  - tags:
      testing: aengeda
```
- Number of DescribeImages call from main: 1604
- Number of DescribeImages call from with Improvements: 79

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.