### PR TITLE
chore: Update `associatePublicIPAddress` to not be set in the launch templets

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -32,9 +32,9 @@ const (
 	// InstanceProfileTTL is the time before we refresh checking instance profile existence at IAM
 	InstanceProfileTTL = 15 * time.Minute
 	// AvailableIPAddressTTL is time to drop AvailableIPAddress data if it is not updated within the TTL
-	AvailableIPAddressTTL = 2 * time.Minute
+	AvailableIPAddressTTL = 5 * time.Minute
 	// AvailableIPAddressTTL is time to drop AssociatePublicIPAddressTTL data if it is not updated within the TTL
-	AssociatePublicIPAddressTTL = 2 * time.Minute
+	AssociatePublicIPAddressTTL = 5 * time.Minute
 )
 
 const (

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -188,15 +188,13 @@ func (p *DefaultProvider) createAMIOptions(ctx context.Context, nodeClass *v1bet
 	}
 	if nodeClass.Spec.AssociatePublicIPAddress != nil {
 		options.AssociatePublicIPAddress = nodeClass.Spec.AssociatePublicIPAddress
-	} else if ok, err := p.subnetProvider.CheckAnyPublicIPAssociations(ctx, nodeClass); err != nil {
-		return nil, err
-	} else if !ok {
+	} else {
 		// when `AssociatePublicIPAddress` is not specified in the `EC2NodeClass` spec,
 		// If all referenced subnets do not assign public IPv4 addresses to EC2 instances therein, we explicitly set
 		// AssociatePublicIPAddress to 'false' in the Launch Template, generated based on this configuration struct.
 		// This is done to help comply with AWS account policies that require explicitly setting of that field to 'false'.
 		// https://github.com/aws/karpenter-provider-aws/issues/3815
-		options.AssociatePublicIPAddress = aws.Bool(false)
+		options.AssociatePublicIPAddress = p.subnetProvider.AssociatePublicIPAddressValue(nodeClass)
 	}
 	return options, nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Before this change https://github.com/aws/karpenter-provider-aws/pull/6057, If a customer did not set `associatePublicIPAddress` in their nodeclass, Karpenter would auto discover setting `associatePublicIPAddress` on launch templates by seeing if any of the subnets can add public IPs. If not, the field would be set to `nil` on launch templates. After PR 6057, we would set `associatePublicIPAddress` to false in the launch template. This PR looks to make feature parity by setting `associatePublicIPAddress` on launch template to `nil`.

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.