### PR TITLE
test: deflake utilization test

### DIFF
--- a/test/suites/integration/utilization_test.go
+++ b/test/suites/integration/utilization_test.go
@@ -38,9 +38,9 @@ var _ = Describe("Utilization", Label(debug.NoWatch), Label(debug.NoEvents), fun
 		test.ReplaceRequirements(nodePool,
 			corev1beta1.NodeSelectorRequirementWithMinValues{
 				NodeSelectorRequirement: v1.NodeSelectorRequirement{
-					Key:      v1.LabelInstanceTypeStable,
+					Key:      v1beta1.LabelInstanceCPU,
 					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{"t3.small"},
+					Values:   []string{"2"},
 				},
 			},
 			corev1beta1.NodeSelectorRequirementWithMinValues{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
We've been seeing flakes in out utilization test due to instances failing to register with the cluster. We believe this is due to the `t3` instances, so this PR removes this instance specification and adds a CPU count requirement.

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.