### PR TITLE
chore: drop implicit public IP association config

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -173,30 +173,20 @@ func (p *DefaultProvider) createAMIOptions(ctx context.Context, nodeClass *v1bet
 	if len(nodeClass.Status.SecurityGroups) == 0 {
 		return nil, fmt.Errorf("no security groups are present in the status")
 	}
-	options := &amifamily.Options{
-		ClusterName:         options.FromContext(ctx).ClusterName,
-		ClusterEndpoint:     p.ClusterEndpoint,
-		ClusterCIDR:         p.ClusterCIDR.Load(),
-		InstanceProfile:     instanceProfile,
-		InstanceStorePolicy: nodeClass.Spec.InstanceStorePolicy,
-		SecurityGroups:      nodeClass.Status.SecurityGroups,
-		Tags:                tags,
-		Labels:              labels,
-		CABundle:            p.CABundle,
-		KubeDNSIP:           p.KubeDNSIP,
-		NodeClassName:       nodeClass.Name,
-	}
-	if nodeClass.Spec.AssociatePublicIPAddress != nil {
-		options.AssociatePublicIPAddress = nodeClass.Spec.AssociatePublicIPAddress
-	} else {
-		// when `AssociatePublicIPAddress` is not specified in the `EC2NodeClass` spec,
-		// If all referenced subnets do not assign public IPv4 addresses to EC2 instances therein, we explicitly set
-		// AssociatePublicIPAddress to 'false' in the Launch Template, generated based on this configuration struct.
-		// This is done to help comply with AWS account policies that require explicitly setting of that field to 'false'.
-		// https://github.com/aws/karpenter-provider-aws/issues/3815
-		options.AssociatePublicIPAddress = p.subnetProvider.AssociatePublicIPAddressValue(nodeClass)
-	}
-	return options, nil
+	return &amifamily.Options{
+		ClusterName:              options.FromContext(ctx).ClusterName,
+		ClusterEndpoint:          p.ClusterEndpoint,
+		ClusterCIDR:              p.ClusterCIDR.Load(),
+		InstanceProfile:          instanceProfile,
+		InstanceStorePolicy:      nodeClass.Spec.InstanceStorePolicy,
+		SecurityGroups:           nodeClass.Status.SecurityGroups,
+		Tags:                     tags,
+		Labels:                   labels,
+		CABundle:                 p.CABundle,
+		KubeDNSIP:                p.KubeDNSIP,
+		AssociatePublicIPAddress: nodeClass.Spec.AssociatePublicIPAddress,
+		NodeClassName:            nodeClass.Name,
+	}, nil
 }
 
 func (p *DefaultProvider) ensureLaunchTemplate(ctx context.Context, options *amifamily.LaunchTemplate) (*ec2.LaunchTemplate, error) {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1973,33 +1973,6 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			})
 		})
 		Context("Public IP Association", func() {
-			It("should explicitly set 'AssociatePublicIPAddress' to false in the Launch Template", func() {
-				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-					{Tags: map[string]string{"Name": "test-subnet-1"}},
-					{Tags: map[string]string{"Name": "test-subnet-3"}},
-				}
-				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-				controller := status.NewController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider)
-				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
-				pod := coretest.UnschedulablePod()
-				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-				ExpectScheduled(ctx, env.Client, pod)
-				input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect(*input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeFalse())
-			})
-			It("should not explicitly set 'AssociatePublicIPAddress' when the subnets are configured to assign public IPv4 addresses", func() {
-				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-					{Tags: map[string]string{"Name": "test-subnet-2"}},
-				}
-				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-				controller := status.NewController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider)
-				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
-				pod := coretest.UnschedulablePod()
-				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-				ExpectScheduled(ctx, env.Client, pod)
-				input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect(len(input.LaunchTemplateData.NetworkInterfaces)).To(BeNumerically("==", 0))
-			})
 			DescribeTable(
 				"should set 'AssociatePublicIPAddress' based on EC2NodeClass",
 				func(setValue, expectedValue, isEFA bool) {

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -37,7 +37,6 @@ import (
 type Provider interface {
 	LivenessProbe(*http.Request) error
 	List(context.Context, *v1beta1.EC2NodeClass) ([]*ec2.Subnet, error)
-	AssociatePublicIPAddressValue(*v1beta1.EC2NodeClass) *bool
 	ZonalSubnetsForLaunch(context.Context, *v1beta1.EC2NodeClass, []*cloudprovider.InstanceType, string) (map[string]*Subnet, error)
 	UpdateInflightIPs(*ec2.CreateFleetInput, *ec2.CreateFleetOutput, []*cloudprovider.InstanceType, []*Subnet, string)
 }
@@ -114,19 +113,6 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1beta1.EC2NodeCl
 			Debugf("discovered subnets")
 	}
 	return lo.Values(subnets), nil
-}
-
-// associatePublicIPAddressValue validates whether we know the association value for all subnets AND
-// that all subnets don't have associatePublicIP set. If both of these are true, we set the value explicitly to false
-// For more detail see: https://github.com/aws/karpenter-provider-aws/pull/3814
-func (p *DefaultProvider) AssociatePublicIPAddressValue(nodeClass *v1beta1.EC2NodeClass) *bool {
-	for _, subnet := range nodeClass.Status.Subnets {
-		subnetAssociatePublicIP, ok := p.associatePublicIPAddressCache.Get(subnet.ID)
-		if !ok || subnetAssociatePublicIP.(bool) {
-			return nil
-		}
-	}
-	return lo.ToPtr(false)
 }
 
 // ZonalSubnetsForLaunch returns a mapping of zone to the subnet with the most available IP addresses and deducts the passed ips from the available count

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -219,53 +219,6 @@ var _ = Describe("SubnetProvider", func() {
 			}, subnets)
 		})
 	})
-	Context("AssociatePublicIPAddress", func() {
-		It("should be false when no subnets assign a public IPv4 address to EC2 instances on launch", func() {
-			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-				{
-					ID:   "subnet-test1",
-					Tags: map[string]string{"foo": "bar"},
-				},
-			}
-			_, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
-			Expect(err).To(BeNil())
-			associatePublicIP := awsEnv.SubnetProvider.AssociatePublicIPAddressValue(nodeClass)
-			Expect(lo.FromPtr(associatePublicIP)).To(BeFalse())
-		})
-		It("should be nil when at least one subnet assigns a public IPv4 address to EC2instances on launch", func() {
-			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-				{
-					ID: "subnet-test2",
-				},
-			}
-			nodeClass.Status.Subnets = []v1beta1.Subnet{
-				{
-					ID:   "subnet-test2",
-					Zone: "test-zone-1b",
-				},
-			}
-			_, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
-			Expect(err).To(BeNil())
-			associatePublicIP := awsEnv.SubnetProvider.AssociatePublicIPAddressValue(nodeClass)
-			Expect(associatePublicIP).To(BeNil())
-		})
-		It("should be nil when no subnet data is present in the provider cache", func() {
-			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
-				{
-					ID: "subnet-test2",
-				},
-			}
-			nodeClass.Status.Subnets = []v1beta1.Subnet{
-				{
-					ID:   "subnet-test2",
-					Zone: "test-zone-1b",
-				},
-			}
-			awsEnv.SubnetCache.Flush() // remove any subnet data that might be in the subnetCache
-			associatePublicIP := awsEnv.SubnetProvider.AssociatePublicIPAddressValue(nodeClass)
-			Expect(associatePublicIP).To(BeNil())
-		})
-	})
 	Context("Provider Cache", func() {
 		It("should resolve subnets from cache that are filtered by id", func() {
 			expectedSubnets := awsEnv.EC2API.DescribeSubnetsOutput.Clone().Subnets


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Drops implicit public IP association as called out in the [v1 roadmap](https://github.com/kubernetes-sigs/karpenter/pull/1222/files#diff-055dd5f24ba5dd20e449cb25f9e8a572200b3bd059ce75b1fbaae860e6284e27R201-R205).

**How was this change tested?**
`make presubmit` and `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.