### PR TITLE
docs: update stable release / rc wording

### DIFF
--- a/website/content/en/docs/upgrading/compatibility.md
+++ b/website/content/en/docs/upgrading/compatibility.md
@@ -75,14 +75,13 @@ Karpenter offers three types of releases. This section explains the purpose of e
 
 ### Stable Releases
 
-Stable releases are the most reliable releases that are released with weekly cadence. Stable releases are our only recommended versions for production environments.
-Sometimes we skip a stable release because we find instability or problems that need to be fixed before having a stable release.
-Stable releases are tagged with a semantic version prefixed by a `v`. For example `v0.13.0`.
+Stable releases are the only recommended versions for production environments. Stable releases are tagged with a semantic version (e.g. `0.35.0`). Note that stable releases prior to `0.35.0` are prefixed with a `v` (e.g. `v0.34.0`).
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `vx.y.z-rc.0`, `vx.y.z-rc.1`. The release candidate will then graduate to `vx.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
+Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 
 ### Snapshot Releases
 

--- a/website/content/en/docs/upgrading/compatibility.md
+++ b/website/content/en/docs/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/docs/upgrading/compatibility.md
+++ b/website/content/en/docs/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/preview/upgrading/compatibility.md
+++ b/website/content/en/preview/upgrading/compatibility.md
@@ -75,14 +75,13 @@ Karpenter offers three types of releases. This section explains the purpose of e
 
 ### Stable Releases
 
-Stable releases are the most reliable releases that are released with weekly cadence. Stable releases are our only recommended versions for production environments.
-Sometimes we skip a stable release because we find instability or problems that need to be fixed before having a stable release.
-Stable releases are tagged with a semantic version prefixed by a `v`. For example `v0.13.0`.
+Stable releases are the only recommended versions for production environments. Stable releases are tagged with a semantic version (e.g. `0.35.0`). Note that stable releases prior to `0.35.0` are prefixed with a `v` (e.g. `v0.34.0`).
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `vx.y.z-rc.0`, `vx.y.z-rc.1`. The release candidate will then graduate to `vx.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
+Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 
 ### Snapshot Releases
 

--- a/website/content/en/preview/upgrading/compatibility.md
+++ b/website/content/en/preview/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/preview/upgrading/compatibility.md
+++ b/website/content/en/preview/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.32/upgrading/compatibility.md
+++ b/website/content/en/v0.32/upgrading/compatibility.md
@@ -75,7 +75,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.32/upgrading/compatibility.md
+++ b/website/content/en/v0.32/upgrading/compatibility.md
@@ -71,14 +71,13 @@ Karpenter offers three types of releases. This section explains the purpose of e
 
 ### Stable Releases
 
-Stable releases are the most reliable releases that are released with weekly cadence. Stable releases are our only recommended versions for production environments.
-Sometimes we skip a stable release because we find instability or problems that need to be fixed before having a stable release.
-Stable releases are tagged with Semantic Versioning. For example `v0.13.0`.
+Stable releases are the only recommended versions for production environments. Stable releases are tagged with a semantic version (e.g. `0.35.0`). Note that stable releases prior to `0.35.0` are prefixed with a `v` (e.g. `v0.34.0`).
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `vx.y.z-rc.0`, `vx.y.z-rc.1`. The release candidate will then graduate to `vx.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
+Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 
 ### Snapshot Releases
 

--- a/website/content/en/v0.32/upgrading/compatibility.md
+++ b/website/content/en/v0.32/upgrading/compatibility.md
@@ -75,7 +75,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.35/upgrading/compatibility.md
+++ b/website/content/en/v0.35/upgrading/compatibility.md
@@ -75,14 +75,13 @@ Karpenter offers three types of releases. This section explains the purpose of e
 
 ### Stable Releases
 
-Stable releases are the most reliable releases that are released with weekly cadence. Stable releases are our only recommended versions for production environments.
-Sometimes we skip a stable release because we find instability or problems that need to be fixed before having a stable release.
-Stable releases are tagged with a semantic version prefixed by a `v`. For example `v0.13.0`.
+Stable releases are the only recommended versions for production environments. Stable releases are tagged with a semantic version (e.g. `0.35.0`). Note that stable releases prior to `0.35.0` are prefixed with a `v` (e.g. `v0.34.0`).
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `vx.y.z-rc.0`, `vx.y.z-rc.1`. The release candidate will then graduate to `vx.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
+Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 
 ### Snapshot Releases
 

--- a/website/content/en/v0.35/upgrading/compatibility.md
+++ b/website/content/en/v0.35/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.35/upgrading/compatibility.md
+++ b/website/content/en/v0.35/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.36/upgrading/compatibility.md
+++ b/website/content/en/v0.36/upgrading/compatibility.md
@@ -75,14 +75,13 @@ Karpenter offers three types of releases. This section explains the purpose of e
 
 ### Stable Releases
 
-Stable releases are the most reliable releases that are released with weekly cadence. Stable releases are our only recommended versions for production environments.
-Sometimes we skip a stable release because we find instability or problems that need to be fixed before having a stable release.
-Stable releases are tagged with a semantic version prefixed by a `v`. For example `v0.13.0`.
+Stable releases are the only recommended versions for production environments. Stable releases are tagged with a semantic version (e.g. `0.35.0`). Note that stable releases prior to `0.35.0` are prefixed with a `v` (e.g. `v0.34.0`).
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `vx.y.z-rc.0`, `vx.y.z-rc.1`. The release candidate will then graduate to `vx.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
+Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 
 ### Snapshot Releases
 

--- a/website/content/en/v0.36/upgrading/compatibility.md
+++ b/website/content/en/v0.36/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.36/upgrading/compatibility.md
+++ b/website/content/en/v0.36/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.37/upgrading/compatibility.md
+++ b/website/content/en/v0.37/upgrading/compatibility.md
@@ -75,14 +75,13 @@ Karpenter offers three types of releases. This section explains the purpose of e
 
 ### Stable Releases
 
-Stable releases are the most reliable releases that are released with weekly cadence. Stable releases are our only recommended versions for production environments.
-Sometimes we skip a stable release because we find instability or problems that need to be fixed before having a stable release.
-Stable releases are tagged with a semantic version prefixed by a `v`. For example `v0.13.0`.
+Stable releases are the only recommended versions for production environments. Stable releases are tagged with a semantic version (e.g. `0.35.0`). Note that stable releases prior to `0.35.0` are prefixed with a `v` (e.g. `v0.34.0`).
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `vx.y.z-rc.0`, `vx.y.z-rc.1`. The release candidate will then graduate to `vx.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
+Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 
 ### Snapshot Releases
 

--- a/website/content/en/v0.37/upgrading/compatibility.md
+++ b/website/content/en/v0.37/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 

--- a/website/content/en/v0.37/upgrading/compatibility.md
+++ b/website/content/en/v0.37/upgrading/compatibility.md
@@ -79,7 +79,7 @@ Stable releases are the only recommended versions for production environments. S
 
 ### Release Candidates
 
-We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal, stable release.
+We consider having release candidates for major and important minor versions. Our release candidates are tagged like `x.y.z-rc.0`, `x.y.z-rc.1`. The release candidate will then graduate to `x.y.z` as a normal stable release.
 By adopting this practice we allow our users who are early adopters to test out new releases before they are available to the wider community, thereby providing us with early feedback resulting in more stable releases.
 Note that, like the stable releases, release candidates prior to `0.35.0` are prefixed with a `v`.
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #6348 

**Description**
Updates the wording for stable releases and release candidates to indicate the tags are no longer prefixed by a `v`. Additionally, this drops the wording around a weekly release cadence.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.