### PR TITLE
fix: scheduling zone-id flake

### DIFF
--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -644,7 +644,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 				},
 			})
 			env.ExpectCreated(nodePool, nodeClass, pod)
-			node := env.EventuallyExpectNodeCount("==", 1)[0]
+			node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
 			Expect(node.Labels[v1.LabelTopologyZone]).To(Equal(subnetInfo[1].Zone))
 			Expect(node.Labels[v1beta1.LabelTopologyZoneID]).To(Equal(subnetInfo[1].ZoneID))
 		})
@@ -686,7 +686,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 			for _, pod := range pods {
 				env.ExpectCreated(pod)
 			}
-			nodes := env.EventuallyExpectCreatedNodeCount("==", len(subnetInfo))
+			nodes := env.EventuallyExpectInitializedNodeCount("==", len(subnetInfo))
 			for _, node := range nodes {
 				expectedZone, ok := node.Labels[expectedZoneLabel]
 				Expect(ok).To(BeTrue())


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes a flake in the zone-id scheduling tests, where we might get the node before the label with the expected zone-id has been propagated by the nodeclaim lifecycle controller.

**How was this change tested?**
`make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.