### PR TITLE
feat: Support empty block device mappings

### DIFF
--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -106,7 +106,7 @@ type EC2NodeClassSpec struct {
 	// +kubebuilder:validation:XValidation:message="must have only one blockDeviceMappings with rootVolume",rule="self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1"
 	// +kubebuilder:validation:MaxItems:=50
 	// +optional
-	BlockDeviceMappings []*BlockDeviceMapping `json:"blockDeviceMappings,omitempty"`
+	BlockDeviceMappings []*BlockDeviceMapping `json:"blockDeviceMappings"`
 	// InstanceStorePolicy specifies how to handle instance-store disks.
 	// +optional
 	InstanceStorePolicy *InstanceStorePolicy `json:"instanceStorePolicy,omitempty"`

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -246,7 +246,8 @@ func (r Resolver) resolveLaunchTemplate(nodeClass *v1.EC2NodeClass, nodeClaim *k
 		EFACount:            efaCount,
 		CapacityType:        capacityType,
 	}
-	if len(resolved.BlockDeviceMappings) == 0 {
+	// If block device mappings are nil, use the default block device mappings.
+	if resolved.BlockDeviceMappings == nil {
 		resolved.BlockDeviceMappings = amiFamily.DefaultBlockDeviceMappings()
 	}
 	if resolved.MetadataOptions == nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #6545 <!-- issue number -->

**Description**

Updates the v1 EC2NodeClass to allow for specifying a nil `.spec.blockDeviceMappings` value as a way to opt for defaulting the EBS block device mappings. Otherwise, if an empty array is assigned to the field, no block device mappings are configured and only block device mappings defined in the AMI are used.

**How was this change tested?**

I have updated the field to a pointer type and updated its assignment in various places in tests. If this is insufficient test coverage, I can add a new test targeting the intended behavior.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.