### PR TITLE
fix: ami family conversion

### DIFF
--- a/pkg/apis/v1/ec2nodeclass_conversion_test.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion_test.go
@@ -365,10 +365,20 @@ var _ = Describe("Convert v1beta1 to v1 EC2NodeClass API", func() {
 			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).To(Succeed())
 			Expect(v1ec2nodeclass.Spec.AMISelectorTerms).To(ContainElement(AMISelectorTerm{Alias: "al2023@latest"}))
 		})
-		It("should convert v1beta1 ec2nodeclass ami family (ubuntu compat)", func() {
-			v1beta1ec2nodeclass.Spec.AMIFamily = &v1beta1.AMIFamilyUbuntu
+		It("should convert v1beta1 ec2nodeclass ami family with non-custom ami family and ami selector terms", func() {
+			v1beta1ec2nodeclass.Spec.AMIFamily = &v1beta1.AMIFamilyAL2023
+			v1beta1ec2nodeclass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{{
+				ID: "ami-0123456789abcdef",
+			}}
 			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).To(Succeed())
-			Expect(v1ec2nodeclass.Annotations).To(HaveKeyWithValue(AnnotationAMIFamilyCompatibility, "Ubuntu"))
+			Expect(v1ec2nodeclass.Annotations).To(HaveKeyWithValue(AnnotationAMIFamilyCompatibility, AMIFamilyAL2023))
+			Expect(v1ec2nodeclass.Spec.AMISelectorTerms).To(Equal([]AMISelectorTerm{{
+				ID: "ami-0123456789abcdef",
+			}}))
+		})
+		It("should fail to convert v1beta1 ec2nodeclass when ami family is Ubuntu", func() {
+			v1beta1ec2nodeclass.Spec.AMIFamily = &v1beta1.AMIFamilyUbuntu
+			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).ToNot(Succeed())
 		})
 		It("should convert v1beta1 ec2nodeclass user data", func() {
 			v1beta1ec2nodeclass.Spec.UserData = lo.ToPtr("test user data")


### PR DESCRIPTION
Fixes the following issues with AMI conversion:
- Fail closed when the AMI family we're convering from is Ubuntu
- Don't create an alias when the AMI family is non-custom but selector terms are specified

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR fixes two issues with the conversion webhooks for AMI family and selector terms:
- Fail closed when the AMI family is Ubuntu
- Don't create an alias when the AMI family is non-custom but AMISelectorTerms are defined

**How was this change tested?**
`make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.