### PR TITLE
feat: Add interruption handling for rebalance recommendations

### DIFF
--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -25,6 +25,9 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -33,10 +36,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	coreapis "sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
 	"github.com/aws/karpenter-provider-aws/pkg/cache"
@@ -183,7 +188,12 @@ func (c *Controller) deleteMessage(ctx context.Context, msg *sqsapi.Message) err
 
 // handleNodeClaim retrieves the action for the message and then performs the appropriate action against the node
 func (c *Controller) handleNodeClaim(ctx context.Context, msg messages.Message, nodeClaim *karpv1.NodeClaim, node *corev1.Node) error {
-	action := actionForMessage(msg)
+	nodePool, err := c.resolveNodePoolFromNodeClaim(ctx, nodeClaim)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("getting NodePool from NodeClaim, %w", err)
+	}
+
+	action := actionForMessage(msg, nodePool)
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("NodeClaim", klog.KRef("", nodeClaim.Name), "action", string(action)))
 	if node != nil {
 		ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KRef("", node.Name)))
@@ -199,7 +209,8 @@ func (c *Controller) handleNodeClaim(ctx context.Context, msg messages.Message, 
 	).Inc()
 
 	// Mark the offering as unavailable in the ICE cache since we got a spot interruption warning
-	if msg.Kind() == messages.SpotInterruptionKind {
+	// or rebalance recommendation with the feature enabled
+	if action != NoAction && (msg.Kind() == messages.SpotInterruptionKind || msg.Kind() == messages.RebalanceRecommendationKind) {
 		zone := nodeClaim.Labels[corev1.LabelTopologyZone]
 		instanceType := nodeClaim.Labels[corev1.LabelInstanceTypeStable]
 		if zone != "" && instanceType != "" {
@@ -296,11 +307,28 @@ func (c *Controller) makeNodeInstanceIDMap(ctx context.Context) (map[string]*cor
 	return m, nil
 }
 
-func actionForMessage(msg messages.Message) Action {
+func actionForMessage(msg messages.Message, _ *v1beta1.NodePool) Action {
 	switch msg.Kind() {
 	case messages.ScheduledChangeKind, messages.SpotInterruptionKind, messages.StateChangeKind:
+		return CordonAndDrain
+	case messages.RebalanceRecommendationKind:
+		// TODO if this is enabled in the nodePool
+		// if nodePool.Spec.Disruption.HandleRebalanceRecommendations:
+		//     return CordonAndDrain
+		// return NoAction
 		return CordonAndDrain
 	default:
 		return NoAction
 	}
+}
+
+func (c *Controller) resolveNodePoolFromNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*v1beta1.NodePool, error) {
+	if nodePoolName, ok := nodeClaim.Labels[v1beta1.NodePoolLabelKey]; ok {
+		nodePool := &v1beta1.NodePool{}
+		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
+			return nil, err
+		}
+		return nodePool, nil
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{Group: coreapis.Group, Resource: "nodepools"}, "")
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #2813 <!-- issue number -->

Karpenter currently cordons and drains nodes when a spot termination event is received through the configured SQS queue.  It also adds the instance type into a temporary block list to avoid cycling the same instance types.

These are all behaviours which would be beneficial during a rebalance recommendation event with the added benefit that rebalance recommendations allow more time to drain the node.

It has been requested by members of the community that this feature should be optional.  It makes sense to enable or disable it on a per NodePool basis but no spec has been agreed yet.  This PR contains code based on a possible API change.  Further discussion will be required to agree the change and get the new API published.


**How was this change tested?**

This has been tested in a dev environment cluster and has been built
against the v0.37.0 tag.

The controller was updated to an image based on this branch (hintofmint/karpenter)[https://hub.docker.com/layers/hintofmint/karpenter/v0.37.0-rebalance-recommendation-handling/images/sha256-a50b2d49059e41ad4cd2f63f86432d7b8d63a34fabb155904385cc95b4a97bd7?context=explore].

Workloads were scaled up until the controller produced a log message that a rebalance
recommendation event had been processed.  The NodeClaims were noticed to have been
deleted shortly after the event.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No (it will do once the API is agreed)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.