### PR TITLE
chore: Paginate resources with aws-sdk-go-v2 pagination (aws#6268)

### DIFF
--- a/test/hack/resource/pkg/resourcetypes/eni.go
+++ b/test/hack/resource/pkg/resourcetypes/eni.go
@@ -127,11 +127,8 @@ func (e *ENI) Cleanup(ctx context.Context, ids []string) ([]string, error) {
 	return deleted, errs
 }
 
-// getAllENIs returns all ENIs that match the provided input. We are using a page size of 100 to match our default page size.
 func (e *ENI) getAllENIs(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput) (enis []ec2types.NetworkInterface, err error) {
-	paginator := ec2.NewDescribeNetworkInterfacesPaginator(e.ec2Client, params, func(o *ec2.DescribeNetworkInterfacesPaginatorOptions) {
-		o.Limit = 100
-	})
+	paginator := ec2.NewDescribeNetworkInterfacesPaginator(e.ec2Client, params)
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)

--- a/test/hack/resource/pkg/resourcetypes/eni.go
+++ b/test/hack/resource/pkg/resourcetypes/eni.go
@@ -43,95 +43,67 @@ func (e *ENI) Global() bool {
 }
 
 func (e *ENI) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := e.ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag-key"),
-					Values: []string{k8sClusterTag},
-				},
+	enis, err := e.getAllENIs(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag-key"),
+				Values: []string{k8sClusterTag},
 			},
-			NextToken: nextToken,
+		},
+	})
+	if err != nil {
+		return ids, err
+	}
+
+	for _, ni := range enis {
+		clusterName, found := lo.Find(ni.TagSet, func(tag ec2types.Tag) bool {
+			return *tag.Key == k8sClusterTag
 		})
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+			continue
+		}
+		creationDate, found := lo.Find(ni.TagSet, func(tag ec2types.Tag) bool {
+			return *tag.Key == "node.k8s.amazonaws.com/createdAt"
+		})
+		if !found {
+			continue
+		}
+		creationTime, err := time.Parse(time.RFC3339, *creationDate.Value)
 		if err != nil {
-			return ids, err
+			continue
 		}
-
-		for _, ni := range out.NetworkInterfaces {
-			clusterName, found := lo.Find(ni.TagSet, func(tag ec2types.Tag) bool {
-				return *tag.Key == k8sClusterTag
-			})
-			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
-				continue
-			}
-			creationDate, found := lo.Find(ni.TagSet, func(tag ec2types.Tag) bool {
-				return *tag.Key == "node.k8s.amazonaws.com/createdAt"
-			})
-			if !found {
-				continue
-			}
-			creationTime, err := time.Parse(time.RFC3339, *creationDate.Value)
-			if err != nil {
-				continue
-			}
-			if ni.Status == ec2types.NetworkInterfaceStatusAvailable && creationTime.Before(expirationTime) {
-				ids = append(ids, lo.FromPtr(ni.NetworkInterfaceId))
-			}
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
+		if ni.Status == ec2types.NetworkInterfaceStatusAvailable && creationTime.Before(expirationTime) {
+			ids = append(ids, lo.FromPtr(ni.NetworkInterfaceId))
 		}
 	}
+
 	return ids, err
 }
 
 func (e *ENI) CountAll(ctx context.Context) (count int, err error) {
-	var nextToken *string
-	for {
-		out, err := e.ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return count, err
-		}
-
-		count += len(out.NetworkInterfaces)
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+	enis, err := e.getAllENIs(ctx, &ec2.DescribeNetworkInterfacesInput{})
+	if err != nil {
+		return 0, err
 	}
-	return count, err
+
+	return len(enis), err
 }
 
 func (e *ENI) Get(ctx context.Context, clusterName string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := e.ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag:" + k8sClusterTag),
-					Values: []string{clusterName},
-				},
+	enis, err := e.getAllENIs(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag:" + k8sClusterTag),
+				Values: []string{clusterName},
 			},
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return ids, err
-		}
+		},
+	})
+	if err != nil {
+		return ids, err
+	}
 
-		for _, ni := range out.NetworkInterfaces {
-			ids = append(ids, lo.FromPtr(ni.NetworkInterfaceId))
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+	for _, ni := range enis {
+		ids = append(ids, lo.FromPtr(ni.NetworkInterfaceId))
 	}
 	return ids, err
 }
@@ -153,4 +125,21 @@ func (e *ENI) Cleanup(ctx context.Context, ids []string) ([]string, error) {
 	}
 
 	return deleted, errs
+}
+
+// getAllENIs returns all ENIs that match the provided input. We are using a page size of 100 to match our default page size.
+func (e *ENI) getAllENIs(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput) (enis []ec2types.NetworkInterface, err error) {
+	paginator := ec2.NewDescribeNetworkInterfacesPaginator(e.ec2Client, params, func(o *ec2.DescribeNetworkInterfacesPaginatorOptions) {
+		o.Limit = 100
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return enis, err
+		}
+		enis = append(enis, page.NetworkInterfaces...)
+	}
+
+	return enis, nil
 }

--- a/test/hack/resource/pkg/resourcetypes/instance.go
+++ b/test/hack/resource/pkg/resourcetypes/instance.go
@@ -129,9 +129,7 @@ func (i *Instance) Cleanup(ctx context.Context, ids []string) ([]string, error) 
 }
 
 func (i *Instance) getAllInstances(ctx context.Context, params *ec2.DescribeInstancesInput) (instances []ec2types.Instance, err error) {
-	paginator := ec2.NewDescribeInstancesPaginator(i.ec2Client, params, func(o *ec2.DescribeInstancesPaginatorOptions) {
-		o.Limit = 100
-	})
+	paginator := ec2.NewDescribeInstancesPaginator(i.ec2Client, params)
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)

--- a/test/hack/resource/pkg/resourcetypes/instance.go
+++ b/test/hack/resource/pkg/resourcetypes/instance.go
@@ -41,114 +41,80 @@ func (i *Instance) Global() bool {
 }
 
 func (i *Instance) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := i.ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("instance-state-name"),
-					Values: []string{string(ec2types.InstanceStateNameRunning)},
-				},
-				{
-					Name:   lo.ToPtr("tag-key"),
-					Values: []string{karpenterNodePoolTag},
-				},
+	instances, err := i.getAllInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("instance-state-name"),
+				Values: []string{string(ec2types.InstanceStateNameRunning)},
 			},
-			NextToken: nextToken,
+			{
+				Name:   lo.ToPtr("tag-key"),
+				Values: []string{karpenterNodePoolTag},
+			},
+		},
+	})
+	if err != nil {
+		return ids, err
+	}
+
+	for _, instance := range instances {
+		clusterName, found := lo.Find(instance.Tags, func(tag ec2types.Tag) bool {
+			return *tag.Key == karpenterTestingTag
 		})
-		if err != nil {
-			return ids, err
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+			continue
 		}
-
-		for _, res := range out.Reservations {
-			for _, instance := range res.Instances {
-				clusterName, found := lo.Find(instance.Tags, func(tag ec2types.Tag) bool {
-					return *tag.Key == karpenterTestingTag
-				})
-				if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
-					continue
-				}
-				if lo.FromPtr(instance.LaunchTime).Before(expirationTime) {
-					ids = append(ids, lo.FromPtr(instance.InstanceId))
-				}
-			}
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
+		if lo.FromPtr(instance.LaunchTime).Before(expirationTime) {
+			ids = append(ids, lo.FromPtr(instance.InstanceId))
 		}
 	}
+
 	return ids, err
 }
 
 func (i *Instance) CountAll(ctx context.Context) (count int, err error) {
-	var nextToken *string
-
-	for {
-		out, err := i.ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-			Filters: []ec2types.Filter{
-				{
-					Name: lo.ToPtr("instance-state-name"),
-					Values: []string{
-						string(ec2types.InstanceStateNameRunning),
-						string(ec2types.InstanceStateNamePending),
-						string(ec2types.InstanceStateNameShuttingDown),
-						string(ec2types.InstanceStateNameStopped),
-						string(ec2types.InstanceStateNameStopping),
-					},
+	instances, err := i.getAllInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name: lo.ToPtr("instance-state-name"),
+				Values: []string{
+					string(ec2types.InstanceStateNameRunning),
+					string(ec2types.InstanceStateNamePending),
+					string(ec2types.InstanceStateNameShuttingDown),
+					string(ec2types.InstanceStateNameStopped),
+					string(ec2types.InstanceStateNameStopping),
 				},
 			},
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return count, err
-		}
-
-		for _, res := range out.Reservations {
-			count += len(res.Instances)
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+		},
+	})
+	if err != nil {
+		return count, err
 	}
-	return count, err
+
+	return len(instances), err
 }
 
 func (i *Instance) Get(ctx context.Context, clusterName string) (ids []string, err error) {
-	var nextToken *string
-
-	for {
-		out, err := i.ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("instance-state-name"),
-					Values: []string{string(ec2types.InstanceStateNameRunning)},
-				},
-				{
-					Name:   lo.ToPtr("tag:" + karpenterClusterNameTag),
-					Values: []string{clusterName},
-				},
+	instances, err := i.getAllInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("instance-state-name"),
+				Values: []string{string(ec2types.InstanceStateNameRunning)},
 			},
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return ids, err
-		}
-
-		for _, res := range out.Reservations {
-			for _, instance := range res.Instances {
-				ids = append(ids, lo.FromPtr(instance.InstanceId))
-			}
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+			{
+				Name:   lo.ToPtr("tag:" + karpenterClusterNameTag),
+				Values: []string{clusterName},
+			},
+		},
+	})
+	if err != nil {
+		return ids, err
 	}
+
+	for _, instance := range instances {
+		ids = append(ids, lo.FromPtr(instance.InstanceId))
+	}
+
 	return ids, err
 }
 
@@ -160,4 +126,23 @@ func (i *Instance) Cleanup(ctx context.Context, ids []string) ([]string, error) 
 		return nil, err
 	}
 	return ids, nil
+}
+
+func (i *Instance) getAllInstances(ctx context.Context, params *ec2.DescribeInstancesInput) (instances []ec2types.Instance, err error) {
+	paginator := ec2.NewDescribeInstancesPaginator(i.ec2Client, params, func(o *ec2.DescribeInstancesPaginatorOptions) {
+		o.Limit = 100
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return instances, err
+		}
+
+		for _, res := range page.Reservations {
+			instances = append(instances, res.Instances...)
+		}
+	}
+
+	return instances, nil
 }

--- a/test/hack/resource/pkg/resourcetypes/launchtemplate.go
+++ b/test/hack/resource/pkg/resourcetypes/launchtemplate.go
@@ -42,86 +42,59 @@ func (lt *LaunchTemplate) Global() bool {
 }
 
 func (lt *LaunchTemplate) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (names []string, err error) {
-	var nextToken *string
-	for {
-		out, err := lt.ec2Client.DescribeLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag-key"),
-					Values: []string{karpenterLaunchTemplateTag},
-				},
+	lts, err := lt.getAllLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag-key"),
+				Values: []string{karpenterLaunchTemplateTag},
 			},
-			NextToken: nextToken,
+		},
+	})
+	if err != nil {
+		return names, err
+	}
+
+	for _, launchtemplate := range lts {
+		clusterName, found := lo.Find(launchtemplate.Tags, func(tag ec2types.Tag) bool {
+			return *tag.Key == k8sClusterTag
 		})
-		if err != nil {
-			return names, err
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+			continue
 		}
-
-		for _, launchTemplate := range out.LaunchTemplates {
-			clusterName, found := lo.Find(launchTemplate.Tags, func(tag ec2types.Tag) bool {
-				return *tag.Key == k8sClusterTag
-			})
-			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
-				continue
-			}
-			if lo.FromPtr(launchTemplate.CreateTime).Before(expirationTime) {
-				names = append(names, lo.FromPtr(launchTemplate.LaunchTemplateName))
-			}
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
+		if lo.FromPtr(launchtemplate.CreateTime).Before(expirationTime) {
+			names = append(names, lo.FromPtr(launchtemplate.LaunchTemplateName))
 		}
 	}
+
 	return names, err
 }
 
 func (lt *LaunchTemplate) CountAll(ctx context.Context) (count int, err error) {
-	var nextToken *string
-	for {
-		out, err := lt.ec2Client.DescribeLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return count, err
-		}
-
-		count += len(out.LaunchTemplates)
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+	lts, err := lt.getAllLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{})
+	if err != nil {
+		return count, err
 	}
-	return count, err
+
+	return len(lts), err
 }
 
 func (lt *LaunchTemplate) Get(ctx context.Context, clusterName string) (names []string, err error) {
-	var nextToken *string
-	for {
-		out, err := lt.ec2Client.DescribeLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag:" + karpenterLaunchTemplateTag),
-					Values: []string{clusterName},
-				},
+	lts, err := lt.getAllLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag:" + karpenterLaunchTemplateTag),
+				Values: []string{clusterName},
 			},
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return names, err
-		}
-
-		for _, launchTemplate := range out.LaunchTemplates {
-			names = append(names, lo.FromPtr(launchTemplate.LaunchTemplateName))
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+		},
+	})
+	if err != nil {
+		return names, err
 	}
+
+	for _, launchtemplate := range lts {
+		names = append(names, lo.FromPtr(launchtemplate.LaunchTemplateName))
+	}
+
 	return names, err
 }
 
@@ -141,4 +114,20 @@ func (lt *LaunchTemplate) Cleanup(ctx context.Context, names []string) ([]string
 		deleted = append(deleted, names[i])
 	}
 	return deleted, errs
+}
+
+func (lt *LaunchTemplate) getAllLaunchTemplates(ctx context.Context, params *ec2.DescribeLaunchTemplatesInput) (lts []ec2types.LaunchTemplate, err error) {
+	paginator := ec2.NewDescribeLaunchTemplatesPaginator(lt.ec2Client, params, func(o *ec2.DescribeLaunchTemplatesPaginatorOptions) {
+		o.Limit = 100
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return lts, err
+		}
+		lts = append(lts, page.LaunchTemplates...)
+	}
+
+	return lts, nil
 }

--- a/test/hack/resource/pkg/resourcetypes/launchtemplate.go
+++ b/test/hack/resource/pkg/resourcetypes/launchtemplate.go
@@ -117,9 +117,7 @@ func (lt *LaunchTemplate) Cleanup(ctx context.Context, names []string) ([]string
 }
 
 func (lt *LaunchTemplate) getAllLaunchTemplates(ctx context.Context, params *ec2.DescribeLaunchTemplatesInput) (lts []ec2types.LaunchTemplate, err error) {
-	paginator := ec2.NewDescribeLaunchTemplatesPaginator(lt.ec2Client, params, func(o *ec2.DescribeLaunchTemplatesPaginatorOptions) {
-		o.Limit = 100
-	})
+	paginator := ec2.NewDescribeLaunchTemplatesPaginator(lt.ec2Client, params)
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)

--- a/test/hack/resource/pkg/resourcetypes/securitygroup.go
+++ b/test/hack/resource/pkg/resourcetypes/securitygroup.go
@@ -129,9 +129,7 @@ func (sg *SecurityGroup) Cleanup(ctx context.Context, ids []string) ([]string, e
 }
 
 func (sg *SecurityGroup) getAllSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput) (sgs []ec2types.SecurityGroup, err error) {
-	paginator := ec2.NewDescribeSecurityGroupsPaginator(sg.ec2Client, params, func(o *ec2.DescribeSecurityGroupsPaginatorOptions) {
-		o.Limit = 100
-	})
+	paginator := ec2.NewDescribeSecurityGroupsPaginator(sg.ec2Client, params)
 
 	for paginator.HasMorePages() {
 		out, err := paginator.NextPage(ctx)

--- a/test/hack/resource/pkg/resourcetypes/securitygroup.go
+++ b/test/hack/resource/pkg/resourcetypes/securitygroup.go
@@ -43,96 +43,69 @@ func (sg *SecurityGroup) Global() bool {
 }
 
 func (sg *SecurityGroup) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := sg.ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("group-name"),
-					Values: []string{"security-group-drift"},
-				},
+	sgs, err := sg.getAllSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("group-name"),
+				Values: []string{"security-group-drift"},
 			},
-			NextToken: nextToken,
+		},
+	})
+	if err != nil {
+		return ids, err
+	}
+
+	for _, sgroup := range sgs {
+		clusterName, found := lo.Find(sgroup.Tags, func(tag ec2types.Tag) bool {
+			return *tag.Key == karpenterTestingTag
 		})
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+			continue
+		}
+		creationDate, found := lo.Find(sgroup.Tags, func(tag ec2types.Tag) bool {
+			return *tag.Key == "creation-date"
+		})
+		if !found {
+			continue
+		}
+		time, err := time.Parse(time.RFC3339, *creationDate.Value)
 		if err != nil {
-			return ids, err
+			continue
 		}
-
-		for _, sgroup := range out.SecurityGroups {
-			clusterName, found := lo.Find(sgroup.Tags, func(tag ec2types.Tag) bool {
-				return *tag.Key == karpenterTestingTag
-			})
-			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
-				continue
-			}
-			creationDate, found := lo.Find(sgroup.Tags, func(tag ec2types.Tag) bool {
-				return *tag.Key == "creation-date"
-			})
-			if !found {
-				continue
-			}
-			time, err := time.Parse(time.RFC3339, *creationDate.Value)
-			if err != nil {
-				continue
-			}
-			if time.Before(expirationTime) {
-				ids = append(ids, lo.FromPtr(sgroup.GroupId))
-			}
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
+		if time.Before(expirationTime) {
+			ids = append(ids, lo.FromPtr(sgroup.GroupId))
 		}
 	}
+
 	return ids, err
 }
 
 func (sg *SecurityGroup) CountAll(ctx context.Context) (count int, err error) {
-	var nextToken *string
-	for {
-		out, err := sg.ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return count, err
-		}
-
-		count += len(out.SecurityGroups)
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+	sgs, err := sg.getAllSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{})
+	if err != nil {
+		return count, err
 	}
-	return count, err
+
+	return len(sgs), err
 }
 
 func (sg *SecurityGroup) Get(ctx context.Context, clusterName string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := sg.ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag:" + karpenterSecurityGroupTag),
-					Values: []string{clusterName},
-				},
+	sgs, err := sg.getAllSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag:" + karpenterSecurityGroupTag),
+				Values: []string{clusterName},
 			},
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return ids, err
-		}
-
-		for _, sgroup := range out.SecurityGroups {
-			ids = append(ids, lo.FromPtr(sgroup.GroupId))
-		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+		},
+	})
+	if err != nil {
+		return ids, err
 	}
+
+	for _, sgroup := range sgs {
+		ids = append(ids, lo.FromPtr(sgroup.GroupId))
+	}
+
 	return ids, err
 }
 
@@ -153,4 +126,20 @@ func (sg *SecurityGroup) Cleanup(ctx context.Context, ids []string) ([]string, e
 	}
 
 	return deleted, errs
+}
+
+func (sg *SecurityGroup) getAllSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput) (sgs []ec2types.SecurityGroup, err error) {
+	paginator := ec2.NewDescribeSecurityGroupsPaginator(sg.ec2Client, params, func(o *ec2.DescribeSecurityGroupsPaginatorOptions) {
+		o.Limit = 100
+	})
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		sgs = append(sgs, out.SecurityGroups...)
+	}
+
+	return sgs, nil
 }

--- a/test/hack/resource/pkg/resourcetypes/stack.go
+++ b/test/hack/resource/pkg/resourcetypes/stack.go
@@ -42,80 +42,51 @@ func (s *Stack) Global() bool {
 }
 
 func (s *Stack) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (names []string, err error) {
-	var nextToken *string
-	for {
-		out, err := s.cloudFormationClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return names, err
-		}
+	stacks, err := s.getAllStacks(ctx, &cloudformation.DescribeStacksInput{})
+	if err != nil {
+		return names, err
+	}
 
-		stacks := lo.Reject(out.Stacks, func(s cloudformationtypes.Stack, _ int) bool {
-			return s.StackStatus == cloudformationtypes.StackStatusDeleteComplete ||
-				s.StackStatus == cloudformationtypes.StackStatusDeleteInProgress
+	activeStacks := lo.Reject(stacks, func(s cloudformationtypes.Stack, _ int) bool {
+		return s.StackStatus == cloudformationtypes.StackStatusDeleteComplete ||
+			s.StackStatus == cloudformationtypes.StackStatusDeleteInProgress
+	})
+	for _, stack := range activeStacks {
+		clusterName, found := lo.Find(stack.Tags, func(tag cloudformationtypes.Tag) bool {
+			return *tag.Key == karpenterTestingTag
 		})
-		for _, stack := range stacks {
-			clusterName, found := lo.Find(stack.Tags, func(tag cloudformationtypes.Tag) bool {
-				return *tag.Key == karpenterTestingTag
-			})
-			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
-				continue
-			}
-			if _, found := lo.Find(stack.Tags, func(t cloudformationtypes.Tag) bool {
-				return lo.FromPtr(t.Key) == karpenterTestingTag || lo.FromPtr(t.Key) == githubRunURLTag
-			}); found && lo.FromPtr(stack.CreationTime).Before(expirationTime) {
-				names = append(names, lo.FromPtr(stack.StackName))
-			}
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+			continue
 		}
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
+		if _, found := lo.Find(stack.Tags, func(t cloudformationtypes.Tag) bool {
+			return lo.FromPtr(t.Key) == karpenterTestingTag || lo.FromPtr(t.Key) == githubRunURLTag
+		}); found && lo.FromPtr(stack.CreationTime).Before(expirationTime) {
+			names = append(names, lo.FromPtr(stack.StackName))
 		}
 	}
 	return names, err
 }
 
 func (s *Stack) CountAll(ctx context.Context) (count int, err error) {
-	var nextToken *string
-	for {
-		out, err := s.cloudFormationClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return count, err
-		}
-
-		count += len(out.Stacks)
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+	stacks, err := s.getAllStacks(ctx, &cloudformation.DescribeStacksInput{})
+	if err != nil {
+		return count, err
 	}
-	return count, nil
+
+	return len(stacks), nil
 }
 
 func (s *Stack) Get(ctx context.Context, clusterName string) (names []string, err error) {
-	var nextToken *string
-	for {
-		out, err := s.cloudFormationClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return names, err
-		}
-		for _, stack := range out.Stacks {
-			if _, found := lo.Find(stack.Tags, func(t cloudformationtypes.Tag) bool {
-				return lo.FromPtr(t.Key) == karpenterTestingTag && lo.FromPtr(t.Value) == clusterName
-			}); found {
-				names = append(names, lo.FromPtr(stack.StackName))
-			}
-		}
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
+	stacks, err := s.getAllStacks(ctx, &cloudformation.DescribeStacksInput{})
+	if err != nil {
+		return names, err
+	}
+
+	for _, stack := range stacks {
+		if _, found := lo.Find(stack.Tags, func(t cloudformationtypes.Tag) bool {
+			return lo.FromPtr(t.Key) == karpenterTestingTag && lo.FromPtr(t.Value) == clusterName
+		}); found {
+			names = append(names, lo.FromPtr(stack.StackName))
 		}
 	}
 	return names, nil
@@ -137,4 +108,18 @@ func (s *Stack) Cleanup(ctx context.Context, names []string) ([]string, error) {
 		deleted = append(deleted, names[i])
 	}
 	return deleted, errs
+}
+
+func (s *Stack) getAllStacks(ctx context.Context, params *cloudformation.DescribeStacksInput) (stacks []cloudformationtypes.Stack, err error) {
+	paginator := cloudformation.NewDescribeStacksPaginator(s.cloudFormationClient, params)
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			return stacks, err
+		}
+		stacks = append(stacks, out.Stacks...)
+	}
+
+	return stacks, nil
 }

--- a/test/hack/resource/pkg/resourcetypes/stack.go
+++ b/test/hack/resource/pkg/resourcetypes/stack.go
@@ -42,7 +42,7 @@ func (s *Stack) Global() bool {
 }
 
 func (s *Stack) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (names []string, err error) {
-	stacks, err := s.getAllStacks(ctx, &cloudformation.DescribeStacksInput{})
+	stacks, err := s.getAllStacks(ctx)
 	if err != nil {
 		return names, err
 	}
@@ -68,7 +68,7 @@ func (s *Stack) GetExpired(ctx context.Context, expirationTime time.Time, exclud
 }
 
 func (s *Stack) CountAll(ctx context.Context) (count int, err error) {
-	stacks, err := s.getAllStacks(ctx, &cloudformation.DescribeStacksInput{})
+	stacks, err := s.getAllStacks(ctx)
 	if err != nil {
 		return count, err
 	}
@@ -77,7 +77,7 @@ func (s *Stack) CountAll(ctx context.Context) (count int, err error) {
 }
 
 func (s *Stack) Get(ctx context.Context, clusterName string) (names []string, err error) {
-	stacks, err := s.getAllStacks(ctx, &cloudformation.DescribeStacksInput{})
+	stacks, err := s.getAllStacks(ctx)
 	if err != nil {
 		return names, err
 	}
@@ -110,8 +110,8 @@ func (s *Stack) Cleanup(ctx context.Context, names []string) ([]string, error) {
 	return deleted, errs
 }
 
-func (s *Stack) getAllStacks(ctx context.Context, params *cloudformation.DescribeStacksInput) (stacks []cloudformationtypes.Stack, err error) {
-	paginator := cloudformation.NewDescribeStacksPaginator(s.cloudFormationClient, params)
+func (s *Stack) getAllStacks(ctx context.Context) (stacks []cloudformationtypes.Stack, err error) {
+	paginator := cloudformation.NewDescribeStacksPaginator(s.cloudFormationClient, &cloudformation.DescribeStacksInput{})
 
 	for paginator.HasMorePages() {
 		out, err := paginator.NextPage(ctx)

--- a/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
+++ b/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
@@ -40,83 +40,60 @@ func (v *VPCEndpoint) Global() bool {
 	return false
 }
 
-func (v *VPCEndpoint) Get(ctx context.Context, clusterName string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := v.ec2Client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag:" + karpenterTestingTag),
-					Values: []string{clusterName},
-				},
+func (v *VPCEndpoint) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
+	endpoints, err := v.getAllVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag-key"),
+				Values: []string{karpenterTestingTag},
 			},
-			NextToken: nextToken,
+		},
+	})
+	if err != nil {
+		return ids, err
+	}
+
+	for _, endpoint := range endpoints {
+		clusterName, found := lo.Find(endpoint.Tags, func(tag ec2types.Tag) bool {
+			return *tag.Key == k8sClusterTag
 		})
-		if err != nil {
-			return ids, err
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+			continue
 		}
-		for _, endpoint := range out.VpcEndpoints {
+		if endpoint.CreationTimestamp.Before(expirationTime) {
 			ids = append(ids, lo.FromPtr(endpoint.VpcEndpointId))
 		}
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
 	}
+
 	return ids, err
 }
 
 func (v *VPCEndpoint) CountAll(ctx context.Context) (count int, err error) {
-	var nextToken *string
-	for {
-		out, err := v.ec2Client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return count, err
-		}
-
-		count += len(out.VpcEndpoints)
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+	endpoints, err := v.getAllVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{})
+	if err != nil {
+		return count, err
 	}
-	return count, err
+
+	return len(endpoints), err
 }
 
-func (v *VPCEndpoint) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := v.ec2Client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag-key"),
-					Values: []string{karpenterTestingTag},
-				},
+func (v *VPCEndpoint) Get(ctx context.Context, clusterName string) (ids []string, err error) {
+	endpoints, err := v.getAllVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag:" + karpenterTestingTag),
+				Values: []string{clusterName},
 			},
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return ids, err
-		}
-		for _, endpoint := range out.VpcEndpoints {
-			clusterName, found := lo.Find(endpoint.Tags, func(tag ec2types.Tag) bool {
-				return *tag.Key == k8sClusterTag
-			})
-			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
-				continue
-			}
-			if endpoint.CreationTimestamp.Before(expirationTime) {
-				ids = append(ids, lo.FromPtr(endpoint.VpcEndpointId))
-			}
-		}
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+		},
+	})
+	if err != nil {
+		return ids, err
 	}
+
+	for _, endpoint := range endpoints {
+		ids = append(ids, lo.FromPtr(endpoint.VpcEndpointId))
+	}
+
 	return ids, err
 }
 
@@ -128,4 +105,20 @@ func (v *VPCEndpoint) Cleanup(ctx context.Context, ids []string) ([]string, erro
 		return nil, err
 	}
 	return ids, nil
+}
+
+func (v *VPCEndpoint) getAllVpcEndpoints(ctx context.Context, params *ec2.DescribeVpcEndpointsInput) (endpoints []ec2types.VpcEndpoint, err error) {
+	paginator := ec2.NewDescribeVpcEndpointsPaginator(v.ec2Client, params, func(o *ec2.DescribeVpcEndpointsPaginatorOptions) {
+		o.Limit = 100
+	})
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			return endpoints, err
+		}
+		endpoints = append(endpoints, out.VpcEndpoints...)
+	}
+
+	return endpoints, nil
 }

--- a/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
+++ b/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
@@ -108,9 +108,7 @@ func (v *VPCEndpoint) Cleanup(ctx context.Context, ids []string) ([]string, erro
 }
 
 func (v *VPCEndpoint) getAllVpcEndpoints(ctx context.Context, params *ec2.DescribeVpcEndpointsInput) (endpoints []ec2types.VpcEndpoint, err error) {
-	paginator := ec2.NewDescribeVpcEndpointsPaginator(v.ec2Client, params, func(o *ec2.DescribeVpcEndpointsPaginatorOptions) {
-		o.Limit = 100
-	})
+	paginator := ec2.NewDescribeVpcEndpointsPaginator(v.ec2Client, params)
 
 	for paginator.HasMorePages() {
 		out, err := paginator.NextPage(ctx)

--- a/test/hack/resource/pkg/resourcetypes/vpc_peering_connection.go
+++ b/test/hack/resource/pkg/resourcetypes/vpc_peering_connection.go
@@ -113,9 +113,7 @@ func (v *VPCPeeringConnection) Cleanup(ctx context.Context, ids []string) ([]str
 }
 
 func (v *VPCPeeringConnection) getAllVpcPeeringConnections(ctx context.Context, params *ec2.DescribeVpcPeeringConnectionsInput) (connections []ec2types.VpcPeeringConnection, err error) {
-	paginator := ec2.NewDescribeVpcPeeringConnectionsPaginator(v.ec2Client, params, func(o *ec2.DescribeVpcPeeringConnectionsPaginatorOptions) {
-		o.Limit = 100
-	})
+	paginator := ec2.NewDescribeVpcPeeringConnectionsPaginator(v.ec2Client, params)
 
 	for paginator.HasMorePages() {
 		out, err := paginator.NextPage(ctx)

--- a/test/hack/resource/pkg/resourcetypes/vpc_peering_connection.go
+++ b/test/hack/resource/pkg/resourcetypes/vpc_peering_connection.go
@@ -40,83 +40,63 @@ func (v *VPCPeeringConnection) Global() bool {
 	return false
 }
 
-func (v *VPCPeeringConnection) Get(ctx context.Context, clusterName string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := v.ec2Client.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag:" + karpenterTestingTag),
-					Values: []string{clusterName},
-				},
+func (v *VPCPeeringConnection) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
+	connections, err := v.getAllVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag-key"),
+				Values: []string{karpenterTestingTag},
 			},
-			NextToken: nextToken,
+		},
+	})
+	if err != nil {
+		return ids, err
+	}
+
+	for _, connection := range connections {
+		clusterName, found := lo.Find(connection.Tags, func(tag ec2types.Tag) bool {
+			return *tag.Key == k8sClusterTag
 		})
-		if err != nil {
-			return ids, err
+		if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
+			continue
 		}
-		for _, connection := range out.VpcPeeringConnections {
+		if connection.ExpirationTime == nil { // Connection is non-pending
+			continue
+		}
+		if connection.ExpirationTime.Before(expirationTime) {
 			ids = append(ids, lo.FromPtr(connection.VpcPeeringConnectionId))
 		}
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
 	}
+
 	return ids, err
 }
 
 func (v *VPCPeeringConnection) CountAll(ctx context.Context) (count int, err error) {
-	var nextToken *string
-	for {
-		out, err := v.ec2Client.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return count, err
-		}
-
-		count += len(out.VpcPeeringConnections)
-
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+	connections, err := v.getAllVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{})
+	if err != nil {
+		return count, err
 	}
-	return count, err
+
+	return len(connections), err
 }
 
-func (v *VPCPeeringConnection) GetExpired(ctx context.Context, expirationTime time.Time, excludedClusters []string) (ids []string, err error) {
-	var nextToken *string
-	for {
-		out, err := v.ec2Client.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
-			Filters: []ec2types.Filter{
-				{
-					Name:   lo.ToPtr("tag-key"),
-					Values: []string{karpenterTestingTag},
-				},
+func (v *VPCPeeringConnection) Get(ctx context.Context, clusterName string) (ids []string, err error) {
+	connections, err := v.getAllVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("tag:" + karpenterTestingTag),
+				Values: []string{clusterName},
 			},
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return ids, err
-		}
-		for _, connection := range out.VpcPeeringConnections {
-			clusterName, found := lo.Find(connection.Tags, func(tag ec2types.Tag) bool {
-				return *tag.Key == k8sClusterTag
-			})
-			if found && slices.Contains(excludedClusters, lo.FromPtr(clusterName.Value)) {
-				continue
-			}
-			if connection.ExpirationTime.Before(expirationTime) {
-				ids = append(ids, lo.FromPtr(connection.VpcPeeringConnectionId))
-			}
-		}
-		nextToken = out.NextToken
-		if nextToken == nil {
-			break
-		}
+		},
+	})
+	if err != nil {
+		return ids, err
 	}
+
+	for _, connection := range connections {
+		ids = append(ids, lo.FromPtr(connection.VpcPeeringConnectionId))
+	}
+
 	return ids, err
 }
 
@@ -130,4 +110,20 @@ func (v *VPCPeeringConnection) Cleanup(ctx context.Context, ids []string) ([]str
 		}
 	}
 	return ids, nil
+}
+
+func (v *VPCPeeringConnection) getAllVpcPeeringConnections(ctx context.Context, params *ec2.DescribeVpcPeeringConnectionsInput) (connections []ec2types.VpcPeeringConnection, err error) {
+	paginator := ec2.NewDescribeVpcPeeringConnectionsPaginator(v.ec2Client, params, func(o *ec2.DescribeVpcPeeringConnectionsPaginatorOptions) {
+		o.Limit = 100
+	})
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		connections = append(connections, out.VpcPeeringConnections...)
+	}
+
+	return connections, nil
 }


### PR DESCRIPTION
Fixes #6268

**Description**
Updated to using [aws-sdk-go-v2 pagination](https://aws.github.io/aws-sdk-go-v2/docs/making-requests/#using-paginators) from manually paginating each API call.

**How was this change tested?**
Local testing for expected count and clean behavior for each resource changed.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.