### PR TITLE
fix: Update Grafana `controller_runtime_reconcile_errors_total` to target a specific controller

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-controllers.json
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-controllers.json
@@ -351,7 +351,7 @@
         "datasource": {
           "uid": "${datasource}"
         },
-        "definition": "label_values(controller_runtime_reconcile_errors_total, controller)",
+        "definition": "label_values(controller_runtime_reconcile_errors_total{job=~\"karpenter\"}, controller)",
         "description": "Kubernetes controller",
         "error": null,
         "hide": 0,
@@ -361,7 +361,7 @@
         "name": "controller",
         "options": [],
         "query": {
-          "query": "label_values(controller_runtime_reconcile_errors_total, controller)",
+          "query": "label_values(controller_runtime_reconcile_errors_total{job=~\"karpenter\"}, controller)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
Fixes #6163

Description : add job in dashboard's label_values query to get controller values only from karpenter and not from other addons

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.