### PR TITLE
fix: nodeclaim custom label test registration failure

### DIFF
--- a/test/suites/nodeclaim/testdata/al2023_userdata_custom_labels_input.yaml
+++ b/test/suites/nodeclaim/testdata/al2023_userdata_custom_labels_input.yaml
@@ -10,6 +10,8 @@ spec:
     config:
       clusterDNS:
       - 10.0.100.10
+      registerWithTaints:
+      - key: karpenter.sh/unregistered
+        effect: NoExecute
     flags:
     - --node-labels="testing/cluster=unspecified,custom-label=custom-value,custom-label2=custom-value2"
-    - --register-with-taints="karpenter.sh/unregistered:NoExecute"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Moves taint registration from flags to config for custom userdata provided in test. Unescaped quotes in the label flag can cause failures when nodeadm reads these flags into an environment variable. Until we align on a fix with the AL2023 / nodeadm folks, this solves the problem by adding the taints via the kubelet config instead.

**How was this change tested?**
`make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.