### PR TITLE
chore: reconfigure nodeclaim terminated metrics due to interruption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v0.37.1-0.20240801002441-47cc550a1adc
+	sigs.k8s.io/karpenter v0.37.1-0.20240801204017-fcbb8eab6558
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.37.1-0.20240801002441-47cc550a1adc h1:b5j3TbLx9FFEEL3A77rF+CPJySO9dbRYJQW1wabLWu0=
-sigs.k8s.io/karpenter v0.37.1-0.20240801002441-47cc550a1adc/go.mod h1:0tyrvPMzL90NMg3Jb0u2cXulPjiI7RCm60BuPUURhlg=
+sigs.k8s.io/karpenter v0.37.1-0.20240801204017-fcbb8eab6558 h1:pBIbeMg+hvk0PSqcNxpO5HArOBwxC/mNgRdNDc8Fr/U=
+sigs.k8s.io/karpenter v0.37.1-0.20240801204017-fcbb8eab6558/go.mod h1:0tyrvPMzL90NMg3Jb0u2cXulPjiI7RCm60BuPUURhlg=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/hack/docs/metrics_gen/main.go
+++ b/hack/docs/metrics_gen/main.go
@@ -43,11 +43,11 @@ type metricInfo struct {
 var (
 	stableMetrics = []string{"controller_runtime", "aws_sdk_go", "client_go", "leader_election", "interruption", "cluster_state", "workqueue", "karpenter_build_info", "karpenter_nodepool_usage", "karpenter_nodepool_limit",
 		"karpenter_nodeclaims_terminated_total", "karpenter_nodeclaims_created_total", "karpenter_nodes_terminated_total", "karpenter_nodes_created_total", "karpenter_pods_startup_duration_seconds",
-		"karpenter_provisioner_scheduling_simulation_duration_seconds", "karpenter_provisioner_scheduling_duration_seconds", "karpenter_nodepool_allowed_disruptions", "karpenter_disruption_decisions_total"}
+		"karpenter_scheduler_scheduling_duration_seconds", "karpenter_provisioner_scheduling_duration_seconds", "karpenter_nodepool_allowed_disruptions", "karpenter_voluntary_disruption_decisions_total"}
 	betaMetrics = []string{"status_condition", "cloudprovider", "cloudprovider_batcher", "karpenter_nodeclaims_termination_duration_seconds", "karpenter_nodeclaims_instance_termination_duration_seconds",
-		"karpenter_nodes_total_pod_requests", "karpenter_nodes_total_pod_limits", "karpenter_nodes_total_daemon_requests", "karpenter_nodes_total_daemon_limits", "karpenter_nodes_termination_time_seconds",
-		"karpenter_nodes_system_overhead", "karpenter_nodes_allocatable", "karpenter_pods_state", "karpenter_provisioner_scheduling_queue_depth", "karpenter_disruption_queue_failures_total",
-		"karpenter_disruption_evaluation_duration_seconds", "karpenter_disruption_eligible_nodes", "karpenter_disruption_consolidation_timeouts_total"}
+		"karpenter_nodes_total_pod_requests", "karpenter_nodes_total_pod_limits", "karpenter_nodes_total_daemon_requests", "karpenter_nodes_total_daemon_limits", "karpenter_nodes_termination_duration_seconds",
+		"karpenter_nodes_system_overhead", "karpenter_nodes_allocatable", "karpenter_pods_state", "karpenter_scheduler_queue_depth", "karpenter_voluntary_disruption_queue_failures_total",
+		"karpenter_voluntary_disruption_decision_evaluation_duration_seconds", "karpenter_voluntary_disruption_eligible_nodes", "karpenter_voluntary_disruption_consolidation_timeouts_total"}
 )
 
 func (i metricInfo) qualifiedName() string {
@@ -358,15 +358,15 @@ func getIdentMapping(identName string) (string, error) {
 		"metrics.NodeClaimSubsystem": "nodeclaims",
 		// TODO @joinnis: We should eventually change this subsystem to be
 		// plural so that it aligns with the other subsystems
-		"nodePoolSubsystem":         "nodepool",
-		"metrics.NodePoolSubsystem": "nodepool",
-		"interruptionSubsystem":     "interruption",
-		"deprovisioningSubsystem":   "deprovisioning",
-		"disruptionSubsystem":       "disruption",
-		"consistencySubsystem":      "consistency",
-		"batcherSubsystem":          "cloudprovider_batcher",
-		"cloudProviderSubsystem":    "cloudprovider",
-		"stateSubsystem":            "cluster_state",
+		"nodePoolSubsystem":            "nodepools",
+		"metrics.NodePoolSubsystem":    "nodepools",
+		"interruptionSubsystem":        "interruption",
+		"deprovisioningSubsystem":      "deprovisioning",
+		"voluntaryDisruptionSubsystem": "voluntary_disruption",
+		"batcherSubsystem":             "cloudprovider_batcher",
+		"cloudProviderSubsystem":       "cloudprovider",
+		"stateSubsystem":               "cluster_state",
+		"schedulerSubsystem":           "scheduler",
 	}
 	if v, ok := identMapping[identName]; ok {
 		return v, nil

--- a/pkg/controllers/interruption/messages/statechange/model.go
+++ b/pkg/controllers/interruption/messages/statechange/model.go
@@ -15,6 +15,8 @@ limitations under the License.
 package statechange
 
 import (
+	"github.com/samber/lo"
+
 	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
 )
 
@@ -35,6 +37,9 @@ func (m Message) EC2InstanceIDs() []string {
 	return []string{m.Detail.InstanceID}
 }
 
-func (Message) Kind() messages.Kind {
-	return messages.StateChangeKind
+func (m Message) Kind() messages.Kind {
+	if lo.Contains([]string{"stopping", "stopped"}, m.Detail.State) {
+		return messages.InstanceStoppedKind
+	}
+	return messages.InstanceTerminatedKind
 }

--- a/pkg/controllers/interruption/messages/types.go
+++ b/pkg/controllers/interruption/messages/types.go
@@ -35,11 +35,12 @@ type Message interface {
 type Kind string
 
 const (
-	RebalanceRecommendationKind Kind = "RebalanceRecommendationKind"
-	ScheduledChangeKind         Kind = "ScheduledChangeKind"
-	SpotInterruptionKind        Kind = "SpotInterruptionKind"
-	StateChangeKind             Kind = "StateChangeKind"
-	NoOpKind                    Kind = "NoOpKind"
+	RebalanceRecommendationKind Kind = "rebalance_recommendation"
+	ScheduledChangeKind         Kind = "scheduled_change"
+	SpotInterruptionKind        Kind = "spot_interrupted"
+	InstanceStoppedKind         Kind = "instance_stopped"
+	InstanceTerminatedKind      Kind = "instance_terminated"
+	NoOpKind                    Kind = "no_op"
 )
 
 type Metadata struct {

--- a/pkg/controllers/interruption/metrics.go
+++ b/pkg/controllers/interruption/metrics.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	interruptionSubsystem  = "interruption"
-	messageTypeLabel       = "message_type"
-	terminationReasonLabel = "interruption"
+	interruptionSubsystem = "interruption"
+	messageTypeLabel      = "message_type"
 )
 
 var (
@@ -50,7 +49,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: interruptionSubsystem,
 			Name:      "message_queue_duration_seconds",
-			Help:      "Length of time between message creation in queue and an action taken on the message by the controller.",
+			Help:      "Amount of time an interruption message is on the queue before it is processed by karpenter.",
 			Buckets:   metrics.DurationBuckets(),
 		},
 	)

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -12,20 +12,6 @@ Karpenter makes several metrics available in Prometheus format to allow monitori
 A metric with a constant '1' value labeled by version from which karpenter was built.
 - Stability Level: STABLE
 
-## Nodepool Metrics
-
-### `karpenter_nodepool_usage`
-The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
-- Stability Level: STABLE
-
-### `karpenter_nodepool_limit`
-Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
-- Stability Level: STABLE
-
-### `karpenter_nodepool_allowed_disruptions`
-The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
-- Stability Level: STABLE
-
 ## Nodeclaims Metrics
 
 ### `karpenter_nodeclaims_termination_duration_seconds`
@@ -33,31 +19,15 @@ Duration of NodeClaim termination in seconds.
 - Stability Level: BETA
 
 ### `karpenter_nodeclaims_terminated_total`
-Number of nodeclaims terminated in total by Karpenter. Labeled by reason the nodeclaim was terminated and the owning nodepool.
+Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
 - Stability Level: STABLE
-
-### `karpenter_nodeclaims_registered_total`
-Number of nodeclaims registered in total by Karpenter. Labeled by the owning nodepool.
-- Stability Level: ALPHA
-
-### `karpenter_nodeclaims_launched_total`
-Number of nodeclaims launched in total by Karpenter. Labeled by the owning nodepool.
-- Stability Level: ALPHA
 
 ### `karpenter_nodeclaims_instance_termination_duration_seconds`
 Duration of CloudProvider Instance termination in seconds.
 - Stability Level: BETA
 
-### `karpenter_nodeclaims_initialized_total`
-Number of nodeclaims initialized in total by Karpenter. Labeled by the owning nodepool.
-- Stability Level: ALPHA
-
-### `karpenter_nodeclaims_drifted_total`
-Number of nodeclaims drifted reasons in total by Karpenter. Labeled by drift type of the nodeclaim and the owning nodepool.
-- Stability Level: ALPHA
-
 ### `karpenter_nodeclaims_disrupted_total`
-Number of nodeclaims disrupted in total by Karpenter. Labeled by disruption type of the nodeclaim and the owning nodepool.
+Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
 - Stability Level: ALPHA
 
 ### `karpenter_nodeclaims_created_total`
@@ -82,7 +52,7 @@ Node total daemon requests are the resource requested by DaemonSet pods bound to
 Node total daemon limits are the resources specified by DaemonSet pod limits.
 - Stability Level: BETA
 
-### `karpenter_nodes_termination_time_seconds`
+### `karpenter_nodes_termination_duration_seconds`
 The time taken between a node's deletion request and the removal of its finalizer
 - Stability Level: BETA
 
@@ -116,19 +86,51 @@ Pod state is the current state of pods. This metric can be used several ways as 
 The time from pod creation until the pod is running.
 - Stability Level: STABLE
 
-## Provisioner Metrics
+## Voluntary Disruption Metrics
 
-### `karpenter_provisioner_scheduling_simulation_duration_seconds`
+### `karpenter_voluntary_disruption_queue_failures_total`
+The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_eligible_nodes`
+Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_decisions_total`
+Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
+Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_consolidation_timeouts_total`
+Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Stability Level: BETA
+
+## Scheduler Metrics
+
+### `karpenter_scheduler_scheduling_duration_seconds`
 Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
 - Stability Level: STABLE
 
-### `karpenter_provisioner_scheduling_queue_depth`
+### `karpenter_scheduler_queue_depth`
 The number of pods currently waiting to be scheduled.
 - Stability Level: BETA
 
-### `karpenter_provisioner_scheduling_duration_seconds`
-Duration of scheduling process in seconds.
-- Stability Level: STABLE
+## Nodepools Metrics
+
+### `karpenter_nodepools_usage`
+The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_limit`
+Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_allowed_disruptions`
+The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Stability Level: ALPHA
 
 ## Interruption Metrics
 
@@ -137,48 +139,12 @@ Count of messages received from the SQS queue. Broken down by message type and w
 - Stability Level: STABLE
 
 ### `karpenter_interruption_message_queue_duration_seconds`
-Length of time between message creation in queue and an action taken on the message by the controller.
+Amount of time an interruption message is on the queue before it is processed by karpenter.
 - Stability Level: STABLE
 
 ### `karpenter_interruption_deleted_messages_total`
 Count of messages deleted from the SQS queue.
 - Stability Level: STABLE
-
-## Disruption Metrics
-
-### `karpenter_disruption_replacement_nodeclaim_initialized_seconds`
-Amount of time required for a replacement nodeclaim to become initialized.
-- Stability Level: ALPHA
-
-### `karpenter_disruption_queue_failures_total`
-The number of times that an enqueued disruption decision failed. Labeled by disruption method.
-- Stability Level: BETA
-
-### `karpenter_disruption_pods_disrupted_total`
-Total number of reschedulable pods disrupted on nodes. Labeled by NodePool, disruption action, method, and consolidation type.
-- Stability Level: ALPHA
-
-### `karpenter_disruption_evaluation_duration_seconds`
-Duration of the disruption evaluation process in seconds. Labeled by method and consolidation type.
-- Stability Level: BETA
-
-### `karpenter_disruption_eligible_nodes`
-Number of nodes eligible for disruption by Karpenter. Labeled by disruption method and consolidation type.
-- Stability Level: BETA
-
-### `karpenter_disruption_decisions_total`
-Number of disruption decisions performed. Labeled by disruption action, method, and consolidation type.
-- Stability Level: STABLE
-
-### `karpenter_disruption_consolidation_timeouts_total`
-Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
-- Stability Level: BETA
-
-## Consistency Metrics
-
-### `karpenter_consistency_errors_total`
-Number of consistency checks that have failed.
-- Stability Level: ALPHA
 
 ## Cluster State Metrics
 
@@ -284,8 +250,16 @@ Total number of adds handled by workqueue
 
 ## Status Condition Metrics
 
+### `operator_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
 ### `operator_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
 - Stability Level: BETA
 
 ### `operator_status_condition_count`


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Reconfigured `karpenter_nodeclaims_terminated_total` to `karpenter_nodeclaims_disrupted_total` metrics in case of interruption. Label type now indicates the kind of interruption message. Updated metrics would now look like -
1. karpenter_nodeclaims_disrupted_total {type="scheduled_change"}
2. karpenter_nodeclaims_disrupted_total {type="instance_terminated"}
3. karpenter_nodeclaims_disrupted_total {type="spot_interruption"}
4. 2. karpenter_nodeclaims_disrupted_total {type="instance_stopped"}

**How was this change tested?**
`make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.