### PR TITLE
fix: bottlerocket settings taint format

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -77,8 +77,7 @@ func (b Bottlerocket) Script() (string, error) {
 
 	s.Settings.Kubernetes.NodeTaints = map[string][]string{}
 	for _, taint := range b.Taints {
-		s.Settings.Kubernetes.NodeTaints[taint.Key] = append(s.Settings.Kubernetes.NodeTaints[taint.Key], fmt.Sprintf("%s%s",
-			lo.Ternary(taint.Value == "", "", taint.Value+":"), taint.Effect))
+		s.Settings.Kubernetes.NodeTaints[taint.Key] = append(s.Settings.Kubernetes.NodeTaints[taint.Key], fmt.Sprintf("%s:%s", taint.Value, taint.Effect))
 	}
 	script, err := s.MarshalTOML()
 	if err != nil {

--- a/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
@@ -16,7 +16,7 @@ custom-node-label = 'custom'
 [settings.kubernetes.node-taints]
 baz = ['bin:NoExecute']
 foo = ['bar:NoExecute']
-'karpenter.sh/unregistered' = ['NoExecute']
+'karpenter.sh/unregistered' = [':NoExecute']
 
 [settings.kubernetes.eviction-hard]
 'memory.available' = '12%%'

--- a/pkg/providers/launchtemplate/testdata/br_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_unmerged.golden
@@ -14,4 +14,4 @@ max-pods = 110
 [settings.kubernetes.node-taints]
 baz = ['bin:NoExecute']
 foo = ['bar:NoExecute']
-'karpenter.sh/unregistered' = ['NoExecute']
+'karpenter.sh/unregistered' = [':NoExecute']


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates the bottlerocket taint format such that a taint with no value still has a leading colon before effect. Failure to do so results in the bottlerocket instance being unable to register with the cluster.

**How was this change tested?**
`make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.