### PR TITLE
test: fix failure happening due to webhook being disabled

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -55,7 +55,6 @@ runs:
       ECR_REGION: ${{ inputs.ecr_region }}
       ACCOUNT_ID: ${{ inputs.account_id }}
       CLUSTER_NAME: ${{ inputs.cluster_name }}
-      K8S_VERSION: ${{ inputs.k8s_version }}
       PRIVATE_CLUSTER: ${{ inputs.private_cluster }}
     run: |
       ./test/hack/e2e_scripts/install_karpenter.sh

--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -1,11 +1,6 @@
 aws eks update-kubeconfig --name "$CLUSTER_NAME"
 
-# Parse minor version to determine whether to enable the webhooks
-K8S_VERSION_MINOR="${K8S_VERSION#*.}"
-WEBHOOK_ENABLED=false
-if (( K8S_VERSION_MINOR < 25 )); then
-  WEBHOOK_ENABLED=true
-fi
+WEBHOOK_ENABLED=true
 
 CHART="oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/karpenter/snapshot/karpenter"
 ADDITIONAL_FLAGS=""


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
We are seeing test failures in integration suite because webhooks are disabled while installing Karpenter on the cluster. Added a change to enable webhooks.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.