### PR TITLE
docs: drop eksctl note and bump min version

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
@@ -32,7 +32,7 @@ Install these tools before proceeding:
 
 1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html)
 2. `kubectl` - [the Kubernetes CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-3. `eksctl` (>= v0.179.0) - [the CLI for AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
+3. `eksctl` (>= v0.180.0) - [the CLI for AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
 4. `helm` - [the package manager for Kubernetes](https://helm.sh/docs/intro/install/)
 
 [Configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
@@ -88,16 +88,6 @@ The following cluster configuration will:
 {{< /tabpane >}}
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step06-add-spot-role.sh" language="bash"%}}
-
-{{% alert title="EKSCTL Breaking Change" color="warning" %}}
-Starting with `eksctl` v1.77.0, a service account is created for each podIdentityAssociation.
-This default service account is incompatible with the Karpenter Helm chart, and it will need to be removed to proceed with installation.
-If you're on an affected version of `eksctl` and you created a cluster with a `podIdentityAssociation`, run the following command before proceeding with the rest of the installation.
-This has been identified as a breaking change in `eksctl` which will be addressed in a future release ([GitHub Issue](https://github.com/eksctl-io/eksctl/issues/7775)).
-```bash
-kubectl delete sa -n ${KARPENTER_NAMESPACE} karpenter
-```
-{{% /alert %}}
 
 {{% alert title="Windows Support Notice" color="warning" %}}
 In order to run Windows workloads, Windows support should be enabled in your EKS Cluster.

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -32,7 +32,7 @@ Install these tools before proceeding:
 
 1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html)
 2. `kubectl` - [the Kubernetes CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-3. `eksctl` (>= v0.179.0) - [the CLI for AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
+3. `eksctl` (>= v0.180.0) - [the CLI for AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
 4. `helm` - [the package manager for Kubernetes](https://helm.sh/docs/intro/install/)
 
 [Configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
@@ -88,16 +88,6 @@ The following cluster configuration will:
 {{< /tabpane >}}
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step06-add-spot-role.sh" language="bash"%}}
-
-{{% alert title="EKSCTL Breaking Change" color="warning" %}}
-Starting with `eksctl` v1.77.0, a service account is created for each podIdentityAssociation.
-This default service account is incompatible with the Karpenter Helm chart, and it will need to be removed to proceed with installation.
-If you're on an affected version of `eksctl` and you created a cluster with a `podIdentityAssociation`, run the following command before proceeding with the rest of the installation.
-This has been identified as a breaking change in `eksctl` which will be addressed in a future release ([GitHub Issue](https://github.com/eksctl-io/eksctl/issues/7775)).
-```bash
-kubectl delete sa -n ${KARPENTER_NAMESPACE} karpenter
-```
-{{% /alert %}}
 
 {{% alert title="Windows Support Notice" color="warning" %}}
 In order to run Windows workloads, Windows support should be enabled in your EKS Cluster.

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/_index.md
@@ -81,16 +81,6 @@ The following cluster configuration will:
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step06-add-spot-role.sh" language="bash"%}}
 
-{{% alert title="EKSCTL Breaking Change" color="warning" %}}
-Starting with `eksctl` v1.77.0, a service account is created for each podIdentityAssociation.
-This default service account is incompatible with the Karpenter Helm chart, and it will need to be removed to proceed with installation.
-If you're on an affected version of `eksctl` and you created a cluster with a `podIdentityAssociation`, run the following command before proceeding with the rest of the installation.
-This has been identified as a breaking change in `eksctl` which will be addressed in a future release ([GitHub Issue](https://github.com/eksctl-io/eksctl/issues/7775)).
-```bash
-kubectl delete sa -n ${KARPENTER_NAMESPACE} karpenter
-```
-{{% /alert %}}
-
 {{% alert title="Windows Support Notice" color="warning" %}}
 In order to run Windows workloads, Windows support should be enabled in your EKS Cluster.
 See [Enabling Windows support](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support) to learn more.

--- a/website/content/en/v0.35/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v0.35/getting-started/getting-started-with-karpenter/_index.md
@@ -89,16 +89,6 @@ The following cluster configuration will:
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step06-add-spot-role.sh" language="bash"%}}
 
-{{% alert title="EKSCTL Breaking Change" color="warning" %}}
-Starting with `eksctl` v1.77.0, a service account is created for each podIdentityAssociation.
-This default service account is incompatible with the Karpenter Helm chart, and it will need to be removed to proceed with installation.
-If you're on an affected version of `eksctl` and you created a cluster with a `podIdentityAssociation`, run the following command before proceeding with the rest of the installation.
-This has been identified as a breaking change in `eksctl` which will be addressed in a future release ([GitHub Issue](https://github.com/eksctl-io/eksctl/issues/7775)).
-```bash
-kubectl delete sa -n ${KARPENTER_NAMESPACE} karpenter
-```
-{{% /alert %}}
-
 {{% alert title="Windows Support Notice" color="warning" %}}
 In order to run Windows workloads, Windows support should be enabled in your EKS Cluster.
 See [Enabling Windows support](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support) to learn more.

--- a/website/content/en/v0.36/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v0.36/getting-started/getting-started-with-karpenter/_index.md
@@ -89,16 +89,6 @@ The following cluster configuration will:
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step06-add-spot-role.sh" language="bash"%}}
 
-{{% alert title="EKSCTL Breaking Change" color="warning" %}}
-Starting with `eksctl` v1.77.0, a service account is created for each podIdentityAssociation.
-This default service account is incompatible with the Karpenter Helm chart, and it will need to be removed to proceed with installation.
-If you're on an affected version of `eksctl` and you created a cluster with a `podIdentityAssociation`, run the following command before proceeding with the rest of the installation.
-This has been identified as a breaking change in `eksctl` which will be addressed in a future release ([GitHub Issue](https://github.com/eksctl-io/eksctl/issues/7775)).
-```bash
-kubectl delete sa -n ${KARPENTER_NAMESPACE} karpenter
-```
-{{% /alert %}}
-
 {{% alert title="Windows Support Notice" color="warning" %}}
 In order to run Windows workloads, Windows support should be enabled in your EKS Cluster.
 See [Enabling Windows support](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support) to learn more.

--- a/website/content/en/v0.37/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v0.37/getting-started/getting-started-with-karpenter/_index.md
@@ -32,7 +32,7 @@ Install these tools before proceeding:
 
 1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html)
 2. `kubectl` - [the Kubernetes CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-3. `eksctl` (>= v0.179.0) - [the CLI for AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
+3. `eksctl` (>= v0.180.0) - [the CLI for AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
 4. `helm` - [the package manager for Kubernetes](https://helm.sh/docs/intro/install/)
 
 [Configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
@@ -88,16 +88,6 @@ The following cluster configuration will:
 {{< /tabpane >}}
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step06-add-spot-role.sh" language="bash"%}}
-
-{{% alert title="EKSCTL Breaking Change" color="warning" %}}
-Starting with `eksctl` v1.77.0, a service account is created for each podIdentityAssociation.
-This default service account is incompatible with the Karpenter Helm chart, and it will need to be removed to proceed with installation.
-If you're on an affected version of `eksctl` and you created a cluster with a `podIdentityAssociation`, run the following command before proceeding with the rest of the installation.
-This has been identified as a breaking change in `eksctl` which will be addressed in a future release ([GitHub Issue](https://github.com/eksctl-io/eksctl/issues/7775)).
-```bash
-kubectl delete sa -n ${KARPENTER_NAMESPACE} karpenter
-```
-{{% /alert %}}
 
 {{% alert title="Windows Support Notice" color="warning" %}}
 In order to run Windows workloads, Windows support should be enabled in your EKS Cluster.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Drops the note on the eksctl breaking change and bumps the min version to v0.180.0 for Karpenter versions which previously required v0.179.0. This is in light of the [v0.180.0 release](https://github.com/eksctl-io/eksctl/releases/tag/v0.180.0) that reverts the breaking change.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.