### PR TITLE
docs: add FAQ entry clarifying that startup taints are necessary to avoid excess node provisioning

### DIFF
--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -72,7 +72,7 @@ spec:
           operator: In
           values: ["c", "m", "r"]
           # minValues here enforces the scheduler to consider at least that number of unique instance-category to schedule the pods.
-          # This field is ALPHA and can be dropped or replaced at any time 
+          # This field is ALPHA and can be dropped or replaced at any time
           minValues: 2
         - key: "karpenter.k8s.aws/instance-family"
           operator: In
@@ -555,6 +555,8 @@ In order for a pod to run on a node defined in this NodePool, it must tolerate `
 ### Cilium Startup Taint
 
 Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects), it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+
+Failure to provide accurate `startupTaints` can result in Karpenter continually provisioning new nodes. When the new node joins and the startup taint that Karpenter is unaware of is added, Karpenter now considers the pending pod to be unschedulable to this node. Karpenter will attempt to provision yet another new node to schedule the pending pod.
 
 ```yaml
 apiVersion: karpenter.sh/v1beta1

--- a/website/content/en/preview/contributing/documentation-updates.md
+++ b/website/content/en/preview/contributing/documentation-updates.md
@@ -1,0 +1,11 @@
+---
+title: "Documentation Updates"
+linkTitle: "Documentation Updates"
+weight: 50
+description: >
+  Infomration helpful for contributing simple documentation updates.
+---
+
+- Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
+- Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
+- Previews for your changes are built and available a few minutes after you push. Look for the "netlify Deploy Preview" link in a comment in your PR.


### PR DESCRIPTION
**Description**
I spent several days tracking down why Karpenter would create several unnecessary nodes in order to schedule pending pods in our clusters. Ultimately, I discovered this behavior was occurring.

1. Karpenter sees a pending pod that cannot be scheduled without a new node.
2. Karpenter creates a new nodeclaim, followed by a new node joining the cluster.
3. Karpenter's provisioning logic correctly determines that the pending node will satisfy the still pending pod.
4. Cilium's agent daemonset starts up on the new unready node, setting a startup taint to block pods from scheduling until the CNI is ready.
5. Karpenter sees that the still pending pod can no longer be scheduled to the node due to the cilium not-ready taint and provisions a second nodeclaim.
6. The original new node becomes ready and Cilium removes the taint.
7. The pending pod schedules to the original new node.
8. Karpenter removes the unnecessary second node via emptiness/consolidation. 

We found that Karpenter has docs on configuring startupTaints to handle this case.
https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint

I'd like to add these documentation updates to the Karpenter FAQ to save users from having to debug the code in order to discover the solution to this problem in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.