### PR TITLE
ci: Increase max retry for the sweeper

### DIFF
--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -46,6 +46,7 @@ func main() {
 
 	ctx := context.Background()
 	cfg := lo.Must(config.LoadDefaultConfig(ctx))
+	cfg.RetryMaxAttempts = 10
 
 	logger := lo.Must(zap.NewProduction()).Sugar()
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- We are experiencing throttling in our [sweeper](https://github.com/aws/karpenter-provider-aws/actions/runs/9564694974/job/26366008036) and will need to increase the default retry attempt 
```
operation error IAM: ListInstanceProfileTags, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: f4676348-05c7-47e8-aae5-6402e1ce5040,
```
- Since the retry strategy is exponential backoff, increasing the number of retry attempts from 3 to 10 to make sure that call will be spread out exponentially and increase the likelihood of call succeeding 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.