### PR TITLE
ci: Fix docgen by calling providers directly

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -148,9 +148,6 @@ func (c *CloudProvider) LivenessProbe(req *http.Request) error {
 
 // GetInstanceTypes returns all available InstanceTypes
 func (c *CloudProvider) GetInstanceTypes(ctx context.Context, nodePool *corev1beta1.NodePool) ([]*cloudprovider.InstanceType, error) {
-	if nodePool == nil {
-		return c.instanceTypeProvider.List(ctx, &corev1beta1.KubeletConfiguration{}, &v1beta1.EC2NodeClass{})
-	}
 	nodeClass, err := c.resolveNodeClassFromNodePool(ctx, nodePool)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -104,10 +104,6 @@ func (p *DefaultProvider) List(ctx context.Context, kc *corev1beta1.KubeletConfi
 	if kc == nil {
 		kc = &corev1beta1.KubeletConfiguration{}
 	}
-	if nodeClass == nil {
-		nodeClass = &v1beta1.EC2NodeClass{}
-	}
-
 	if len(p.instanceTypesInfo) == 0 {
 		return nil, fmt.Errorf("no instance types found")
 	}

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -326,7 +326,7 @@ func ENILimitedPods(ctx context.Context, info *ec2.InstanceTypeInfo) *resource.Q
 	// VPC CNI only uses the default network interface
 	// https://github.com/aws/amazon-vpc-cni-k8s/blob/3294231c0dce52cfe473bf6c62f47956a3b333b6/scripts/gen_vpc_ip_limits.go#L162
 	networkInterfaces := *info.NetworkInfo.NetworkCards[*info.NetworkInfo.DefaultNetworkCardIndex].MaximumNetworkInterfaces
-	usableNetworkInterfaces := lo.Max([]int64{(networkInterfaces - int64(options.FromContext(ctx).ReservedENIs)), 0})
+	usableNetworkInterfaces := lo.Max([]int64{networkInterfaces - int64(options.FromContext(ctx).ReservedENIs), 0})
 	if usableNetworkInterfaces == 0 {
 		return resource.NewQuantity(0, resource.DecimalSI)
 	}

--- a/website/content/en/preview/reference/instance-types.md
+++ b/website/content/en/preview/reference/instance-types.md
@@ -3174,8 +3174,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|238333Mi|
- |pods|345|
+ |memory|237794Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ### `c6in.metal`
@@ -3200,8 +3200,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|238333Mi|
- |pods|345|
+ |memory|237794Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ## c7a Family
@@ -11192,8 +11192,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|480816Mi|
- |pods|345|
+ |memory|480277Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ### `m6idn.metal`
@@ -11219,8 +11219,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|480816Mi|
- |pods|345|
+ |memory|480277Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ## m6in Family
@@ -11446,8 +11446,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|480816Mi|
- |pods|345|
+ |memory|480277Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ### `m6in.metal`
@@ -11472,8 +11472,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|480816Mi|
- |pods|345|
+ |memory|480277Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ## m7a Family
@@ -16231,8 +16231,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|965782Mi|
- |pods|345|
+ |memory|965243Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ### `r6idn.metal`
@@ -16258,8 +16258,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|965782Mi|
- |pods|345|
+ |memory|965243Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ## r6in Family
@@ -16485,8 +16485,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|965782Mi|
- |pods|345|
+ |memory|965243Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ### `r6in.metal`
@@ -16511,8 +16511,8 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |cpu|127610m|
  |ephemeral-storage|17Gi|
- |memory|965782Mi|
- |pods|345|
+ |memory|965243Mi|
+ |pods|394|
  |vpc.amazonaws.com/efa|2|
  |vpc.amazonaws.com/pod-eni|108|
 ## r7a Family


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change fixes calling `make docgen` and the instance types generation by calling the providers directly.

**How was this change tested?**

`make docgen`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.