### PR TITLE
docs: Scheduling concept doc GPU taint example value: true bool should be a string

### DIFF
--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -281,7 +281,7 @@ spec:
           - p3
       taints:
       - key: nvidia.com/gpu
-        value: true
+        value: "true"
         effect: "NoSchedule"
 ```
 

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -295,7 +295,7 @@ spec:
           - p3
       taints:
       - key: nvidia.com/gpu
-        value: true
+        value: "true"
         effect: "NoSchedule"
 ```
 

--- a/website/content/en/v0.32/concepts/scheduling.md
+++ b/website/content/en/v0.32/concepts/scheduling.md
@@ -278,7 +278,7 @@ spec:
           - p3
       taints:
       - key: nvidia.com/gpu
-        value: true
+        value: "true"
         effect: "NoSchedule"
 ```
 

--- a/website/content/en/v0.35/concepts/scheduling.md
+++ b/website/content/en/v0.35/concepts/scheduling.md
@@ -279,7 +279,7 @@ spec:
           - p3
       taints:
       - key: nvidia.com/gpu
-        value: true
+        value: "true"
         effect: "NoSchedule"
 ```
 

--- a/website/content/en/v0.36/concepts/scheduling.md
+++ b/website/content/en/v0.36/concepts/scheduling.md
@@ -280,7 +280,7 @@ spec:
           - p3
       taints:
       - key: nvidia.com/gpu
-        value: true
+        value: "true"
         effect: "NoSchedule"
 ```
 

--- a/website/content/en/v0.37/concepts/scheduling.md
+++ b/website/content/en/v0.37/concepts/scheduling.md
@@ -281,7 +281,7 @@ spec:
           - p3
       taints:
       - key: nvidia.com/gpu
-        value: true
+        value: "true"
         effect: "NoSchedule"
 ```
 


### PR DESCRIPTION
Quoting bool value in gpu taint example

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Following this documentation, I applied the taint as shown
```
taints: 
  - key: nvidia.com/gpu
    value: true
    effect: "NoSchedule"
```
and got an error
```
NodePool.karpenter.sh "gpu" is invalid: [spec.template.spec.taints[0].value: Invalid value: "boolean": spec.template.spec.taints[0].value in body must be of type string: "boolean"
```
Quoting the `true` applied successfully. Also see here where the same example is already quoted:
https://karpenter.sh/docs/concepts/nodepools/

**How was this change tested?**
Previewed the scheduling.md

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.