### PR TITLE
chore: update kubelet hash annotation on nodeclaim

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -26,7 +26,8 @@ import (
 
 //go:generate controller-gen crd object:headerFile="../../hack/boilerplate.go.txt" paths="./..." output:crd:artifacts:config=crds
 var (
-	Group = "karpenter.k8s.aws"
+	Group              = "karpenter.k8s.aws"
+	CompatabilityGroup = "compatibility." + Group
 	//go:embed crds/karpenter.k8s.aws_ec2nodeclasses.yaml
 	EC2NodeClassCRD []byte
 	CRDs            = append(apis.CRDs,

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -92,7 +92,7 @@ type EC2NodeClassSpec struct {
 	// +kubebuilder:validation:XValidation:message="evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod",rule="has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true"
 	// +kubebuilder:validation:XValidation:message="evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft",rule="has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true"
 	// +optional
-	Kubelet *KubeletConfiguration `json:"kubelet,omitempty"`
+	Kubelet *KubeletConfiguration `json:"kubelet,omitempty" hash:"ignore"`
 	// BlockDeviceMappings to be applied to provisioned nodes.
 	// +kubebuilder:validation:XValidation:message="must have only one blockDeviceMappings with rootVolume",rule="self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1"
 	// +kubebuilder:validation:MaxItems:=50
@@ -416,7 +416,7 @@ type EC2NodeClass struct {
 // 1. A field changes its default value for an existing field that is already hashed
 // 2. A field is added to the hash calculation with an already-set value
 // 3. A field is removed from the hash calculations
-const EC2NodeClassHashVersion = "v2"
+const EC2NodeClassHashVersion = "v3"
 
 func (in *EC2NodeClass) Hash() string {
 	return fmt.Sprint(lo.Must(hashstructure.Hash(in.Spec, hashstructure.FormatV2, &hashstructure.HashOptions{

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -119,6 +119,7 @@ var (
 	LabelInstanceAcceleratorManufacturer      = apis.Group + "/instance-accelerator-manufacturer"
 	LabelInstanceAcceleratorCount             = apis.Group + "/instance-accelerator-count"
 	AnnotationEC2NodeClassHash                = apis.Group + "/ec2nodeclass-hash"
+	AnnotationKubeletCompatibilityHash        = apis.CompatabilityGroup + "/kubelet-drift-hash"
 	AnnotationEC2NodeClassHashVersion         = apis.Group + "/ec2nodeclass-hash-version"
 	AnnotationInstanceTagged                  = apis.Group + "/tagged"
 

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -43,6 +43,10 @@ func (c *CloudProvider) isNodeClassDrifted(ctx context.Context, nodeClaim *karpv
 	if drifted := c.areStaticFieldsDrifted(nodeClaim, nodeClass); drifted != "" {
 		return drifted, nil
 	}
+	kubeletDrifted, err := c.isKubeletConfigurationDrifted(nodeClaim, nodeClass, nodePool)
+	if err != nil {
+		return "", err
+	}
 	instance, err := c.getInstance(ctx, nodeClaim.Status.ProviderID)
 	if err != nil {
 		return "", err
@@ -59,7 +63,7 @@ func (c *CloudProvider) isNodeClassDrifted(ctx context.Context, nodeClaim *karpv
 	if err != nil {
 		return "", fmt.Errorf("calculating subnet drift, %w", err)
 	}
-	drifted := lo.FindOrElse([]cloudprovider.DriftReason{amiDrifted, securitygroupDrifted, subnetDrifted}, "", func(i cloudprovider.DriftReason) bool {
+	drifted := lo.FindOrElse([]cloudprovider.DriftReason{amiDrifted, securitygroupDrifted, subnetDrifted, kubeletDrifted}, "", func(i cloudprovider.DriftReason) bool {
 		return string(i) != ""
 	})
 	return drifted, nil
@@ -133,6 +137,27 @@ func (c *CloudProvider) areStaticFieldsDrifted(nodeClaim *karpv1.NodeClaim, node
 		return ""
 	}
 	return lo.Ternary(nodeClassHash != nodeClaimHash, NodeClassDrift, "")
+}
+
+// Remove once v1beta1 is dropped
+func (c *CloudProvider) isKubeletConfigurationDrifted(nodeClaim *karpv1.NodeClaim, nodeClass *v1.EC2NodeClass, nodePool *karpv1.NodePool) (cloudprovider.DriftReason, error) {
+	kubeletHash, err := utils.GetHashKubelet(nodePool, nodeClass)
+	if err != nil {
+		return "", err
+	}
+	nodeClaimKubeletHash, foundNodeClaimKubeletHash := nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]
+	nodeClassHashVersion, foundNodeClassHashVersion := nodeClass.Annotations[v1.AnnotationEC2NodeClassHashVersion]
+	nodeClaimHashVersion, foundNodeClaimHashVersion := nodeClaim.Annotations[v1.AnnotationEC2NodeClassHashVersion]
+
+	if !foundNodeClaimKubeletHash || !foundNodeClaimHashVersion || !foundNodeClassHashVersion {
+		return "", nil
+	}
+
+	// validate that the hash version for the EC2NodeClass is the same as the NodeClaim before evaluating for static drift
+	if nodeClassHashVersion != nodeClaimHashVersion {
+		return "", nil
+	}
+	return lo.Ternary(kubeletHash != nodeClaimKubeletHash, NodeClassDrift, ""), nil
 }
 
 func (c *CloudProvider) getInstance(ctx context.Context, providerID string) (*instance.Instance, error) {

--- a/pkg/controllers/nodeclass/hash/suite_test.go
+++ b/pkg/controllers/nodeclass/hash/suite_test.go
@@ -16,7 +16,13 @@ package hash_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+
+	"github.com/samber/lo"
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+
+	"github.com/aws/karpenter-provider-aws/pkg/utils"
 
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 
@@ -75,6 +81,7 @@ var _ = AfterEach(func() {
 
 var _ = Describe("NodeClass Hash Controller", func() {
 	var nodeClass *v1.EC2NodeClass
+	var nodePool *karpv1.NodePool
 	BeforeEach(func() {
 		nodeClass = test.EC2NodeClass(v1.EC2NodeClass{
 			Spec: v1.EC2NodeClassSpec{
@@ -91,6 +98,19 @@ var _ = Describe("NodeClass Hash Controller", func() {
 				AMISelectorTerms: []v1.AMISelectorTerm{
 					{
 						Tags: map[string]string{"*": "*"},
+					},
+				},
+			},
+		})
+		nodePool = coretest.NodePool(karpv1.NodePool{
+			Spec: karpv1.NodePoolSpec{
+				Template: karpv1.NodeClaimTemplate{
+					Spec: karpv1.NodeClaimSpec{
+						NodeClassRef: &karpv1.NodeClassReference{
+							Group: object.GVK(nodeClass).Group,
+							Kind:  object.GVK(nodeClass).Kind,
+							Name:  nodeClass.Name,
+						},
 					},
 				},
 			},
@@ -123,6 +143,113 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		Entry("MetadataOptions Drift", &v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPEndpoint: aws.String("disabled")}}}),
 		Entry("Context Drift", &v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{Context: aws.String("context-2")}}),
 	)
+	It("should update nodeClaim annotation kubelet hash if nodePool was configured using v1beta1 NodePool", func() {
+		kubeletConfig := &v1beta1.KubeletConfiguration{
+			ClusterDNS:  []string{"test-cluster-dns"},
+			MaxPods:     lo.ToPtr(int32(9383)),
+			PodsPerCore: lo.ToPtr(int32(9334283)),
+		}
+		kubeletConfigString, _ := json.Marshal(kubeletConfig)
+		nodePool.Annotations = lo.Assign(nodePool.Annotations, map[string]string{
+			karpv1.KubeletCompatabilityAnnotationKey: string(kubeletConfigString),
+		})
+		nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
+				Annotations: map[string]string{
+					v1.AnnotationEC2NodeClassHash:         "123456",
+					v1.AnnotationEC2NodeClassHashVersion:  "test",
+					v1.AnnotationKubeletCompatibilityHash: "123456",
+				},
+			},
+			Spec: karpv1.NodeClaimSpec{
+				NodeClassRef: &karpv1.NodeClassReference{
+					Group: object.GVK(nodeClass).Group,
+					Kind:  object.GVK(nodeClass).Kind,
+					Name:  nodeClass.Name,
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim, nodePool)
+		expectedHash, _ := utils.GetHashKubelet(nodePool, nodeClass)
+
+		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]).To(Equal(expectedHash))
+	})
+	It("should update nodeClaim annotation kubelet hash when kubelet is configured using ec2nodeClass", func() {
+		nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
+				Annotations: map[string]string{
+					v1.AnnotationEC2NodeClassHash:         "123456",
+					v1.AnnotationEC2NodeClassHashVersion:  "test",
+					v1.AnnotationKubeletCompatibilityHash: "123456",
+				},
+			},
+			Spec: karpv1.NodeClaimSpec{
+				NodeClassRef: &karpv1.NodeClassReference{
+					Group: object.GVK(nodeClass).Group,
+					Kind:  object.GVK(nodeClass).Kind,
+					Name:  nodeClass.Name,
+				},
+			},
+		})
+		nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
+			ClusterDNS:  []string{"test-cluster-dns"},
+			MaxPods:     lo.ToPtr(int32(9383)),
+			PodsPerCore: lo.ToPtr(int32(9334283)),
+		}
+		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim, nodePool)
+		expectedHash, _ := utils.GetHashKubelet(nodePool, nodeClass)
+
+		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]).To(Equal(expectedHash))
+	})
+	It("should not update nodeClaim annotation kubelet hash if annotation is same as kubelet configuration on nodeClass", func() {
+		kubeletConfig := &v1beta1.KubeletConfiguration{
+			ClusterDNS:  []string{"test-cluster-dns"},
+			MaxPods:     lo.ToPtr(int32(9383)),
+			PodsPerCore: lo.ToPtr(int32(9334283)),
+		}
+		kubeletConfigString, _ := json.Marshal(kubeletConfig)
+		nodePool.Annotations = lo.Assign(nodePool.Annotations, map[string]string{
+			karpv1.KubeletCompatabilityAnnotationKey: string(kubeletConfigString),
+		})
+		nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
+				Annotations: map[string]string{
+					v1.AnnotationEC2NodeClassHash:        "123456",
+					v1.AnnotationEC2NodeClassHashVersion: "test",
+				},
+			},
+			Spec: karpv1.NodeClaimSpec{
+				NodeClassRef: &karpv1.NodeClassReference{
+					Group: object.GVK(nodeClass).Group,
+					Kind:  object.GVK(nodeClass).Kind,
+					Name:  nodeClass.Name,
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim, nodePool)
+
+		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		hashBefore := nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]
+
+		nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
+			ClusterDNS:  []string{"test-cluster-dns"},
+			MaxPods:     lo.ToPtr(int32(9383)),
+			PodsPerCore: lo.ToPtr(int32(9334283)),
+		}
+		nodePool.Annotations = nil
+		ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]).To(Equal(hashBefore))
+	})
 	It("should not update the drift hash when dynamic field is updated", func() {
 		ExpectApplied(ctx, env.Client, nodeClass)
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
@@ -174,6 +301,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		}
 		nodeClaimOne := coretest.NodeClaim(karpv1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
 				Annotations: map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "123456",
 					v1.AnnotationEC2NodeClassHashVersion: "test",
@@ -189,6 +317,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		})
 		nodeClaimTwo := coretest.NodeClaim(karpv1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
 				Annotations: map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "123456",
 					v1.AnnotationEC2NodeClassHashVersion: "test",
@@ -203,7 +332,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 			},
 		})
 
-		ExpectApplied(ctx, env.Client, nodeClass, nodeClaimOne, nodeClaimTwo)
+		ExpectApplied(ctx, env.Client, nodeClass, nodeClaimOne, nodeClaimTwo, nodePool)
 
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
@@ -224,6 +353,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		}
 		nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
 				Annotations: map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "1234564654",
 					v1.AnnotationEC2NodeClassHashVersion: v1.EC2NodeClassHashVersion,
@@ -237,7 +367,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 				},
 			},
 		})
-		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim)
+		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim, nodePool)
 
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
@@ -259,6 +389,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		}
 		nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
 				Annotations: map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "123456",
 					v1.AnnotationEC2NodeClassHashVersion: "test",
@@ -273,7 +404,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 			},
 		})
 		nodeClaim.StatusConditions().SetTrue(karpv1.ConditionTypeDrifted)
-		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim)
+		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim, nodePool)
 
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)

--- a/test/suites/integration/ec2nodeclass_kubelet_test.go
+++ b/test/suites/integration/ec2nodeclass_kubelet_test.go
@@ -1,0 +1,145 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/awslabs/operatorpkg/object"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-provider-aws/pkg/test"
+
+	"github.com/Pallinder/go-randomdata"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	karpv1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+)
+
+var _ = Describe("EC2nodeClass Kubelet Configuration", func() {
+	var betaNodePool *karpv1beta1.NodePool
+	var betaNodeClass *v1beta1.EC2NodeClass
+	BeforeEach(func() {
+		betaNodeClass = test.BetaEC2NodeClass(v1beta1.EC2NodeClass{
+			Spec: v1beta1.EC2NodeClassSpec{
+				AMIFamily: lo.ToPtr(v1beta1.AMIFamilyAL2023),
+				Role:      fmt.Sprintf("KarpenterNodeRole-%s", env.ClusterName),
+				Tags: map[string]string{
+					"testing/cluster": env.ClusterName,
+				},
+				SecurityGroupSelectorTerms: []v1beta1.SecurityGroupSelectorTerm{
+					{
+						Tags: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+					},
+				},
+				SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
+					{
+						Tags: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+					},
+				},
+			},
+		})
+		betaNodePool = &karpv1beta1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			Spec: karpv1beta1.NodePoolSpec{
+				Template: karpv1beta1.NodeClaimTemplate{
+					Spec: karpv1beta1.NodeClaimSpec{
+						NodeClassRef: &karpv1beta1.NodeClassReference{
+							APIVersion: object.GVK(betaNodeClass).GroupVersion().String(),
+							Kind:       object.GVK(betaNodeClass).Kind,
+							Name:       betaNodeClass.Name,
+						},
+						Requirements: []karpv1beta1.NodeSelectorRequirementWithMinValues{
+							{
+								NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+									Key:      karpv1beta1.CapacityTypeLabelKey,
+									Operator: corev1.NodeSelectorOpExists,
+								},
+							},
+						},
+						Kubelet: &karpv1beta1.KubeletConfiguration{MaxPods: lo.ToPtr[int32](20)},
+					},
+				},
+			},
+		}
+	})
+	It("should expect v1beta1 nodePool to have kubelet compatibility annotation", func() {
+		env.ExpectCreated(betaNodeClass, betaNodePool)
+		Eventually(func(g Gomega) {
+			np := &karpv1.NodePool{}
+			expectExists(betaNodePool, np)
+
+			hash, found := np.Annotations[karpv1.KubeletCompatabilityAnnotationKey]
+			g.Expect(found).To(BeTrue())
+			g.Expect(hash).To(Equal(np.Hash()))
+		})
+	})
+	It("should expect nodeClaim to not drift when kubelet configuration on v1 nodeClass is same as v1beta1 nodePool", func() {
+		pod := coretest.Pod()
+		env.ExpectCreated(pod, betaNodeClass, betaNodePool)
+		env.EventuallyExpectHealthy(pod)
+		nodeClaim := env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
+		_, found := nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]
+		Expect(found).To(BeTrue())
+
+		np := &karpv1.NodePool{}
+		expectExists(betaNodePool, np)
+		nc := &v1.EC2NodeClass{}
+		expectExists(betaNodeClass, nc)
+
+		delete(np.Annotations, karpv1.KubeletCompatabilityAnnotationKey)
+		nc.Spec.Kubelet = &v1.KubeletConfiguration{MaxPods: lo.ToPtr[int32](20)}
+		env.ExpectUpdated(np, nc)
+
+		Eventually(func(g Gomega) {
+			g.Expect(nodeClaim.StatusConditions().Get(karpv1.ConditionTypeDrifted).IsUnknown()).To(BeTrue())
+		}).Should(Succeed())
+	})
+	It("should expect nodeClaim to drift when kubelet configuration on v1 nodeClass is different from v1beta1 nodePool", func() {
+		pod := coretest.Pod()
+		env.ExpectCreated(pod, betaNodeClass, betaNodePool)
+		env.EventuallyExpectHealthy(pod)
+		nodeClaim := env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
+		_, found := nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]
+		Expect(found).To(BeTrue())
+
+		np := &karpv1.NodePool{}
+		expectExists(betaNodePool, np)
+		nc := &v1.EC2NodeClass{}
+		expectExists(betaNodeClass, nc)
+
+		delete(np.Annotations, karpv1.KubeletCompatabilityAnnotationKey)
+		nc.Spec.Kubelet = &v1.KubeletConfiguration{MaxPods: lo.ToPtr[int32](10)}
+		env.ExpectUpdated(np, nc)
+		env.EventuallyExpectDrifted(nodeClaim)
+	})
+})
+
+func expectExists(v1beta1object client.Object, v1object client.Object) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(v1beta1object), v1object)).To(Succeed())
+	}).WithTimeout(time.Second * 5).Should(Succeed())
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Added change to update nodeClaim hash when kubelet configuration on ec2nodeclass changes. This change has been added to orchestrate the conversion from v1beta1 to v1 apis specifically for the case where we have moved kubelet configuration from nodePool to nodeClass. We don't want to drift the nodeClaim if kubelet config is moved from nodePool to nodeClass if it's unchanged.

**How was this change tested?**
Added functional tests for this change.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.