### PR TITLE
ci: bump upgrade suite source commit

### DIFF
--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -215,7 +215,8 @@ runs:
       # Adding taints after all necessary pods have scheduled to the manged node group nodes
       # amazon-cloudwatch-observability pods do no not tolerate CriticalAddonsOnly=true:NoSchedule and
       # amazon-cloudwatch-observability addons does not allow to add tolerations to the addon pods as part of the advanced configuration
-      kubectl taint nodes CriticalAddonsOnly=true:NoSchedule --all
+      # Overwrite existing taints to ensure we don't fail here on upgrade
+      kubectl taint nodes CriticalAddonsOnly=true:NoSchedule --all --overwrite
 
       # We delete DaemonSets that we don't care about because it causes inconsistencies in scheduling due to
       # dcgm-exporter and neuron-monitor selecting on specific instance types

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -95,7 +95,7 @@ jobs:
       statuses: write # ./.github/actions/commit-status/start
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      from_git_ref: 283e7b2a51ec73903a6d3f9362fc3009b898ef33
+      from_git_ref: 39057a50b32fe11f720662ede8e968f218d998ed
       to_git_ref: ${{ inputs.git_ref }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Bumps the source version for the upgrade suite to be after the cloudwatch infrastructure changes.

**How was this change tested?**
N/A (can't test top-level workflow changes w/ `/karpenter snapshot`)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.