### PR TITLE
tests: fix expiration test failing due to drift when we modify expireAfter

### DIFF
--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -67,7 +67,6 @@ var _ = Describe("Expiration", func() {
 	var numPods int
 	BeforeEach(func() {
 		numPods = 1
-		// Add pods with a do-not-disrupt annotation so that we can check node metadata before we disrupt
 		dep = coretest.Deployment(coretest.DeploymentOptions{
 			Replicas: int32(numPods),
 			PodOptions: coretest.PodOptions{
@@ -82,16 +81,13 @@ var _ = Describe("Expiration", func() {
 		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 	})
 	It("should expire the node after the expiration is reached", func() {
+		nodePool.Spec.Template.Spec.ExpireAfter = karpv1.NillableDuration{Duration: lo.ToPtr(time.Minute * 2)}
 		env.ExpectCreated(nodeClass, nodePool, dep)
 
 		nodeClaim := env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
 		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
 		env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
-
-		// Set the expireAfter value to get the node deleted
-		nodePool.Spec.Template.Spec.ExpireAfter = karpv1.NillableDuration{Duration: lo.ToPtr(time.Second * 15)}
-		env.ExpectUpdated(nodePool)
 
 		// Eventually the node will be tainted, which means its actively being disrupted
 		Eventually(func(g Gomega) {
@@ -102,10 +98,9 @@ var _ = Describe("Expiration", func() {
 			g.Expect(ok).To(BeTrue())
 		}).Should(Succeed())
 
-		// Set the expireAfter to "Never" to make sure new node isn't deleted
-		// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
-		// racing at the end of the E2E test, leaking node resources into subsequent tests
-		nodePool.Spec.Template.Spec.ExpireAfter.Duration = nil
+		// Set the limit to 0 to make sure we don't continue to create nodeClaims.
+		// This is CRITICAL since it prevents leaking node resources into subsequent tests
+		nodePool.Spec.Limits = nil
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained
@@ -117,6 +112,9 @@ var _ = Describe("Expiration", func() {
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
 	})
 	It("should replace expired node with a single node and schedule all pods", func() {
+		// Set expire after to 5 minutes since we have to respect PDB and move over pods one at a time from one node to another.
+		// The new nodes should not expire before all the pods are moved over.
+		nodePool.Spec.Template.Spec.ExpireAfter = karpv1.NillableDuration{Duration: lo.ToPtr(time.Minute * 5)}
 		var numPods int32 = 5
 		// We should setup a PDB that will only allow a minimum of 1 pod to be pending at a time
 		minAvailable := intstr.FromInt32(numPods - 1)
@@ -135,10 +133,6 @@ var _ = Describe("Expiration", func() {
 		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
 		env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
 
-		// Set the expireAfter value to get the node deleted
-		nodePool.Spec.Template.Spec.ExpireAfter.Duration = lo.ToPtr(time.Second * 15)
-		env.ExpectUpdated(nodePool)
-
 		// Eventually the node will be tainted, which means its actively being disrupted
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).Should(Succeed())
@@ -148,10 +142,9 @@ var _ = Describe("Expiration", func() {
 			g.Expect(ok).To(BeTrue())
 		}).Should(Succeed())
 
-		// Set the expireAfter to "Never" to make sure new node isn't deleted
-		// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
-		// racing at the end of the E2E test, leaking node resources into subsequent tests
-		nodePool.Spec.Template.Spec.ExpireAfter.Duration = nil
+		// Set the limit to 0 to make sure we don't continue to create nodeClaims.
+		// This is CRITICAL since it prevents leaking node resources into subsequent tests
+		nodePool.Spec.Limits = nil
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
ExpireAfter has been now moved to nodeClaim. With this change, if we modify expireAfter, nodeClaim will drift causing test failures. Updated the tests to have expireAfter set to a lower value at the beginning of the test.

**How was this change tested?**
Tested on local cluster

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.