### PR TITLE
chore: Fix spurious `discovered subnets` lines in logging

### DIFF
--- a/pkg/providers/securitygroup/securitygroup.go
+++ b/pkg/providers/securitygroup/securitygroup.go
@@ -62,11 +62,10 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1beta1.EC2NodeCl
 	if err != nil {
 		return nil, err
 	}
-	if p.cm.HasChanged(fmt.Sprintf("security-groups/%s", nodeClass.Name), securityGroups) {
+	securityGroupIDs := lo.Map(securityGroups, func(s *ec2.SecurityGroup, _ int) string { return aws.StringValue(s.GroupId) })
+	if p.cm.HasChanged(fmt.Sprintf("security-groups/%s", nodeClass.Name), securityGroupIDs) {
 		log.FromContext(ctx).
-			WithValues("security-groups", lo.Map(securityGroups, func(s *ec2.SecurityGroup, _ int) string {
-				return aws.StringValue(s.GroupId)
-			})).
+			WithValues("security-groups", securityGroupIDs).
 			V(1).Info("discovered security groups")
 	}
 	return securityGroups, nil

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -109,7 +109,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1beta1.EC2NodeCl
 		}
 	}
 	p.cache.SetDefault(fmt.Sprint(hash), lo.Values(subnets))
-	if p.cm.HasChanged(fmt.Sprintf("subnets/%s", nodeClass.Name), subnets) {
+	if p.cm.HasChanged(fmt.Sprintf("subnets/%s", nodeClass.Name), lo.Keys(subnets)) {
 		log.FromContext(ctx).
 			WithValues("subnets", lo.Map(lo.Values(subnets), func(s *ec2.Subnet, _ int) v1beta1.Subnet {
 				return v1beta1.Subnet{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This fixes an issue where Karpenter was spurious logging "discovered subnets" any time there was a change in the subnet's IP availability. This change ensures that we will only log subnets when there is a change in the ids that are being selected on.

```console
{"level":"DEBUG","time":"2024-07-10T07:08:41.539Z","logger":"controller","message":"discovered subnets","commit":"ff0dc7d","controller":"nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"default"},"namespace":"","name":"default","reconcileID":"54da3ce7-88e7-42e3-ad25-6c0d9fef954f","subnets":[{"id":"subnet-0c89532267e680e6f","zone":"us-west-2a","zoneID":"usw2-az1"},{"id":"subnet-09d3d3e0bd7f68ee9","zone":"us-west-2b","zoneID":"usw2-az2"},{"id":"subnet-01095f4c202083b01","zone":"us-west-2a","zoneID":"usw2-az1"},{"id":"subnet-01a75589aa6237be1","zone":"us-west-2b","zoneID":"usw2-az2"},{"id":"subnet-060f9fb17941d125c","zone":"us-west-2c","zoneID":"usw2-az3"},{"id":"subnet-0e60f26cf52c5a6df","zone":"us-west-2c","zoneID":"usw2-az3"}]}
{"level":"DEBUG","time":"2024-07-10T07:12:45.409Z","logger":"controller","message":"discovered subnets","commit":"ff0dc7d","controller":"nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"default"},"namespace":"","name":"default","reconcileID":"6cc09a98-b64f-42a7-b8b2-3f6a37ea1448","subnets":[{"id":"subnet-01095f4c202083b01","zone":"us-west-2a","zoneID":"usw2-az1"},{"id":"subnet-01a75589aa6237be1","zone":"us-west-2b","zoneID":"usw2-az2"},{"id":"subnet-060f9fb17941d125c","zone":"us-west-2c","zoneID":"usw2-az3"},{"id":"subnet-0e60f26cf52c5a6df","zone":"us-west-2c","zoneID":"usw2-az3"},{"id":"subnet-0c89532267e680e6f","zone":"us-west-2a","zoneID":"usw2-az1"},{"id":"subnet-09d3d3e0bd7f68ee9","zone":"us-west-2b","zoneID":"usw2-az2"}]}
```

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.