### PR TITLE
test: fix drift suite

### DIFF
--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -547,6 +547,8 @@ var _ = Describe("Drift", func() {
 								Kind:       object.GVK(nodeClass).Kind,
 								Name:       nodeClass.Name,
 							},
+							// keep the same instance type requirements to prevent considering instance types that require swap
+							Requirements: nodePool.Spec.Template.Spec.Requirements,
 						},
 					},
 				},
@@ -620,7 +622,12 @@ var _ = Describe("Drift", func() {
 		}),
 		Entry("NodeRequirements", corev1beta1.NodeClaimTemplate{
 			Spec: corev1beta1.NodeClaimSpec{
-				Requirements: []corev1beta1.NodeSelectorRequirementWithMinValues{{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: corev1beta1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{corev1beta1.CapacityTypeSpot}}}},
+				// since this will overwrite the default requirements, add instance category and family selectors back into requirements
+				Requirements: []corev1beta1.NodeSelectorRequirementWithMinValues{
+					{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: corev1beta1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{corev1beta1.CapacityTypeSpot}}},
+					{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: v1beta1.LabelInstanceCategory, Operator: v1.NodeSelectorOpIn, Values: []string{"c", "m", "r"}}},
+					{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: v1beta1.LabelInstanceFamily, Operator: v1.NodeSelectorOpNotIn, Values: []string{"a1"}}},
+				},
 			},
 		}),
 	)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Drift where the nodepool would be altered during each update and then open up the nodepool to all possible EC2 instances. Some of these instances would be too small and use swap memory which causes kubelet to fail.

Example error:
```
Jul 12 20:24:01 kubelet[1596]: E0712 20:24:01.933476    1596 run.go:74] "command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false. /proc/swaps contained: [Filename\t\t\t\tType\t\tSize\t\tUsed\t\tPriority /dev/zram0                              partition\t416>
```
**How was this change tested?**
`make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.