### PR TITLE
test: Add zero CPU limits to expiration

### DIFF
--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -98,9 +99,12 @@ var _ = Describe("Expiration", func() {
 			g.Expect(ok).To(BeTrue())
 		}).Should(Succeed())
 
+		env.EventuallyExpectCreatedNodeCount("==", 2)
 		// Set the limit to 0 to make sure we don't continue to create nodeClaims.
 		// This is CRITICAL since it prevents leaking node resources into subsequent tests
-		nodePool.Spec.Limits = nil
+		nodePool.Spec.Limits = karpv1.Limits{
+			corev1.ResourceCPU: resource.MustParse("0"),
+		}
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained
@@ -142,9 +146,12 @@ var _ = Describe("Expiration", func() {
 			g.Expect(ok).To(BeTrue())
 		}).Should(Succeed())
 
+		env.EventuallyExpectCreatedNodeCount("==", 2)
 		// Set the limit to 0 to make sure we don't continue to create nodeClaims.
 		// This is CRITICAL since it prevents leaking node resources into subsequent tests
-		nodePool.Spec.Limits = nil
+		nodePool.Spec.Limits = karpv1.Limits{
+			corev1.ResourceCPU: resource.MustParse("0"),
+		}
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add zero CPU limits instead removing nodepool limits 

**How was this change tested?**
- Tested Locally

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.