### PR TITLE
feat:  Added an interruption taint to the nodes

### DIFF
--- a/pkg/apis/v1beta1/taints.go
+++ b/pkg/apis/v1beta1/taints.go
@@ -1,0 +1,10 @@
+package v1beta1
+
+// Karpenter aws specific taints
+var (
+	InterruptionTaintKey                          = Group + "/interruption"
+	InterruptionRebalanceRecommendationTaintValue = "RebalanceRecommendation"
+	InterruptionScheduledChangeTaintValue         = "ScheduledChange"
+	InterruptionSpotInterruptionTaintValue        = "SpotInterruption"
+	InterruptionStateChangeTaintValue             = "StateChange"
+)

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -179,6 +179,7 @@ If interruption-handling is enabled, Karpenter will watch for upcoming involunta
 * Instance Stopping Events
 
 When Karpenter detects one of these events will occur to your nodes, it automatically taints, drains, and terminates the node(s) ahead of the interruption event to give the maximum amount of time for workload cleanup prior to compute disruption. This enables scenarios where the `terminationGracePeriod` for your workloads may be long or cleanup for your workloads is critical, and you want enough time to be able to gracefully clean-up your pods.
+The node will also be tainted according to the interruption, the taint key is `karpenter.k8s.aws/interruption`, the value denotes which interruption is happening to the node.
 
 For Spot interruptions, the NodePool will start a new node as soon as it sees the Spot interruption warning. Spot interruptions have a __2 minute notice__ before Amazon EC2 reclaims the instance. Karpenter's average node startup time means that, generally, there is sufficient time for the new node to become ready and to move the pods to the new node before the NodeClaim is reclaimed.
 


### PR DESCRIPTION
That way pods can look at the node to see if they were interrupted because of a spot interrupt

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #6103  <!-- issue number -->

**Description**

Added a taint to the nodes when there is an interruption happening

**How was this change tested?**

Unit test

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.