### PR TITLE
ci: Remove daemonsets causing testing issues

### DIFF
--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -216,6 +216,17 @@ runs:
       # amazon-cloudwatch-observability pods do no not tolerate CriticalAddonsOnly=true:NoSchedule and 
       # amazon-cloudwatch-observability addons does not allow to add tolerations to the addon pods as part of the advanced configuration
       kubectl taint nodes CriticalAddonsOnly=true:NoSchedule --all
+      
+      # We delete DaemonSets that we don't care about because it causes inconsistencies in scheduling due to 
+      # dcgm-exporter and neuron-monitor selecting on specific instance types
+      # See https://github.com/kubernetes-sigs/karpenter/issues/715 for more detail
+      kubectl delete daemonsets -n amazon-cloudwatch dcgm-exporter neuron-monitor
+      
+      # We patch the priorityClass onto all DaemonSets to ensure that DaemonSets always schedule to nodes so we don't get scheduling inconsistencies
+      # See https://karpenter.sh/docs/faq/#when-deploying-an-additional-daemonset-to-my-cluster-why-does-karpenter-not-scale-up-my-nodes-to-support-the-extra-daemonset for more detail
+      for DAEMONSET in "cloudwatch-agent" "cloudwatch-agent-windows" "fluent-bit" "fluent-bit-windows"; do
+        kubectl patch daemonset -n amazon-cloudwatch $DAEMONSET -p '{"spec":{"template":{"spec":{"priorityClassName":"system-node-critical"}}}}' --type=merge
+      done
   - name: tag oidc provider of the cluster
     if: always()
     shell: bash


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change removes Daemonsets in the CWA add-on that we don't care about and ensures that we don't miscalculate DaemonSet capacity during scheduling due to: https://github.com/kubernetes-sigs/karpenter/issues/715. This also patches on the priority class so that we ensure that we always schedule these pods.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.