### PR TITLE
chore: Add pod-pids-limit to bottlerocket settings

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -77,6 +77,7 @@ type BottlerocketKubernetes struct {
 	ShutdownGracePeriodForCriticalPods *string                                   `toml:"shutdown-grace-period-for-critical-pods,omitempty"`
 	ClusterDomain                      *string                                   `toml:"cluster-domain,omitempty"`
 	SeccompDefault                     *bool                                     `toml:"seccomp-default,omitempty"`
+	PodPidsLimit                       *int                                      `toml:"pod-pids-limit,omitempty"`
 }
 
 type BottlerocketStaticPod struct {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Add [pod-pids-limit](https://bottlerocket.dev/en/os/1.19.x/api/settings/kubernetes/#pod-pids-limit) to bottlerocket settings.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.