### PR TITLE
chore: Use AMI IDs in the logs for AMI discovery

### DIFF
--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -118,8 +118,10 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1beta1.EC2NodeCl
 		}
 	}
 	amis.Sort()
-	if p.cm.HasChanged(fmt.Sprintf("amis/%s", nodeClass.Name), amis) {
-		logging.FromContext(ctx).With("ids", amis, "count", len(amis)).Debugf("discovered amis")
+	uniqueAMIs := lo.Uniq(lo.Map(amis, func(a AMI, _ int) string { return a.AmiID }))
+	if p.cm.HasChanged(fmt.Sprintf("amis/%s", nodeClass.Name), uniqueAMIs) {
+		logging.FromContext(ctx).With(
+			"ids", uniqueAMIs).Debugf("discovered amis")
 	}
 	return amis, nil
 }

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily/bootstrap"
@@ -127,7 +126,7 @@ func (r Resolver) Resolve(nodeClass *v1beta1.EC2NodeClass, nodeClaim *corev1beta
 	}
 	mappedAMIs := MapToInstanceTypes(instanceTypes, nodeClass.Status.AMIs)
 	if len(mappedAMIs) == 0 {
-		return nil, fmt.Errorf("no instance types satisfy requirements of amis %v", pretty.Slice(lo.Map(nodeClass.Status.AMIs, func(a v1beta1.AMI, _ int) string { return a.ID }), 25))
+		return nil, fmt.Errorf("no instance types satisfy requirements of amis %v", lo.Uniq(lo.Map(nodeClass.Status.AMIs, func(a v1beta1.AMI, _ int) string { return a.ID })))
 	}
 	var resolvedTemplates []*LaunchTemplate
 	for amiID, instanceTypes := range mappedAMIs {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixed the Log message listing all AMIs details
```
{"level":"DEBUG","time":"2024-05-17T12:58:20.632-0500","logger":"controller.nodeclass.status","message":"discovered amis","ec2nodeclass":"critical-addons-only","ids":[{"Name":"amazon-eks-arm64-node-1.29-v20240514","AmiID":"ami-06882dd1807dd93be","CreationDate":"2024-05-14T16:59:11.000Z","Requirements":{"karpenter.k8s.aws/instance-accelerator-count":{"Key":"karpenter.k8s.aws/instance-accelerator-count","MinValues":null},"karpenter.k8s.aws/instance-gpu-count":{"Key":"karpenter.k8s.aws/instance-gpu-count","MinValues":null},"kubernetes.io/arch":{"Key":"kubernetes.io/arch","MinValues":null}}},{"Name":"amazon-eks-gpu-node-1.29-v20240514","AmiID":"ami-086598116d98d2953","CreationDate":"2024-05-14T16:59:11.000Z","Requirements":{"karpenter.k8s.aws/instance-gpu-count":{"Key":"karpenter.k8s.aws/instance-gpu-count","MinValues":null},"kubernetes.io/arch":{"Key":"kubernetes.io/arch","MinValues":null}}},{"Name":"amazon-eks-gpu-node-1.29-v20240514","AmiID":"ami-086598116d98d2953","CreationDate":"2024-05-14T16:59:11.000Z","Requirements":{"karpenter.k8s.aws/instance-accelerator-count":{"Key":"karpenter.k8s.aws/instance-accelerator-count","MinValues":null},"kubernetes.io/arch":{"Key":"kubernetes.io/arch","MinValues":null}}},{"Name":"amazon-eks-node-1.29-v20240514","AmiID":"ami-0ef5558292b11416e","CreationDate":"2024-05-14T16:59:11.000Z","Requirements":{"karpenter.k8s.aws/instance-accelerator-count":{"Key":"karpenter.k8s.aws/instance-accelerator-count","MinValues":null},"karpenter.k8s.aws/instance-gpu-count":{"Key":"karpenter.k8s.aws/instance-gpu-count","MinValues":null},"kubernetes.io/arch":{"Key":"kubernetes.io/arch","MinValues":null}}}],"count":4}
```
To just using AMI Ids 

```
{"level":"DEBUG","time":"2024-05-17T11:20:42.176-0700","logger":"controller.nodeclass.status","message":"discovered amis","ec2nodeclass":"default","ids":"ami-06882dd1807dd93be, ami-086598116d98d2953, ami-0ef5558292b11416e","count":4}
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.