### PR TITLE
ci: Clean leaked `VPC-resource-controller` ENIs

### DIFF
--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -26,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 
 	"github.com/aws/karpenter-provider-aws/test/hack/resource/pkg/metrics"
 	"github.com/aws/karpenter-provider-aws/test/hack/resource/pkg/resourcetypes"
@@ -69,7 +69,7 @@ func main() {
 	resourceTypes := []resourcetypes.Type{
 		resourcetypes.NewInstance(ec2Client),
 		resourcetypes.NewVPCEndpoint(ec2Client),
-		resourcetypes.NewENI(ec2Client),
+		resourcetypes.NewENI(ec2Client, cloudFormationClient),
 		resourcetypes.NewSecurityGroup(ec2Client),
 		resourcetypes.NewLaunchTemplate(ec2Client),
 		resourcetypes.NewOIDC(iamClient),

--- a/test/hack/resource/count/main.go
+++ b/test/hack/resource/count/main.go
@@ -44,7 +44,7 @@ func main() {
 	resourceTypes := []resourcetypes.Type{
 		resourcetypes.NewInstance(ec2Client),
 		resourcetypes.NewVPCEndpoint(ec2Client),
-		resourcetypes.NewENI(ec2Client),
+		resourcetypes.NewENI(ec2Client, cloudFormationClient),
 		resourcetypes.NewSecurityGroup(ec2Client),
 		resourcetypes.NewLaunchTemplate(ec2Client),
 		resourcetypes.NewOIDC(iamClient),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Clean-up ENIs that are created and leaked by the `vpc-resource-controller`

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.