### PR TITLE
test: Fix time out in scale tests

### DIFF
--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -101,6 +101,11 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				},
 			},
 		}...)
+		nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{
+			{
+				Nodes: "70%",
+			},
+		}
 		deploymentOptions = test.DeploymentOptions{
 			PodOptions: test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
@@ -297,6 +302,11 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			env.MeasureDeprovisioningDurationFor(func() {
 				By("enabling deprovisioning across nodePools")
 				for _, p := range nodePoolMap {
+					p.Spec.Disruption.Budgets = []corev1beta1.Budget{
+						{
+							Nodes: "70%",
+						},
+					}
 					env.ExpectCreatedOrUpdated(p)
 				}
 				env.ExpectUpdated(driftNodeClass)

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -48,6 +48,11 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), fu
 		nodeClass = env.DefaultEC2NodeClass()
 		nodePool = env.DefaultNodePool(nodeClass)
 		nodePool.Spec.Limits = nil
+		nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{
+			{
+				Nodes: "70%",
+			},
+		}
 		test.ReplaceRequirements(nodePool, corev1beta1.NodeSelectorRequirementWithMinValues{
 			NodeSelectorRequirement: v1.NodeSelectorRequirement{
 				Key:      v1beta1.LabelInstanceHypervisor,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Deprovisioning scale tests were timing out since we merged the "Wait for instance termination PR". This was happening because the disruption budget of 10% would not allow all the nodes to be gone together thereby increasing the time taken for nodes to be deleted. To fix this, the budget has been increased to 70% in this PR.

**How was this change tested?**
Ran these tests on local cluster.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.