### PR TITLE
chore: Add soft eviction setting to Bottlerocket kublet config

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -64,6 +64,18 @@ func (b Bottlerocket) Script() (string, error) {
 		if b.KubeletConfig.EvictionHard != nil {
 			s.Settings.Kubernetes.EvictionHard = b.KubeletConfig.EvictionHard
 		}
+		if b.KubeletConfig.EvictionMaxPodGracePeriod != nil {
+			s.Settings.Kubernetes.EvictionMaxPodGracePeriod = aws.Int(int(ptr.Int32Value(b.KubeletConfig.EvictionMaxPodGracePeriod)))
+		}
+		if b.KubeletConfig.EvictionSoft != nil {
+			s.Settings.Kubernetes.EvictionSoft = b.KubeletConfig.EvictionSoft
+		}
+		if b.KubeletConfig.EvictionSoftGracePeriod != nil {
+			s.Settings.Kubernetes.EvictionSoftGracePeriod = make(map[string]string)
+			for k, v := range b.KubeletConfig.EvictionSoftGracePeriod {
+				s.Settings.Kubernetes.EvictionSoftGracePeriod[k] = v.Duration.String()
+			}
+		}
 		if b.KubeletConfig.ImageGCHighThresholdPercent != nil {
 			s.Settings.Kubernetes.ImageGCHighThresholdPercent = lo.ToPtr(strconv.FormatInt(int64(*b.KubeletConfig.ImageGCHighThresholdPercent), 10))
 		}

--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -54,6 +54,9 @@ type BottlerocketKubernetes struct {
 	MaxPods                            *int                                      `toml:"max-pods,omitempty"`
 	StaticPods                         map[string]BottlerocketStaticPod          `toml:"static-pods,omitempty"`
 	EvictionHard                       map[string]string                         `toml:"eviction-hard,omitempty"`
+	EvictionMaxPodGracePeriod          *int                                      `toml:"eviction-max-pod-grace-period,omitempty"`
+	EvictionSoft                       map[string]string                         `toml:"eviction-soft,omitempty"`
+	EvictionSoftGracePeriod            map[string]string                         `toml:"eviction-soft-grace-period,omitempty"`
 	KubeReserved                       map[string]string                         `toml:"kube-reserved,omitempty"`
 	SystemReserved                     map[string]string                         `toml:"system-reserved,omitempty"`
 	AllowedUnsafeSysctls               []string                                  `toml:"allowed-unsafe-sysctls,omitempty"`

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -128,17 +128,11 @@ func (b Bottlerocket) EphemeralBlockDevice() *string {
 // podsPerCore will be ignored
 // https://github.com/bottlerocket-os/bottlerocket/issues/1721
 
-// EvictionSoftEnabled is currently disabled for Bottlerocket AMIFamily because it does
-// not currently support the evictionSoft parameter passed through the kubernetes settings TOML userData
-// If a NodePool sets the evictionSoft value when using the Bottlerocket AMIFamily in the provider,
-// evictionSoft will be ignored
-// https://github.com/bottlerocket-os/bottlerocket/issues/1445
-
 func (b Bottlerocket) FeatureFlags() FeatureFlags {
 	return FeatureFlags{
 		UsesENILimitedMemoryOverhead: false,
 		PodsPerCoreEnabled:           false,
-		EvictionSoftEnabled:          false,
+		EvictionSoftEnabled:          true,
 		SupportsENILimitedPodDensity: true,
 	}
 }


### PR DESCRIPTION
Fixes #N/A

**Description**

Issue https://github.com/bottlerocket-os/bottlerocket/issues/1445 is fixed and so soft eviction settings can now be used with Bottlerocket. It looks like old docs have already been removed that used to discuss this limitation.

**How was this change tested?**

Tested on a live EKS cluster to provision Bottlerocket nodes, then the kubelet configuration was checked using `http://localhost:8001/api/v1/nodes/$NODE/proxy/configz`.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.