### PR TITLE
ci: Add `git_ref` for versionCompatibility 

### DIFF
--- a/.github/workflows/e2e-version-compatibility-trigger.yaml
+++ b/.github/workflows/e2e-version-compatibility-trigger.yaml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       region: ${{ inputs.region || 'eu-west-1' }}
+      git_ref: ${{ needs.resolve.outputs.GIT_REF }}
       k8s_version: ${{ matrix.k8s_version }}
       workflow_trigger: "versionCompatibility"
       # Default to true unless using a workflow_dispatch


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Without `git_ref` PR runs are currently broken for versionCompatibility. Adding it to fix `/karpenter versionCompatibility` 
- https://github.com/aws/karpenter-provider-aws/actions/runs/9452050051

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.