### PR TITLE
add back TopologyManagerPolicy to bottlerocketsettings

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -69,6 +69,7 @@ type BottlerocketKubernetes struct {
 	CPUManagerPolicy                   *string                                   `toml:"cpu-manager-policy,omitempty"`
 	CPUManagerReconcilePeriod          *string                                   `toml:"cpu-manager-reconcile-period,omitempty"`
 	TopologyManagerScope               *string                                   `toml:"topology-manager-scope,omitempty"`
+	TopologyManagerPolicy              *string                                   `toml:"topology-manager-policy,omitempty"`
 	ImageGCHighThresholdPercent        *string                                   `toml:"image-gc-high-threshold-percent,omitempty"`
 	ImageGCLowThresholdPercent         *string                                   `toml:"image-gc-low-threshold-percent,omitempty"`
 	CPUCFSQuota                        *bool                                     `toml:"cpu-cfs-quota-enforced,omitempty"`


### PR DESCRIPTION
Currently, no topology-manager-policy setting appears in instance userdata if it is set in EC2NodeClass userdata

It seems like this setting was inadvertently removed in https://github.com/aws/karpenter-provider-aws/pull/3264/files#diff-a3cbfce28a0ecf65dea19fa09613d36dc9d5c653ff993472e70820de27f03efeL70

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.