### PR TITLE
migrated from "marvinpinto/action-automatic-releases" to Officital GIthub Action for creating releases.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Create GitHub Release
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo_token: '${{ secrets.GITHUB_TOKEN }}'
-          prerelease: false
+          tag_name: ${{github.ref}}
+          release_name: Release ${{ github.ref }}
+          body:  |
+            Release notes for ${{ github.ref }}.
+          prerelease: ${{github.ref}} contains "-rc."  || ${{ github.ref }} contains "-alpha."  || ${{ github.ref }} contains "-beta."
       - uses: ./.github/actions/install-deps
       - uses: ./.github/actions/e2e/install-helm
         with:
@@ -68,3 +73,5 @@ jobs:
               issue_number: result.data.number,
               labels: ['stable-release','website','helm-charts']
             });
+
+  


### PR DESCRIPTION
chore: Replaced "marvinpinto/action-automatic-releases" with "actions/create-release".

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes ##6206

**Description**

- Replaced "marvinpinto/action-automatic-releases" with "actions/create-release" in the release workflow.
- Updated the workflow to use "actions/create-release" for creating GitHub releases based on semantic version tags.
- Adjusted the prerelease condition to properly handle -rc., -alpha., and -beta. tags.

**How was this change tested?**
- Tested by pushing tags that match the supported semantic version patterns and ensuring that releases are created correctly.
- Verified that the "prerelease" condition is properly evaluated and releases are marked accordingly.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.