### PR TITLE
feat: per-instance type VM memory overhead percentages

### DIFF
--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -26,6 +26,7 @@ func (o Options) Validate() error {
 	return multierr.Combine(
 		o.validateEndpoint(),
 		o.validateVMMemoryOverheadPercent(),
+		o.validatePerInstanceVMMemoryOverheadPercent(),
 		o.validateAssumeRoleDuration(),
 		o.validateReservedENIs(),
 		o.validateRequiredFields(),
@@ -55,6 +56,15 @@ func (o Options) validateEndpoint() error {
 func (o Options) validateVMMemoryOverheadPercent() error {
 	if o.VMMemoryOverheadPercent < 0 {
 		return fmt.Errorf("vm-memory-overhead-percent cannot be negative")
+	}
+	return nil
+}
+
+func (o Options) validatePerInstanceVMMemoryOverheadPercent() error {
+	for instanceType, percent := range o.PerInstanceTypeVMMemoryOverheadPercent {
+		if percent < 0 {
+			return fmt.Errorf("per-instance-vm-memory-overhead-percent cannot be negative: %s", instanceType)
+		}
 	}
 	return nil
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -25,15 +25,16 @@ import (
 )
 
 type OptionsFields struct {
-	AssumeRoleARN           *string
-	AssumeRoleDuration      *time.Duration
-	ClusterCABundle         *string
-	ClusterName             *string
-	ClusterEndpoint         *string
-	IsolatedVPC             *bool
-	VMMemoryOverheadPercent *float64
-	InterruptionQueue       *string
-	ReservedENIs            *int
+	AssumeRoleARN                          *string
+	AssumeRoleDuration                     *time.Duration
+	ClusterCABundle                        *string
+	ClusterName                            *string
+	ClusterEndpoint                        *string
+	IsolatedVPC                            *bool
+	VMMemoryOverheadPercent                *float64
+	InterruptionQueue                      *string
+	ReservedENIs                           *int
+	PerInstanceTypeVMMemoryOverheadPercent *options.PerInstanceTypeVMMemoryOverheadPercent
 }
 
 func Options(overrides ...OptionsFields) *options.Options {
@@ -44,14 +45,15 @@ func Options(overrides ...OptionsFields) *options.Options {
 		}
 	}
 	return &options.Options{
-		AssumeRoleARN:           lo.FromPtrOr(opts.AssumeRoleARN, ""),
-		AssumeRoleDuration:      lo.FromPtrOr(opts.AssumeRoleDuration, 15*time.Minute),
-		ClusterCABundle:         lo.FromPtrOr(opts.ClusterCABundle, ""),
-		ClusterName:             lo.FromPtrOr(opts.ClusterName, "test-cluster"),
-		ClusterEndpoint:         lo.FromPtrOr(opts.ClusterEndpoint, "https://test-cluster"),
-		IsolatedVPC:             lo.FromPtrOr(opts.IsolatedVPC, false),
-		VMMemoryOverheadPercent: lo.FromPtrOr(opts.VMMemoryOverheadPercent, 0.075),
-		InterruptionQueue:       lo.FromPtrOr(opts.InterruptionQueue, ""),
-		ReservedENIs:            lo.FromPtrOr(opts.ReservedENIs, 0),
+		AssumeRoleARN:                          lo.FromPtrOr(opts.AssumeRoleARN, ""),
+		AssumeRoleDuration:                     lo.FromPtrOr(opts.AssumeRoleDuration, 15*time.Minute),
+		ClusterCABundle:                        lo.FromPtrOr(opts.ClusterCABundle, ""),
+		ClusterName:                            lo.FromPtrOr(opts.ClusterName, "test-cluster"),
+		ClusterEndpoint:                        lo.FromPtrOr(opts.ClusterEndpoint, "https://test-cluster"),
+		IsolatedVPC:                            lo.FromPtrOr(opts.IsolatedVPC, false),
+		VMMemoryOverheadPercent:                lo.FromPtrOr(opts.VMMemoryOverheadPercent, 0.075),
+		PerInstanceTypeVMMemoryOverheadPercent: lo.FromPtrOr(opts.PerInstanceTypeVMMemoryOverheadPercent, options.PerInstanceTypeVMMemoryOverheadPercent{}),
+		InterruptionQueue:                      lo.FromPtrOr(opts.InterruptionQueue, ""),
+		ReservedENIs:                           lo.FromPtrOr(opts.ReservedENIs, 0),
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Bandaid for https://github.com/aws/karpenter-provider-aws/issues/5161, without trying to solve the problem globally for all EC2 instance types

**Description**

As originally discussed in https://github.com/kubernetes-sigs/karpenter/issues/716 the global `vmMemoryOverheadPercent` option is limiting when running on a heterogeneous set of nodes. For instance, a small EC2 instance may require ~7% overhead, but the larger nodes may only require 1-2% overhead. Undersizing this values risks provisioning nodes that cannot actually run the pods it's intended for, and oversizing is inefficient / expensive.

This PR is a strawman proposal for solving this problem: allow Karpenter to accept a mapping of instance type to memory overhead percentage, and fall back to the global `vmMemoryOverheadPercent` if no specific mapping exists. For our deployment this would allow us to create a mapping for the instance types we care about, and potentially sets up the suggestion in #5161 of "We could launch instance types, check their capacity and diff the reported capacity from the actual capacity in a generated file that can be shipped with Karpenter on release so we always have accurate measurements on the instance type overhead"

**How was this change tested?**

It hasn't been yet! Before going further on the tests, I wanted to gather input into whether this change might be accepted at all first.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.