### PR TITLE
docs: Add spot-instance-requests to AllowScopedResourceCreationTagging in v1beta1-controller-policy.json

### DIFF
--- a/website/content/en/v0.32/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/v0.32/upgrading/v1beta1-controller-policy.json
@@ -49,7 +49,8 @@
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
         "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
-        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"
       ],
       "Action": "ec2:CreateTags",
       "Condition": {


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
In the v1beta1-migration docs https://karpenter.sh/v0.32/upgrading/v1beta1-migration/#upgrade-procedure, the [new Karpenter policy](https://raw.githubusercontent.com/aws/karpenter-provider-aws/v0.32.10/website/content/en/preview/upgrading/v1beta1-controller-policy.json) in step 4 is missing         `"arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"` here https://github.com/aws/karpenter-provider-aws/blob/e50a3427362cead0a534fbd9d30a1822c4c6146b/website/content/en/v0.32/upgrading/v1beta1-controller-policy.json#L45-L52

Without it, you get this error 
`not authorized to perform: ec2:CreateTags on resource: arn:aws:ec2:us-east-1:012345678900:spot-instances-request/* because no identity-based policy allows the ec2:CreateTags action.`

**How was this change tested?**
After adding `"arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*"` no longer get the error. 
Also, that line is already correctly included in the reference cloudformation such as here https://github.com/aws/karpenter-provider-aws/blob/e50a3427362cead0a534fbd9d30a1822c4c6146b/website/content/en/v0.34/reference/cloudformation.md?plain=1#L210

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.