### PR TITLE
adding a new interface for ami resolver

### DIFF
--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -34,6 +34,10 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
+type AMIResolver interface {
+	Resolve(nodeClass *v1beta1.EC2NodeClass, nodeClaim *corev1beta1.NodeClaim, instanceTypes []*cloudprovider.InstanceType, capacityType string, options *Options) ([]*LaunchTemplate, error)
+}
+
 var DefaultEBS = v1beta1.BlockDevice{
 	Encrypted:  aws.Bool(true),
 	VolumeType: aws.String(ec2.VolumeTypeGp3),

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -70,7 +70,7 @@ type DefaultProvider struct {
 	sync.Mutex
 	ec2api                ec2iface.EC2API
 	eksapi                eksiface.EKSAPI
-	amiFamily             *amifamily.Resolver
+	amiFamily             amifamily.AMIResolver
 	securityGroupProvider securitygroup.Provider
 	subnetProvider        subnet.Provider
 	cache                 *cache.Cache


### PR DESCRIPTION
ci: Adding a new interface for AMI resolver


**Description**
Adding a new interface for AMI resolver as this class didn't have any existing interface which makes it tightly coupled with LaunchTemplateProvider. 

**How was this change tested?**
I haven't tested this change locally

**Does this change impact docs?**
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.