### PR TITLE
chore: Scope down the IAM permission on instance profiles for Karpenter

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -213,7 +213,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileCreationActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:CreateInstanceProfile"
               ],
@@ -230,7 +230,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileTagActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:TagInstanceProfile"
               ],
@@ -250,7 +250,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
@@ -269,7 +269,7 @@ Resources:
             {
               "Sid": "AllowInstanceProfileReadActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
             },
             {

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -383,7 +383,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileCreationActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:CreateInstanceProfile"
   ],
@@ -408,7 +408,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileTagActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:TagInstanceProfile"
   ],
@@ -438,7 +438,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This permissio
 {
   "Sid": "AllowScopedInstanceProfileActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:AddRoleToInstanceProfile",
     "iam:RemoveRoleFromInstanceProfile",
@@ -464,7 +464,7 @@ The AllowInstanceProfileActions Sid gives the Karpenter controller permission to
 {
   "Sid": "AllowInstanceProfileReadActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
 }
 ```

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -213,7 +213,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileCreationActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:CreateInstanceProfile"
               ],
@@ -230,7 +230,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileTagActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:TagInstanceProfile"
               ],
@@ -250,7 +250,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
@@ -269,7 +269,7 @@ Resources:
             {
               "Sid": "AllowInstanceProfileReadActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
             },
             {

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -383,7 +383,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileCreationActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:CreateInstanceProfile"
   ],
@@ -408,7 +408,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileTagActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:TagInstanceProfile"
   ],
@@ -438,7 +438,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This permissio
 {
   "Sid": "AllowScopedInstanceProfileActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:AddRoleToInstanceProfile",
     "iam:RemoveRoleFromInstanceProfile",
@@ -464,7 +464,7 @@ The AllowInstanceProfileActions Sid gives the Karpenter controller permission to
 {
   "Sid": "AllowInstanceProfileReadActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
 }
 ```

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -196,7 +196,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileCreationActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:CreateInstanceProfile"
               ],
@@ -213,7 +213,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileTagActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:TagInstanceProfile"
               ],
@@ -233,7 +233,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
@@ -252,7 +252,7 @@ Resources:
             {
               "Sid": "AllowInstanceProfileReadActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
             },
             {

--- a/website/content/en/v0.32/reference/cloudformation.md
+++ b/website/content/en/v0.32/reference/cloudformation.md
@@ -357,7 +357,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileCreationActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:CreateInstanceProfile"
   ],
@@ -382,7 +382,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileTagActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:TagInstanceProfile"
   ],
@@ -412,7 +412,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This permissio
 {
   "Sid": "AllowScopedInstanceProfileActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:AddRoleToInstanceProfile",
     "iam:RemoveRoleFromInstanceProfile",
@@ -438,7 +438,7 @@ The AllowInstanceProfileActions Sid gives the Karpenter controller permission to
 {
   "Sid": "AllowInstanceProfileReadActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
 }
 ```

--- a/website/content/en/v0.35/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.35/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -213,7 +213,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileCreationActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:CreateInstanceProfile"
               ],
@@ -230,7 +230,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileTagActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:TagInstanceProfile"
               ],
@@ -250,7 +250,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
@@ -269,7 +269,7 @@ Resources:
             {
               "Sid": "AllowInstanceProfileReadActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
             },
             {

--- a/website/content/en/v0.35/reference/cloudformation.md
+++ b/website/content/en/v0.35/reference/cloudformation.md
@@ -383,7 +383,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileCreationActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:CreateInstanceProfile"
   ],
@@ -408,7 +408,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileTagActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:TagInstanceProfile"
   ],
@@ -438,7 +438,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This permissio
 {
   "Sid": "AllowScopedInstanceProfileActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:AddRoleToInstanceProfile",
     "iam:RemoveRoleFromInstanceProfile",
@@ -464,7 +464,7 @@ The AllowInstanceProfileActions Sid gives the Karpenter controller permission to
 {
   "Sid": "AllowInstanceProfileReadActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:aws:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
 }
 ```

--- a/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -213,7 +213,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileCreationActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:CreateInstanceProfile"
               ],
@@ -230,7 +230,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileTagActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:TagInstanceProfile"
               ],
@@ -250,7 +250,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
@@ -269,7 +269,7 @@ Resources:
             {
               "Sid": "AllowInstanceProfileReadActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
             },
             {

--- a/website/content/en/v0.36/reference/cloudformation.md
+++ b/website/content/en/v0.36/reference/cloudformation.md
@@ -383,7 +383,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileCreationActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:CreateInstanceProfile"
   ],
@@ -408,7 +408,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileTagActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:TagInstanceProfile"
   ],
@@ -438,7 +438,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This permissio
 {
   "Sid": "AllowScopedInstanceProfileActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:AddRoleToInstanceProfile",
     "iam:RemoveRoleFromInstanceProfile",
@@ -464,7 +464,7 @@ The AllowInstanceProfileActions Sid gives the Karpenter controller permission to
 {
   "Sid": "AllowInstanceProfileReadActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
 }
 ```

--- a/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -213,7 +213,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileCreationActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:CreateInstanceProfile"
               ],
@@ -230,7 +230,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileTagActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:TagInstanceProfile"
               ],
@@ -250,7 +250,7 @@ Resources:
             {
               "Sid": "AllowScopedInstanceProfileActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": [
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
@@ -269,7 +269,7 @@ Resources:
             {
               "Sid": "AllowInstanceProfileReadActions",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
             },
             {

--- a/website/content/en/v0.37/reference/cloudformation.md
+++ b/website/content/en/v0.37/reference/cloudformation.md
@@ -383,7 +383,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileCreationActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:CreateInstanceProfile"
   ],
@@ -408,7 +408,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 {
   "Sid": "AllowScopedInstanceProfileTagActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:TagInstanceProfile"
   ],
@@ -438,7 +438,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This permissio
 {
   "Sid": "AllowScopedInstanceProfileActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": [
     "iam:AddRoleToInstanceProfile",
     "iam:RemoveRoleFromInstanceProfile",
@@ -464,7 +464,7 @@ The AllowInstanceProfileActions Sid gives the Karpenter controller permission to
 {
   "Sid": "AllowInstanceProfileReadActions",
   "Effect": "Allow",
-  "Resource": "*",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
 }
 ```


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Scoping down instance profile permission to wild card only on instance profiles

**How was this change tested?**
- Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.