### PR TITLE
test: Validate that only the start-up is remaining before Drift check

### DIFF
--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -588,6 +588,7 @@ var _ = Describe("Drift", func() {
 			// Remove the startup taints from the new nodes to initialize them
 			Eventually(func(g Gomega) {
 				g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeTwo), nodeTwo)).To(Succeed())
+				g.Expect(len(nodeTwo.Spec.Taints)).To(BeNumerically("==", 1))
 				_, found := lo.Find(nodeTwo.Spec.Taints, func(t corev1.Taint) bool {
 					return t.MatchTaint(&corev1.Taint{Key: "example.com/another-taint-2", Effect: corev1.TaintEffectPreferNoSchedule})
 				})


### PR DESCRIPTION


<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Making sure that only the start-up taint is on the node before we patch the taints. This should help with having conflicting patch calls.

**How was this change tested?**
- Repeatedly tested that only start-up taint remaining before it's removed 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.