### PR TITLE
test: Fix private cluster test failure

### DIFF
--- a/test/suites/integration/validation_test.go
+++ b/test/suites/integration/validation_test.go
@@ -253,6 +253,12 @@ var _ = Describe("Validation", func() {
 			Expect(env.Client.Update(env.Context, nodeClass)).ToNot(Succeed())
 		})
 		It("should fail to switch between a managed and unmanaged instance profile", func() {
+			// Skipping this test for private cluster because there is no VPC private endpoint for the IAM API. As a result,
+			// you cannot use the default spec.role field in your EC2NodeClass. Instead, you need to provision and manage an
+			// instance profile manually and then specify Karpenter to use this instance profile through the spec.instanceProfile field.
+			if env.PrivateCluster {
+				Skip("skipping Unmanaged instance profile test for private cluster")
+			}
 			nodeClass.Spec.Role = "test-role"
 			nodeClass.Spec.InstanceProfile = nil
 			Expect(env.Client.Create(env.Context, nodeClass)).To(Succeed())


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
We have been seeing failure in the private cluster test run. This PR adds a fix for it. 

**How was this change tested?**
Tested on private cluster in my account

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.