### PR TITLE
chore: fix nodeClaim tests failure

### DIFF
--- a/pkg/controllers/nodeclass/hash/suite_test.go
+++ b/pkg/controllers/nodeclass/hash/suite_test.go
@@ -412,4 +412,32 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1.AnnotationEC2NodeClassHash, "123456"))
 		Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1.AnnotationEC2NodeClassHashVersion, v1.EC2NodeClassHashVersion))
 	})
+	It("should update nodeClaim annotation kubelet hash when using a standalone nodeClaim", func() {
+		nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1.AnnotationEC2NodeClassHash:        "123456",
+					v1.AnnotationEC2NodeClassHashVersion: "test",
+				},
+			},
+			Spec: karpv1.NodeClaimSpec{
+				NodeClassRef: &karpv1.NodeClassReference{
+					Group: object.GVK(nodeClass).Group,
+					Kind:  object.GVK(nodeClass).Kind,
+					Name:  nodeClass.Name,
+				},
+			},
+		})
+		nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
+			ClusterDNS:  []string{"test-cluster-dns"},
+			MaxPods:     lo.ToPtr(int32(9383)),
+			PodsPerCore: lo.ToPtr(int32(9334283)),
+		}
+		ExpectApplied(ctx, env.Client, nodeClass, nodeClaim, nodePool)
+		expectedHash, _ := utils.GetHashKubelet(nil, nodeClass)
+
+		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.Annotations[v1.AnnotationKubeletCompatibilityHash]).To(Equal(expectedHash))
+	})
 })

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -97,8 +97,10 @@ func WithDefaultFloat64(key string, def float64) float64 {
 // 1.) v1 NodePool kubelet annotation (Showing a user configured using v1beta1 NodePool at some point)
 // 2.) v1 EC2NodeClass will be used (showing a user configured using v1 EC2NodeClass)
 func GetKubletConfigurationWithNodePool(nodePool *karpv1.NodePool, nodeClass *v1.EC2NodeClass) (*v1.KubeletConfiguration, error) {
-	if annotation, ok := nodePool.Annotations[karpv1.KubeletCompatibilityAnnotationKey]; ok {
-		return parseKubeletConfiguration(annotation)
+	if nodePool != nil {
+		if annotation, ok := nodePool.Annotations[karpv1.KubeletCompatibilityAnnotationKey]; ok {
+			return parseKubeletConfiguration(annotation)
+		}
 	}
 	return nodeClass.Spec.Kubelet, nil
 }
@@ -152,5 +154,6 @@ func ResolveNodePoolFromNodeClaim(ctx context.Context, kubeClient client.Client,
 		}
 		return nodePool, nil
 	}
-	return nil, fmt.Errorf("label %s not found on nodeClaim", karpv1.NodePoolLabelKey)
+	// There will be no nodePool referenced inside the nodeClaim in case of standalone nodeClaims
+	return nil, nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
NodeClaim tests are failing because the standalone nodeClaims do not reference any nodePool. While adding the kubelet compatibility hash if this reference is empty, we should not throw an error and rather fall back to nodeClass kubelet config.

**How was this change tested?**
Tested on local cluster.`make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.