### PR TITLE
test: get ami ssm path with offset

### DIFF
--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -373,8 +373,8 @@ var _ = Describe("Drift", func() {
 	It("should disrupt nodes that have drifted due to AMIs", func() {
 		// Choose an old static image (AL2023 AMIs don't exist for 1.22)
 		oldCustomAMI := env.GetAMIBySSMPath(lo.Ternary(env.K8sMinorVersion() == 23,
-			"/aws/service/eks/optimized-ami/1.23/amazon-linux-2023/x86_64/standard/amazon-eks-node-al2023-x86_64-standard-1.23-v20240307/image_id",
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersionWithOffset(1)),
+			env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 1),
+			env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersionWithOffset(1), "amd64", 0),
 		))
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyAL2023
 		nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{{ID: oldCustomAMI}}
@@ -396,7 +396,7 @@ var _ = Describe("Drift", func() {
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
 	})
 	It("should return drifted if the AMI no longer matches the existing NodeClaims instance type", func() {
-		armAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id", env.K8sVersion()))
+		armAMI := env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "arm64", 0))
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyAL2023
 		nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{{ID: armAMI}}
 
@@ -421,8 +421,8 @@ var _ = Describe("Drift", func() {
 
 		// Choose an old static image (AL2023 AMIs don't exist for 1.22)
 		oldCustomAMI := env.GetAMIBySSMPath(lo.Ternary(env.K8sMinorVersion() == 23,
-			"/aws/service/eks/optimized-ami/1.23/amazon-linux-2023/x86_64/standard/amazon-eks-node-al2023-x86_64-standard-1.23-v20240307/image_id",
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersionWithOffset(1)),
+			env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 1),
+			env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersionWithOffset(1), "amd64", 0),
 		))
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyAL2023
 		nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{{ID: oldCustomAMI}}

--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -46,7 +46,7 @@ import (
 var _ = Describe("AMI", func() {
 	var customAMI string
 	BeforeEach(func() {
-		customAMI = env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
+		customAMI = env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 0))
 	})
 
 	It("should use the AMI defined by the AMI Selector Terms", func() {
@@ -64,7 +64,8 @@ var _ = Describe("AMI", func() {
 	})
 	It("should use the most recent AMI when discovering multiple", func() {
 		// choose an old static image that will definitely have an older creation date
-		oldCustomAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%[1]s/amazon-linux-2023/x86_64/standard/amazon-eks-node-al2023-x86_64-standard-%[1]s-v20240514/image_id", env.K8sVersion()))
+		oldCustomAMI := env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 1))
+
 		nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
 			{
 				ID: customAMI,
@@ -185,7 +186,7 @@ var _ = Describe("AMI", func() {
 		})
 		It("should support Custom AMIFamily with AMI Selectors", func() {
 			nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyCustom
-			al2023AMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
+			al2023AMI := env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 0))
 			nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
 				{
 					ID: al2023AMI,

--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Extended Resources", func() {
 		Skip("skipping test on AMD instance types")
 		ExpectAMDDevicePluginCreated()
 
-		customAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
+		customAMI := env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 0))
 
 		// We create custom userData that installs the AMD Radeon driver and then performs the EKS bootstrap script
 		// We use a Custom AMI so that we can reboot after we start the kubelet service

--- a/test/suites/nodeclaim/garbage_collection_test.go
+++ b/test/suites/nodeclaim/garbage_collection_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GarbageCollection", func() {
 		Expect(securityGroups).ToNot(HaveLen(0))
 		Expect(subnets).ToNot(HaveLen(0))
 
-		customAMI = env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
+		customAMI = env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 0))
 		instanceProfileName = fmt.Sprintf("KarpenterNodeInstanceProfile-%s", env.ClusterName)
 		roleName = fmt.Sprintf("KarpenterNodeRole-%s", env.ClusterName)
 		instanceInput = &ec2.RunInstancesInput{

--- a/test/suites/nodeclaim/nodeclaim_test.go
+++ b/test/suites/nodeclaim/nodeclaim_test.go
@@ -268,7 +268,7 @@ var _ = Describe("StandaloneNodeClaim", func() {
 		}, time.Second*10).Should(Succeed())
 	})
 	It("should create a NodeClaim with custom labels passed through the userData", func() {
-		customAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
+		customAMI := env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 0))
 		// Update the userData for the instance input with the correct NodePool
 		rawContent, err := os.ReadFile("testdata/al2023_userdata_custom_labels_input.yaml")
 		Expect(err).ToNot(HaveOccurred())
@@ -318,7 +318,7 @@ var _ = Describe("StandaloneNodeClaim", func() {
 		env.EventuallyExpectNodeClaimsReady(nodeClaim)
 	})
 	It("should delete a NodeClaim after the registration timeout when the node doesn't register", func() {
-		customAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
+		customAMI := env.GetAMIBySSMPath(env.GetSSMPath(v1beta1.AMIFamilyAL2023, env.K8sVersion(), "amd64", 0))
 		// Update the userData for the instance input with the correct NodePool
 		rawContent, err := os.ReadFile("testdata/al2023_userdata_input.yaml")
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a helper function to our environment to get the SSM path for a supported AMI family, with a release offset. Importantly, this allows us to avoid hardcoding old AMIs.

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.