### PR TITLE
test: fix race in flakey drift test

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -479,12 +479,13 @@ func (env *Environment) ExpectNodeCount(comparator string, count int) {
 	Expect(len(nodeList.Items)).To(BeNumerically(comparator, count))
 }
 
-func (env *Environment) ExpectNodeClaimCount(comparator string, count int) {
+func (env *Environment) ExpectNodeClaimCount(comparator string, count int) []*corev1beta1.NodeClaim {
 	GinkgoHelper()
 
 	nodeClaimList := &corev1beta1.NodeClaimList{}
 	Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
 	Expect(len(nodeClaimList.Items)).To(BeNumerically(comparator, count))
+	return lo.ToSlicePtr(nodeClaimList.Items)
 }
 
 func NodeClaimNames(nodeClaims []*corev1beta1.NodeClaim) []string {

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -479,13 +479,12 @@ func (env *Environment) ExpectNodeCount(comparator string, count int) {
 	Expect(len(nodeList.Items)).To(BeNumerically(comparator, count))
 }
 
-func (env *Environment) ExpectNodeClaimCount(comparator string, count int) []*corev1beta1.NodeClaim {
+func (env *Environment) ExpectNodeClaimCount(comparator string, count int) {
 	GinkgoHelper()
 
 	nodeClaimList := &corev1beta1.NodeClaimList{}
 	Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
 	Expect(len(nodeClaimList.Items)).To(BeNumerically(comparator, count))
-	return lo.ToSlicePtr(nodeClaimList.Items)
 }
 
 func NodeClaimNames(nodeClaims []*corev1beta1.NodeClaim) []string {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes a flake in a drift test. The test eventually expects the original replacement nodeclaim to be deleted, and checks for this by expecting on the number of nodeclaims. The problem is a new replacement nodeclaim may be created between checks in the eventually block. 

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.