### PR TITLE
test: Fix scale test provisioning spike

### DIFF
--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), fu
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
 		}, map[string]string{
 			aws.TestCategoryDimension:           testGroup,
-			aws.TestNameDimension:               "node-dense",
+			aws.TestNameDimension:               "node-dense-min-val",
 			aws.ProvisionedNodeCountDimension:   strconv.Itoa(expectedNodeCount),
 			aws.DeprovisionedNodeCountDimension: strconv.Itoa(0),
 			aws.PodDensityDimension:             strconv.Itoa(replicasPerNode),
@@ -253,7 +253,7 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), fu
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
 		}, map[string]string{
 			aws.TestCategoryDimension:           testGroup,
-			aws.TestNameDimension:               "pod-dense",
+			aws.TestNameDimension:               "pod-dense-min-val",
 			aws.ProvisionedNodeCountDimension:   strconv.Itoa(expectedNodeCount),
 			aws.DeprovisionedNodeCountDimension: strconv.Itoa(0),
 			aws.PodDensityDimension:             strconv.Itoa(replicasPerNode),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
We have been seeing spikes in the scale tests for provisioning. That's because there are two different tests that are captured by the same metric and the execution times are different for both.
1. Metric `node-dense` for node dense scale-up and node dense scale-up with minValues
2. Metric `pod-dense` for pod dense scale-up and pod dense scale-up with minValues

Created a different metric for scale up with and without min values. Now we have `node-dense`, `node-dense-min-val`, `pod-dense`, `pod-dense-min-val`.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.