### PR TITLE
fix: adjust status conditions to only use root condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.2
-	sigs.k8s.io/karpenter v0.36.1-0.20240516162236-0e678127e788
+	sigs.k8s.io/karpenter v0.36.1-0.20240514204811-ce4a2f890fa2
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.53.0
 	github.com/aws/karpenter-provider-aws/tools/kompat v0.0.0-20240410220356-6b868db24881
 	github.com/awslabs/amazon-eks-ami/nodeadm v0.0.0-20240229193347-cfab22a10647
-	github.com/awslabs/operatorpkg v0.0.0-20240514175841-edb8fe5824b4
+	github.com/awslabs/operatorpkg v0.0.0-20240518001059-1e35978ba21b
 	github.com/go-logr/zapr v1.3.0
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2
@@ -29,7 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.2
-	sigs.k8s.io/karpenter v0.36.1-0.20240514204811-ce4a2f890fa2
+	sigs.k8s.io/karpenter v0.36.1-0.20240516162236-0e678127e788
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/aws/karpenter-provider-aws/tools/kompat v0.0.0-20240410220356-6b868db
 github.com/aws/karpenter-provider-aws/tools/kompat v0.0.0-20240410220356-6b868db24881/go.mod h1:+Mk5k0b6HpKobxNq+B56DOhZ+I/NiPhd5MIBhQMSTSs=
 github.com/awslabs/amazon-eks-ami/nodeadm v0.0.0-20240229193347-cfab22a10647 h1:8yRBVsjGmI7qQsPWtIrbWP+XfwHO9Wq7gdLVzjqiZFs=
 github.com/awslabs/amazon-eks-ami/nodeadm v0.0.0-20240229193347-cfab22a10647/go.mod h1:9NafTAUHL0FlMeL6Cu5PXnMZ1q/LnC9X2emLXHsVbM8=
-github.com/awslabs/operatorpkg v0.0.0-20240514175841-edb8fe5824b4 h1:Du6S9Xa+/VuCpoSwOW7QpPM30IEIvB91WJEIltWQwRk=
-github.com/awslabs/operatorpkg v0.0.0-20240514175841-edb8fe5824b4/go.mod h1:YcidmUg8Pjk349+jd+sRCdo6h3jzxqAY1VDNgVJKbSA=
+github.com/awslabs/operatorpkg v0.0.0-20240518001059-1e35978ba21b h1:bmlbw6EjSDoZEWbGE2rnXDsCgbTsxMyufM4NRRHaLVk=
+github.com/awslabs/operatorpkg v0.0.0-20240518001059-1e35978ba21b/go.mod h1:YcidmUg8Pjk349+jd+sRCdo6h3jzxqAY1VDNgVJKbSA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -761,8 +761,8 @@ sigs.k8s.io/controller-runtime v0.18.2 h1:RqVW6Kpeaji67CY5nPEfRz6ZfFMk0lWQlNrLql
 sigs.k8s.io/controller-runtime v0.18.2/go.mod h1:tuAt1+wbVsXIT8lPtk5RURxqAnq7xkpv2Mhttslg7Hw=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.36.1-0.20240514204811-ce4a2f890fa2 h1:rmZTOL+DHtldS2z70kAXQUHHym2B5QhrPjGGGzBE198=
-sigs.k8s.io/karpenter v0.36.1-0.20240514204811-ce4a2f890fa2/go.mod h1:Ov8+tDVcF2BIPti+HL0hgoxIGy+rGIymKZAYZprl0Ww=
+sigs.k8s.io/karpenter v0.36.1-0.20240516162236-0e678127e788 h1:xrzVuIjd2MWfdoiIElJlJgzMvYA6MDaA1CVQUxCOhRk=
+sigs.k8s.io/karpenter v0.36.1-0.20240516162236-0e678127e788/go.mod h1:Ov8+tDVcF2BIPti+HL0hgoxIGy+rGIymKZAYZprl0Ww=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ sigs.k8s.io/controller-runtime v0.18.2 h1:RqVW6Kpeaji67CY5nPEfRz6ZfFMk0lWQlNrLql
 sigs.k8s.io/controller-runtime v0.18.2/go.mod h1:tuAt1+wbVsXIT8lPtk5RURxqAnq7xkpv2Mhttslg7Hw=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.36.1-0.20240516162236-0e678127e788 h1:xrzVuIjd2MWfdoiIElJlJgzMvYA6MDaA1CVQUxCOhRk=
-sigs.k8s.io/karpenter v0.36.1-0.20240516162236-0e678127e788/go.mod h1:Ov8+tDVcF2BIPti+HL0hgoxIGy+rGIymKZAYZprl0Ww=
+sigs.k8s.io/karpenter v0.36.1-0.20240514204811-ce4a2f890fa2 h1:rmZTOL+DHtldS2z70kAXQUHHym2B5QhrPjGGGzBE198=
+sigs.k8s.io/karpenter v0.36.1-0.20240514204811-ce4a2f890fa2/go.mod h1:Ov8+tDVcF2BIPti+HL0hgoxIGy+rGIymKZAYZprl0Ww=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/apis/v1beta1/ec2nodeclass_status.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_status.go
@@ -15,7 +15,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	op "github.com/awslabs/operatorpkg/status"
+	"github.com/awslabs/operatorpkg/status"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -71,22 +71,17 @@ type EC2NodeClassStatus struct {
 	InstanceProfile string `json:"instanceProfile,omitempty"`
 	// Conditions contains signals for health and readiness
 	// +optional
-	Conditions []op.Condition `json:"conditions,omitempty"`
+	Conditions []status.Condition `json:"conditions,omitempty"`
 }
 
-const (
-	// 	ConditionTypeNodeClassReady = "Ready" condition indicates that subnets, security groups, AMIs and instance profile for nodeClass were resolved
-	ConditionTypeNodeClassReady = "Ready"
-)
-
-func (in *EC2NodeClass) StatusConditions() op.ConditionSet {
-	return op.NewReadyConditions(ConditionTypeNodeClassReady).For(in)
+func (in *EC2NodeClass) StatusConditions() status.ConditionSet {
+	return status.NewReadyConditions().For(in)
 }
 
-func (in *EC2NodeClass) GetConditions() []op.Condition {
+func (in *EC2NodeClass) GetConditions() []status.Condition {
 	return in.Status.Conditions
 }
 
-func (in *EC2NodeClass) SetConditions(conditions []op.Condition) {
+func (in *EC2NodeClass) SetConditions(conditions []status.Condition) {
 	in.Status.Conditions = conditions
 }

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/awslabs/operatorpkg/status"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -87,7 +88,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1beta1.NodeC
 		// We treat a failure to resolve the NodeClass as an ICE since this means there is no capacity possibilities for this NodeClaim
 		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("resolving node class, %w", err))
 	}
-	nodeClassReady := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady)
+	nodeClassReady := nodeClass.StatusConditions().Get(status.ConditionReady)
 	if !nodeClassReady.IsTrue() {
 		return nil, fmt.Errorf("resolving ec2nodeclass, %s", nodeClassReady.Message)
 	}

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -180,7 +180,7 @@ var _ = Describe("CloudProvider", func() {
 		Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypeOfferings(ctx)).To(Succeed())
 	})
 	It("should not proceed with instance creation of nodeClass in not ready", func() {
-		nodeClass.StatusConditions().SetFalse(opstatus.ConditionReady, "NodeClass not ready", "NodeClass not ready")
+		nodeClass.StatusConditions().SetFalse(opstatus.ConditionReady, "NodeClassNotReady", "NodeClass not ready")
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)
 		_, err := cloudProvider.Create(ctx, nodeClaim)
 		Expect(err).To(HaveOccurred())

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	opstatus "github.com/awslabs/operatorpkg/status"
 	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 
@@ -113,8 +114,42 @@ var _ = Describe("CloudProvider", func() {
 	var nodePool *corev1beta1.NodePool
 	var nodeClaim *corev1beta1.NodeClaim
 	var _ = BeforeEach(func() {
-		nodeClass = test.EC2NodeClass()
-		nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeNodeClassReady)
+		nodeClass = test.EC2NodeClass(
+			v1beta1.EC2NodeClass{
+				Status: v1beta1.EC2NodeClassStatus{
+					InstanceProfile: "test-profile",
+					SecurityGroups: []v1beta1.SecurityGroup{
+						{
+							ID:   "sg-test1",
+							Name: "securityGroup-test1",
+						},
+						{
+							ID:   "sg-test2",
+							Name: "securityGroup-test2",
+						},
+						{
+							ID:   "sg-test3",
+							Name: "securityGroup-test3",
+						},
+					},
+					Subnets: []v1beta1.Subnet{
+						{
+							ID:   "subnet-test1",
+							Zone: "test-zone-1a",
+						},
+						{
+							ID:   "subnet-test2",
+							Zone: "test-zone-1b",
+						},
+						{
+							ID:   "subnet-test3",
+							Zone: "test-zone-1c",
+						},
+					},
+				},
+			},
+		)
+		nodeClass.StatusConditions().SetTrue(opstatus.ConditionReady)
 		nodePool = coretest.NodePool(corev1beta1.NodePool{
 			Spec: corev1beta1.NodePoolSpec{
 				Template: corev1beta1.NodeClaimTemplate{
@@ -145,7 +180,7 @@ var _ = Describe("CloudProvider", func() {
 		Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypeOfferings(ctx)).To(Succeed())
 	})
 	It("should not proceed with instance creation of nodeClass in not ready", func() {
-		nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "NodeClassNotReady", "NodeClass not ready")
+		nodeClass.StatusConditions().SetFalse(opstatus.ConditionReady, "NodeClass not ready", "NodeClass not ready")
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)
 		_, err := cloudProvider.Create(ctx, nodeClaim)
 		Expect(err).To(HaveOccurred())

--- a/pkg/controllers/nodeclass/status/readiness.go
+++ b/pkg/controllers/nodeclass/status/readiness.go
@@ -34,19 +34,19 @@ type Readiness struct {
 
 func (n Readiness) Reconcile(ctx context.Context, nodeClass *v1beta1.EC2NodeClass) (reconcile.Result, error) {
 	if len(nodeClass.Status.AMIs) == 0 {
-		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve AMIs")
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClassNotReady", "Failed to resolve AMIs")
 		return reconcile.Result{}, nil
 	}
 	if len(nodeClass.Status.Subnets) == 0 {
-		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve subnets")
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClassNotReady", "Failed to resolve subnets")
 		return reconcile.Result{}, nil
 	}
 	if len(nodeClass.Status.SecurityGroups) == 0 {
-		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve security groups")
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClassNotReady", "Failed to resolve security groups")
 		return reconcile.Result{}, nil
 	}
 	if len(nodeClass.Status.InstanceProfile) == 0 {
-		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve instance profile")
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClassNotReady", "Failed to resolve instance profile")
 		return reconcile.Result{}, nil
 	}
 	// A NodeClass that uses AL2023 requires the cluster CIDR for launching nodes.
@@ -54,7 +54,7 @@ func (n Readiness) Reconcile(ctx context.Context, nodeClass *v1beta1.EC2NodeClas
 	// will not be done at startup but instead in a reconcile loop.
 	if lo.FromPtr(nodeClass.Spec.AMIFamily) == v1beta1.AMIFamilyAL2023 {
 		if err := n.launchTemplateProvider.ResolveClusterCIDR(ctx); err != nil {
-			nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to detect the cluster CIDR")
+			nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClassNotReady", "Failed to detect the cluster CIDR")
 			return reconcile.Result{}, fmt.Errorf("failed to detect the cluster CIDR, %w", err)
 		}
 	}

--- a/pkg/controllers/nodeclass/status/readiness.go
+++ b/pkg/controllers/nodeclass/status/readiness.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
@@ -33,30 +34,30 @@ type Readiness struct {
 
 func (n Readiness) Reconcile(ctx context.Context, nodeClass *v1beta1.EC2NodeClass) (reconcile.Result, error) {
 	if len(nodeClass.Status.AMIs) == 0 {
-		nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "NodeClassNotReady", "unable to resolve AMIs")
-		return reconcile.Result{Requeue: true}, nil
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve AMIs")
+		return reconcile.Result{}, nil
 	}
 	if len(nodeClass.Status.Subnets) == 0 {
-		nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "NodeClassNotReady", "unable to resolve subnets")
-		return reconcile.Result{Requeue: true}, nil
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve subnets")
+		return reconcile.Result{}, nil
 	}
 	if len(nodeClass.Status.SecurityGroups) == 0 {
-		nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "NodeClassNotReady", "unable to resolve security groups")
-		return reconcile.Result{Requeue: true}, nil
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve security groups")
+		return reconcile.Result{}, nil
 	}
 	if len(nodeClass.Status.InstanceProfile) == 0 {
-		nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "NodeClassNotReady", "unable to resolve instance profile")
-		return reconcile.Result{Requeue: true}, nil
+		nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to resolve instance profile")
+		return reconcile.Result{}, nil
 	}
 	// A NodeClass that uses AL2023 requires the cluster CIDR for launching nodes.
 	// To allow Karpenter to be used for Non-EKS clusters, resolving the Cluster CIDR
 	// will not be done at startup but instead in a reconcile loop.
 	if lo.FromPtr(nodeClass.Spec.AMIFamily) == v1beta1.AMIFamilyAL2023 {
 		if err := n.launchTemplateProvider.ResolveClusterCIDR(ctx); err != nil {
-			nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "NodeClassNotReady", "unable to detect the cluster CIDR")
-			return reconcile.Result{}, fmt.Errorf("unable to detect the cluster CIDR, %w", err)
+			nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClass not ready", "Failed to detect the cluster CIDR")
+			return reconcile.Result{}, fmt.Errorf("failed to detect the cluster CIDR, %w", err)
 		}
 	}
-	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeNodeClassReady)
+	nodeClass.StatusConditions().SetTrue(status.ConditionReady)
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclass/status/readiness_test.go
+++ b/pkg/controllers/nodeclass/status/readiness_test.go
@@ -17,6 +17,8 @@ package status_test
 import (
 	_ "knative.dev/pkg/system/testing"
 
+	"github.com/awslabs/operatorpkg/status"
+
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
 
@@ -52,7 +54,7 @@ var _ = Describe("NodeClass Status Condition Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.Status.Conditions).To(HaveLen(1))
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).IsTrue()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsTrue()).To(BeTrue())
 	})
 	It("should update status condition as Not Ready", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -64,7 +66,7 @@ var _ = Describe("NodeClass Status Condition Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).IsFalse()).To(BeTrue())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).Message).To(Equal("unable to resolve security groups"))
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsFalse()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).Message).To(Equal("Failed to resolve security groups"))
 	})
 })

--- a/pkg/controllers/nodeclass/status/securitygroup_test.go
+++ b/pkg/controllers/nodeclass/status/securitygroup_test.go
@@ -17,6 +17,8 @@ package status_test
 import (
 	_ "knative.dev/pkg/system/testing"
 
+	"github.com/awslabs/operatorpkg/status"
+
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
 
@@ -190,8 +192,8 @@ var _ = Describe("NodeClass Security Group Status Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.Status.SecurityGroups).To(BeNil())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).IsFalse()).To(BeTrue())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).Message).To(Equal("unable to resolve security groups"))
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsFalse()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).Message).To(Equal("Failed to resolve security groups"))
 	})
 	It("Should not resolve a invalid selectors for an updated Security Groups selector", func() {
 		ExpectApplied(ctx, env.Client, nodeClass)
@@ -221,7 +223,7 @@ var _ = Describe("NodeClass Security Group Status Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.Status.SecurityGroups).To(BeNil())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).IsFalse()).To(BeTrue())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).Message).To(Equal("unable to resolve security groups"))
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsFalse()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).Message).To(Equal("Failed to resolve security groups"))
 	})
 })

--- a/pkg/controllers/nodeclass/status/subnet_test.go
+++ b/pkg/controllers/nodeclass/status/subnet_test.go
@@ -17,7 +17,7 @@ package status_test
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	_ "knative.dev/pkg/system/testing"
+	"github.com/awslabs/operatorpkg/status"
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
@@ -232,8 +232,8 @@ var _ = Describe("NodeClass Subnet Status Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.Status.Subnets).To(BeNil())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).IsFalse()).To(BeTrue())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).Message).To(Equal("unable to resolve subnets"))
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsFalse()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).Message).To(Equal("Failed to resolve subnets"))
 	})
 	It("Should not resolve a invalid selectors for an updated subnet selector", func() {
 		ExpectApplied(ctx, env.Client, nodeClass)
@@ -267,7 +267,7 @@ var _ = Describe("NodeClass Subnet Status Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.Status.Subnets).To(BeNil())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).IsFalse()).To(BeTrue())
-		Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeNodeClassReady).Message).To(Equal("unable to resolve subnets"))
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsFalse()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).Message).To(Equal("Failed to resolve subnets"))
 	})
 })

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/imdario/mergo"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -109,8 +110,39 @@ var _ = Describe("InstanceTypeProvider", func() {
 	var nodeClass, windowsNodeClass *v1beta1.EC2NodeClass
 	var nodePool, windowsNodePool *corev1beta1.NodePool
 	BeforeEach(func() {
-		nodeClass = test.EC2NodeClass()
-		nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeNodeClassReady)
+		nodeClass = test.EC2NodeClass(
+			v1beta1.EC2NodeClass{
+				Status: v1beta1.EC2NodeClassStatus{
+					InstanceProfile: "test-profile",
+					SecurityGroups: []v1beta1.SecurityGroup{
+						{
+							ID: "sg-test1",
+						},
+						{
+							ID: "sg-test2",
+						},
+						{
+							ID: "sg-test3",
+						},
+					},
+					Subnets: []v1beta1.Subnet{
+						{
+							ID:   "subnet-test1",
+							Zone: "test-zone-1a",
+						},
+						{
+							ID:   "subnet-test2",
+							Zone: "test-zone-1b",
+						},
+						{
+							ID:   "subnet-test3",
+							Zone: "test-zone-1c",
+						},
+					},
+				},
+			},
+		)
+		nodeClass.StatusConditions().SetTrue(status.ConditionReady)
 		nodePool = coretest.NodePool(corev1beta1.NodePool{
 			Spec: corev1beta1.NodePoolSpec{
 				Template: corev1beta1.NodeClaimTemplate{
@@ -152,7 +184,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 				},
 			},
 		})
-		windowsNodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeNodeClassReady)
+		windowsNodeClass.StatusConditions().SetTrue(status.ConditionReady)
 		windowsNodePool = coretest.NodePool(corev1beta1.NodePool{
 			Spec: corev1beta1.NodePoolSpec{
 				Template: corev1beta1.NodeClaimTemplate{

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -23,10 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
-
-	"github.com/awslabs/operatorpkg/status"
-	op "github.com/awslabs/operatorpkg/test/expectations"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -927,11 +923,4 @@ func (env *Environment) GetDaemonSetOverhead(np *corev1beta1.NodePool) v1.Resour
 		}
 		return p, true
 	})...)
-}
-
-func (env *Environment) EventuallyExpectStatusCondition(nodeClass *v1beta1.EC2NodeClass, conditions ...status.Condition) {
-	GinkgoHelper()
-	Eventually(func(g Gomega) {
-		op.ExpectStatusConditions(nodeClass, conditions...)
-	}).WithTimeout(10 * time.Second).Should(Succeed())
 }

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 
+	"github.com/awslabs/operatorpkg/status"
+	op "github.com/awslabs/operatorpkg/test/expectations"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -927,15 +929,9 @@ func (env *Environment) GetDaemonSetOverhead(np *corev1beta1.NodePool) v1.Resour
 	})...)
 }
 
-func (env *Environment) EventuallyExpectStatusCondition(nodeClass *v1beta1.EC2NodeClass, condition metav1.Condition) {
+func (env *Environment) EventuallyExpectStatusCondition(nodeClass *v1beta1.EC2NodeClass, conditions ...status.Condition) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
-		nc := &v1beta1.EC2NodeClass{}
-		g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nodeClass), nc)).To(Succeed())
-		statusCondition := nc.StatusConditions().Get(condition.Type)
-		g.Expect(statusCondition).ToNot(BeNil())
-		g.Expect(statusCondition.Status).To(Equal(condition.Status))
-		g.Expect(statusCondition.Message).To(Equal(condition.Message))
-		g.Expect(statusCondition.Reason).To(Equal(condition.Reason))
+		op.ExpectStatusConditions(nodeClass, conditions...)
 	}).WithTimeout(10 * time.Second).Should(Succeed())
 }

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -927,13 +927,15 @@ func (env *Environment) GetDaemonSetOverhead(np *corev1beta1.NodePool) v1.Resour
 	})...)
 }
 
-func (env *Environment) EventuallyExpectNodeClassStatusCondition(nodeClass *v1beta1.EC2NodeClass, condition string, status bool, message string) {
+func (env *Environment) EventuallyExpectStatusCondition(nodeClass *v1beta1.EC2NodeClass, condition metav1.Condition) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
 		nc := &v1beta1.EC2NodeClass{}
 		g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nodeClass), nc)).To(Succeed())
-		statusCondition := nc.StatusConditions().Get(condition)
-		g.Expect(statusCondition.IsTrue()).To(Equal(status))
-		g.Expect(statusCondition.Message).To(Equal(message))
+		statusCondition := nc.StatusConditions().Get(condition.Type)
+		g.Expect(statusCondition).ToNot(BeNil())
+		g.Expect(statusCondition.Status).To(Equal(condition.Status))
+		g.Expect(statusCondition.Message).To(Equal(condition.Message))
+		g.Expect(statusCondition.Reason).To(Equal(condition.Reason))
 	}).WithTimeout(10 * time.Second).Should(Succeed())
 }

--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/awslabs/operatorpkg/status"
+	. "github.com/awslabs/operatorpkg/test/expectations"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -222,7 +223,7 @@ var _ = Describe("AMI", func() {
 			nc := EventuallyExpectAMIsToExist(nodeClass)
 			Expect(len(nc.Status.AMIs)).To(BeNumerically("==", 1))
 			Expect(nc.Status.AMIs[0].ID).To(Equal(customAMI))
-			env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 		})
 		It("should have ec2nodeClass status as not ready since AMI was not resolved", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
@@ -231,7 +232,7 @@ var _ = Describe("AMI", func() {
 				},
 			}
 			env.ExpectCreated(nodeClass)
-			env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve AMIs"})
+			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve AMIs"})
 		})
 	})
 

--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -222,7 +222,7 @@ var _ = Describe("AMI", func() {
 			nc := EventuallyExpectAMIsToExist(nodeClass)
 			Expect(len(nc.Status.AMIs)).To(BeNumerically("==", 1))
 			Expect(nc.Status.AMIs[0].ID).To(Equal(customAMI))
-			env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+			env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 		})
 		It("should have ec2nodeClass status as not ready since AMI was not resolved", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
@@ -231,7 +231,7 @@ var _ = Describe("AMI", func() {
 				},
 			}
 			env.ExpectCreated(nodeClass)
-			env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve AMIs"})
+			env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve AMIs"})
 		})
 	})
 

--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -23,8 +23,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -219,7 +222,7 @@ var _ = Describe("AMI", func() {
 			nc := EventuallyExpectAMIsToExist(nodeClass)
 			Expect(len(nc.Status.AMIs)).To(BeNumerically("==", 1))
 			Expect(nc.Status.AMIs[0].ID).To(Equal(customAMI))
-			env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, true, "")
+			env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 		})
 		It("should have ec2nodeClass status as not ready since AMI was not resolved", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
@@ -228,7 +231,7 @@ var _ = Describe("AMI", func() {
 				},
 			}
 			env.ExpectCreated(nodeClass)
-			env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, false, "unable to resolve AMIs")
+			env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve AMIs"})
 		})
 	})
 

--- a/test/suites/integration/instance_profile_test.go
+++ b/test/suites/integration/instance_profile_test.go
@@ -17,7 +17,8 @@ package integration_test
 import (
 	"fmt"
 
-	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+	"github.com/awslabs/operatorpkg/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -83,11 +84,15 @@ var _ = Describe("InstanceProfile Generation", func() {
 		instance := env.GetInstance(node.Name)
 		Expect(instance.IamInstanceProfile).ToNot(BeNil())
 		Expect(lo.FromPtr(instance.IamInstanceProfile.Arn)).To(ContainSubstring(nodeClass.Status.InstanceProfile))
+<<<<<<< HEAD
 		env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, true, "")
+=======
+		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+>>>>>>> 74974d2b (adjust)
 	})
 	It("should have the EC2NodeClass status as not ready since Instance Profile was not resolved", func() {
 		nodeClass.Spec.Role = fmt.Sprintf("KarpenterNodeRole-%s", "invalidRole")
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, false, "unable to resolve instance profile")
+		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve instance profile"})
 	})
 })

--- a/test/suites/integration/instance_profile_test.go
+++ b/test/suites/integration/instance_profile_test.go
@@ -84,15 +84,11 @@ var _ = Describe("InstanceProfile Generation", func() {
 		instance := env.GetInstance(node.Name)
 		Expect(instance.IamInstanceProfile).ToNot(BeNil())
 		Expect(lo.FromPtr(instance.IamInstanceProfile.Arn)).To(ContainSubstring(nodeClass.Status.InstanceProfile))
-<<<<<<< HEAD
-		env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, true, "")
-=======
-		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
->>>>>>> 74974d2b (adjust)
+		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 	})
 	It("should have the EC2NodeClass status as not ready since Instance Profile was not resolved", func() {
 		nodeClass.Spec.Role = fmt.Sprintf("KarpenterNodeRole-%s", "invalidRole")
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve instance profile"})
+		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve instance profile"})
 	})
 })

--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -77,7 +77,7 @@ var _ = Describe("SecurityGroups", func() {
 	It("should update the EC2NodeClass status security groups", func() {
 		env.ExpectCreated(nodeClass)
 		EventuallyExpectSecurityGroups(env, nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 	})
 
 	It("should have the NodeClass status as not ready since security groups were not resolved", func() {
@@ -87,7 +87,7 @@ var _ = Describe("SecurityGroups", func() {
 			},
 		}
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve security groups"})
+		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve security groups"})
 	})
 })
 

--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-provider-aws/test/pkg/environment/aws"
 
+	. "github.com/awslabs/operatorpkg/test/expectations"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -77,7 +78,7 @@ var _ = Describe("SecurityGroups", func() {
 	It("should update the EC2NodeClass status security groups", func() {
 		env.ExpectCreated(nodeClass)
 		EventuallyExpectSecurityGroups(env, nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+		ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 	})
 
 	It("should have the NodeClass status as not ready since security groups were not resolved", func() {
@@ -87,7 +88,7 @@ var _ = Describe("SecurityGroups", func() {
 			},
 		}
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve security groups"})
+		ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve security groups"})
 	})
 })
 

--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -18,7 +18,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -75,7 +77,7 @@ var _ = Describe("SecurityGroups", func() {
 	It("should update the EC2NodeClass status security groups", func() {
 		env.ExpectCreated(nodeClass)
 		EventuallyExpectSecurityGroups(env, nodeClass)
-		env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, true, "")
+		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 	})
 
 	It("should have the NodeClass status as not ready since security groups were not resolved", func() {
@@ -85,7 +87,7 @@ var _ = Describe("SecurityGroups", func() {
 			},
 		}
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, false, "unable to resolve security groups")
+		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve security groups"})
 	})
 })
 

--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Subnets", func() {
 	It("should have the NodeClass status for subnets", func() {
 		env.ExpectCreated(nodeClass)
 		EventuallyExpectSubnets(env, nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 	})
 	It("should have the NodeClass status as not ready since subnets were not resolved", func() {
 		nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -133,7 +133,7 @@ var _ = Describe("Subnets", func() {
 			},
 		}
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve Subnets"})
+		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve Subnets"})
 	})
 })
 

--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -18,9 +18,11 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/onsi/gomega/types"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -122,7 +124,7 @@ var _ = Describe("Subnets", func() {
 	It("should have the NodeClass status for subnets", func() {
 		env.ExpectCreated(nodeClass)
 		EventuallyExpectSubnets(env, nodeClass)
-		env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, true, "")
+		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 	})
 	It("should have the NodeClass status as not ready since subnets were not resolved", func() {
 		nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -131,7 +133,7 @@ var _ = Describe("Subnets", func() {
 			},
 		}
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectNodeClassStatusCondition(nodeClass, v1beta1.ConditionTypeNodeClassReady, false, "unable to resolve subnets")
+		env.EventuallyExpectStatusCondition(nodeClass, metav1.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve Subnets"})
 	})
 })
 

--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-provider-aws/test/pkg/environment/aws"
 
+	. "github.com/awslabs/operatorpkg/test/expectations"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -124,7 +125,7 @@ var _ = Describe("Subnets", func() {
 	It("should have the NodeClass status for subnets", func() {
 		env.ExpectCreated(nodeClass)
 		EventuallyExpectSubnets(env, nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+		ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 	})
 	It("should have the NodeClass status as not ready since subnets were not resolved", func() {
 		nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -133,7 +134,7 @@ var _ = Describe("Subnets", func() {
 			},
 		}
 		env.ExpectCreated(nodeClass)
-		env.EventuallyExpectStatusCondition(nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve Subnets"})
+		ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "Failed to resolve subnets"})
 	})
 })
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Readjusts the status conditions to not use two root conditions and pulls in the latest for sigs.k8s.io/karpenter and awslabs/operatorpkg

**How was this change tested?**
make presubmit and snapshots here

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.