### PR TITLE
docs: fix migrating from cas node affinity guide

### DIFF
--- a/website/content/en/docs/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/docs/getting-started/migrating-from-cas/_index.md
@@ -117,7 +117,6 @@ affinity:
       - matchExpressions:
         - key: karpenter.sh/nodepool
           operator: DoesNotExist
-      - matchExpressions:
         - key: eks.amazonaws.com/nodegroup
           operator: In
           values:

--- a/website/content/en/preview/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/preview/getting-started/migrating-from-cas/_index.md
@@ -117,7 +117,6 @@ affinity:
       - matchExpressions:
         - key: karpenter.sh/nodepool
           operator: DoesNotExist
-      - matchExpressions:
         - key: eks.amazonaws.com/nodegroup
           operator: In
           values:

--- a/website/content/en/v0.32/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.32/getting-started/migrating-from-cas/_index.md
@@ -117,7 +117,6 @@ affinity:
       - matchExpressions:
         - key: karpenter.sh/nodepool
           operator: DoesNotExist
-      - matchExpressions:
         - key: eks.amazonaws.com/nodegroup
           operator: In
           values:

--- a/website/content/en/v0.34/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.34/getting-started/migrating-from-cas/_index.md
@@ -117,7 +117,6 @@ affinity:
       - matchExpressions:
         - key: karpenter.sh/nodepool
           operator: DoesNotExist
-      - matchExpressions:
         - key: eks.amazonaws.com/nodegroup
           operator: In
           values:

--- a/website/content/en/v0.35/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.35/getting-started/migrating-from-cas/_index.md
@@ -117,7 +117,6 @@ affinity:
       - matchExpressions:
         - key: karpenter.sh/nodepool
           operator: DoesNotExist
-      - matchExpressions:
         - key: eks.amazonaws.com/nodegroup
           operator: In
           values:

--- a/website/content/en/v0.36/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.36/getting-started/migrating-from-cas/_index.md
@@ -117,7 +117,6 @@ affinity:
       - matchExpressions:
         - key: karpenter.sh/nodepool
           operator: DoesNotExist
-      - matchExpressions:
         - key: eks.amazonaws.com/nodegroup
           operator: In
           values:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The migrating from CAS guide incorrectly split the affinity terms into two different match expressions, which will treat the two terms as an OR semantic, only requiring one of them to be true. If the items are within the same MatchExpressions block, they're treated as an AND.

**How was this change tested?**
Tested with manual application of deployment on my own cluster

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.