### PR TITLE
fix: use templated datasource in capacity dashboard method templating

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
@@ -1607,7 +1607,7 @@
 				},
 				"datasource": {
 					"type": "prometheus",
-					"uid": "prometheus"
+					"uid": "${datasource}"
 				},
 				"definition": "label_values(karpenter_disruption_actions_performed_total,method)",
 				"hide": 0,

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
@@ -1607,7 +1607,7 @@
 				},
 				"datasource": {
 					"type": "prometheus",
-					"uid": "prometheus"
+					"uid": "${datasource}"
 				},
 				"definition": "label_values(karpenter_disruption_actions_performed_total,method)",
 				"hide": 0,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
When importing the karpenter-capacity-dashboard.json I kept seeing "failed to upgrade legacy query" warning in dashboards because of "prometheus datasource not found", and the "method" variable did not contain any values, because it was using a hard-coded variable.

**How was this change tested?**
By importing the new dashboards, and seeing that there are no warnings and the method variable contain now values.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.