### PR TITLE
feat: Add tenancy option dedicated on LaunchTemplate

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -433,6 +433,20 @@ spec:
                   rule: self.all(k, k !='karpenter.sh/nodeclaim')
                 - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
                   rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+              tenancy:
+                description: |-
+                  Tenancy of the instance. An instance with a tenancy of dedicated runs on single-tenant hardware.
+
+
+                  If not set, Tenancy will be set to default.
+                  Currently, Karpenter only support default and dedicated option.
+                  For more information,
+                  See the AWS::EC2::LaunchTemplate Placement Document.
+                  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-placement.html
+                enum:
+                - default
+                - dedicated
+                type: string
               userData:
                 description: |-
                   UserData to be applied to the provisioned nodes.

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -113,6 +113,16 @@ type EC2NodeClassSpec struct {
 	// +kubebuilder:default={"httpEndpoint":"enabled","httpProtocolIPv6":"disabled","httpPutResponseHopLimit":2,"httpTokens":"required"}
 	// +optional
 	MetadataOptions *MetadataOptions `json:"metadataOptions,omitempty"`
+	// Tenancy of the instance. An instance with a tenancy of dedicated runs on single-tenant hardware.
+	//
+	// If not set, Tenancy will be set to default.
+	// Currently, Karpenter only support default and dedicated option.
+	// For more information,
+	// See the AWS::EC2::LaunchTemplate Placement Document.
+	// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-placement.html
+	// +kubebuilder:validation:Enum:={default,dedicated}
+	// +optional
+	Tenancy *string `json:"tenancy,omitempty"`
 	// Context is a Reserved field in EC2 APIs
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
 	// +optional

--- a/pkg/apis/v1beta1/ec2nodeclass_validation.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation.go
@@ -32,6 +32,7 @@ const (
 	amiFamilyPath                  = "amiFamily"
 	tagsPath                       = "tags"
 	metadataOptionsPath            = "metadataOptions"
+	tenancyPath                    = "tenancy"
 	blockDeviceMappingsPath        = "blockDeviceMappings"
 	rolePath                       = "role"
 	instanceProfilePath            = "instanceProfile"
@@ -79,6 +80,7 @@ func (in *EC2NodeClassSpec) validate(_ context.Context) (errs *apis.FieldError) 
 		in.validateAMISelectorTerms().ViaField(amiSelectorTermsPath),
 		in.validateMetadataOptions().ViaField(metadataOptionsPath),
 		in.validateAMIFamily().ViaField(amiFamilyPath),
+		in.validateTenancy().ViaField(tenancyPath),
 		in.validateBlockDeviceMappings().ViaField(blockDeviceMappingsPath),
 		in.validateTags().ViaField(tagsPath),
 	)
@@ -302,6 +304,13 @@ func (in *EC2NodeClassSpec) validateRoleImmutability(originalSpec *EC2NodeClassS
 			Message: "Immutable field changed",
 			Paths:   []string{"role"},
 		}
+	}
+	return nil
+}
+
+func (in *EC2NodeClassSpec) validateTenancy() (errs *apis.FieldError) {
+	if in.Tenancy != nil {
+		return in.validateStringEnum(*in.Tenancy, "tenancy", ec2.Tenancy_Values())
 	}
 	return nil
 }

--- a/pkg/apis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1beta1/zz_generated.deepcopy.go
@@ -284,6 +284,11 @@ func (in *EC2NodeClassSpec) DeepCopyInto(out *EC2NodeClassSpec) {
 		*out = new(MetadataOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tenancy != nil {
+		in, out := &in.Tenancy, &out.Tenancy
+		*out = new(string)
+		**out = **in
+	}
 	if in.Context != nil {
 		in, out := &in.Context, &out.Context
 		*out = new(string)

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -71,6 +71,7 @@ type LaunchTemplate struct {
 	AMIID               string
 	InstanceTypes       []*cloudprovider.InstanceType `hash:"ignore"`
 	DetailedMonitoring  bool
+	Tenancy             string
 	EFACount            int
 	CapacityType        string
 }
@@ -231,6 +232,7 @@ func (r Resolver) resolveLaunchTemplate(nodeClass *v1beta1.EC2NodeClass, nodeCla
 		MetadataOptions:     nodeClass.Spec.MetadataOptions,
 		DetailedMonitoring:  aws.BoolValue(nodeClass.Spec.DetailedMonitoring),
 		AMIID:               amiID,
+		Tenancy:             aws.StringValue(nodeClass.Spec.Tenancy),
 		InstanceTypes:       instanceTypes,
 		EFACount:            efaCount,
 		CapacityType:        capacityType,

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -259,6 +259,9 @@ func (p *DefaultProvider) createLaunchTemplate(ctx context.Context, options *ami
 			SecurityGroupIds: lo.Ternary(networkInterfaces != nil, nil, lo.Map(options.SecurityGroups, func(s v1beta1.SecurityGroup, _ int) *string { return aws.String(s.ID) })),
 			UserData:         aws.String(userData),
 			ImageId:          aws.String(options.AMIID),
+			Placement: &ec2.LaunchTemplatePlacementRequest{
+				Tenancy: aws.String(options.Tenancy),
+			},
 			MetadataOptions: &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
 				HttpEndpoint:            options.MetadataOptions.HTTPEndpoint,
 				HttpProtocolIpv6:        options.MetadataOptions.HTTPProtocolIPv6,

--- a/website/content/en/v0.37/concepts/nodeclasses.md
+++ b/website/content/en/v0.37/concepts/nodeclasses.md
@@ -117,6 +117,10 @@ spec:
   # Optional, configures if the instance should be launched with an associated public IP address.
   # If not specified, the default value depends on the subnet's public IP auto-assign setting.
   associatePublicIPAddress: true
+
+  # Optional, configures tenancy for the instance
+  # Currently only support default and dedicated
+  tenancy: default
 status:
   # Resolved subnets
   subnets:
@@ -1109,6 +1113,19 @@ A boolean field that controls whether instances created by Karpenter for this EC
 If a `NodeClaim` requests `vpc.amazonaws.com/efa` resources, `spec.associatePublicIPAddress` is respected. However, if this `NodeClaim` requests **multiple** EFA resources and the value for `spec.associatePublicIPAddress` is true, the instance will fail to launch. This is due to an EC2 restriction which
 requires that the field is only set to true when configuring an instance with a single ENI at launch. When using this field, it is advised that users segregate their EFA workload to use a separate `NodePool` / `EC2NodeClass` pair.
 {{% /alert %}}
+
+## spec.tenancy
+
+A string field that sets the [Dedicated instances](https://docs.aws.amazon.com/ko_kr/AWSEC2/latest/UserGuide/dedicated-instance.html). Currently allowed values are default and dedicated.
+
+```yaml
+spec:
+  tenancy: dedicated
+```
+
+By default, EC2 instances run on shared tenancy hardware. This means that multiple AWS accounts can share the same physical hardware.
+
+Dedicated instances are EC2 instances that run on hardware dedicated to a single AWS account. This means that Dedicated Instances are physically isolated at the host hardware level from instances belonging to other AWS accounts, even if that account is associated with a single payer account. However, Dedicated Instances can share hardware with other instances in the same AWS account that are not Dedicated Instances.
 
 ## status.subnets
 [`status.subnets`]({{< ref "#statussubnets" >}}) contains the resolved `id` and `zone` of the subnets that were selected by the [`spec.subnetSelectorTerms`]({{< ref "#specsubnetselectorterms" >}}) for the node class. The subnets will be sorted by the available IP address count in decreasing order.

--- a/website/content/en/v0.37/concepts/nodeclasses.md
+++ b/website/content/en/v0.37/concepts/nodeclasses.md
@@ -1116,7 +1116,7 @@ requires that the field is only set to true when configuring an instance with a 
 
 ## spec.tenancy
 
-A string field that sets the [Dedicated instances](https://docs.aws.amazon.com/ko_kr/AWSEC2/latest/UserGuide/dedicated-instance.html). Currently allowed values are default and dedicated.
+A string field that sets the [Dedicated instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html). Currently allowed values are default and dedicated.
 
 ```yaml
 spec:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #4633 <!-- issue number -->

**Description**
Support `tenancy: dedicated` options for mitigate compliance issues for some reason.

**How was this change tested?**

I confirmed that the dedicated instance was launched fine in my own eks cluster.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.