### PR TITLE
fix: Increase to large instance size for scale tests

### DIFF
--- a/.github/actions/e2e/install-prometheus/values.yaml
+++ b/.github/actions/e2e/install-prometheus/values.yaml
@@ -47,10 +47,10 @@ prometheus:
     resources:
       requests:
         cpu: 1
-        memory: 5Gi
+        memory: 15Gi
       limits:
         cpu: 1
-        memory: 5Gi
+        memory: 15Gi
     serviceMonitorSelector:
       matchLabels:
         scrape: enabled

--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -26,9 +26,9 @@ helm upgrade --install karpenter "${CHART}" \
   --set settings.clusterName="$CLUSTER_NAME" \
   --set settings.interruptionQueue="$CLUSTER_NAME" \
   --set settings.featureGates.spotToSpotConsolidation=true \
-  --set controller.resources.requests.cpu=3 \
+  --set controller.resources.requests.cpu=5 \
   --set controller.resources.requests.memory=3Gi \
-  --set controller.resources.limits.cpu=3 \
+  --set controller.resources.limits.cpu=5 \
   --set controller.resources.limits.memory=3Gi \
   --set serviceMonitor.enabled=true \
   --set serviceMonitor.additionalLabels.scrape=enabled \

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -58,6 +58,7 @@ var (
 		&schedulingv1.PriorityClass{},
 		&v1.Node{},
 		&corev1beta1.NodeClaim{},
+		&v1beta1.EC2NodeClass{},
 	}
 )
 

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -85,11 +85,22 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 		nodeClass = env.DefaultEC2NodeClass()
 		nodePool = env.DefaultNodePool(nodeClass)
 		nodePool.Spec.Limits = nil
-		test.ReplaceRequirements(nodePool, corev1beta1.NodeSelectorRequirementWithMinValues{
-			NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: v1beta1.LabelInstanceHypervisor,
-				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"nitro"},
-			}})
+		test.ReplaceRequirements(nodePool, []corev1beta1.NodeSelectorRequirementWithMinValues{
+			{
+				NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: v1beta1.LabelInstanceHypervisor,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"nitro"},
+				},
+			},
+			// Ensure that all pods can fit on to the provisioned nodes including all daemonsets
+			{
+				NodeSelectorRequirement: v1.NodeSelectorRequirement{
+					Key:      v1beta1.LabelInstanceSize,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"large"},
+				},
+			},
+		}...)
 		deploymentOptions = test.DeploymentOptions{
 			PodOptions: test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
1.) We are finding that nodes launched on with c6g.medium can't fit all the nodes provisioned by karpenter when using Bottlerocket AMIs. When we receive these instance type, we the scheduler not placing all the expected pods on those nodes. https://github.com/aws/karpenter-provider-aws/issues/5161. CW daemonset was added that that totaled  to `158Mi`.
- Reported memory values: 
  - AL2023 c6g.medium: 1425680Ki
  - Bottlerocket c6g.medium: 1216348Ki
  - AL2023 m6g.medium: 3433832Ki
  - Bottlerocket m6g.medium: 3224432Ki
- From looking at the memory overhead usage we see that, instance memory for c6g.medium: 2048 https://karpenter.sh/docs/reference/instance-types/#c6gmedium and m6g.medium: 4096 https://karpenter.sh/docs/reference/instance-types/#m6gmedium

2.) EC2NodeClass were not getting cleaned up as part of AfterSuite 
3.) Karpenter was also getting CPU throttled at 3 CPUs, as the request and limits are set to 3 CPU. This is due to the increases in the number of pods from daemonSets
<img width="678" alt="Screenshot 2024-05-12 at 3 31 15 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/9c58c261-cdde-4508-ba0e-a7c2e1a22d80">

4.) Prometheus metrics collection `prometheus-prometheus-kube-prometheus-prometheus-0` pods was seeing memory throttling with OOMKilled errors
<img width="897" alt="Screenshot 2024-05-12 at 4 28 50 PM" src="https://github.com/aws/karpenter-provider-aws/assets/74629455/f6e32213-1836-4dd0-b62b-153908f56a9c">


**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.