### PR TITLE
test: add lastPodEventTime e2es

### DIFF
--- a/test/pkg/environment/aws/environment.go
+++ b/test/pkg/environment/aws/environment.go
@@ -143,6 +143,8 @@ func GetTimeStreamAPI(session *session.Session) timestreamwriteiface.TimestreamW
 
 func (env *Environment) DefaultEC2NodeClass() *v1.EC2NodeClass {
 	nodeClass := test.EC2NodeClass()
+	// Set the AMI Family to AL2023 in case the AMISelectorTerms change.
+	nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
 	nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
 	nodeClass.Spec.Tags = map[string]string{
 		"testing/cluster": env.ClusterName,

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -66,7 +66,7 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() { env.Cleanup() })
 var _ = AfterEach(func() { env.AfterEach() })
 
-var _ = FDescribe("Consolidation", func() {
+var _ = Describe("Consolidation", func() {
 	Context("LastPodEventTime", func() {
 		var nodePool *karpv1.NodePool
 		BeforeEach(func() {
@@ -131,9 +131,8 @@ var _ = FDescribe("Consolidation", func() {
 			podLabels := map[string]string{"app": "regular-app"}
 			pod := test.Pod(test.PodOptions{
 				// use a non-pause image so that we can have a sleep
-				Image:        "alpine:3.20.2",
-				Command:      []string{"/bin/sh", "-c", "sleep 30"},
-				PreStopSleep: lo.ToPtr(int64(30)),
+				Image:   "alpine:3.20.2",
+				Command: []string{"/bin/sh", "-c", "sleep 30"},
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: podLabels,
 				},

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -165,9 +165,11 @@ var _ = Describe("Consolidation", func() {
 			env.EventuallyExpectCreatedNodeCount("==", 1)
 			pods := env.EventuallyExpectHealthyPodCount(selector, int(1))
 
+			// pods are healthy, which means the job has started its 30s sleep
 			nodeClaim := env.ExpectExists(nodeClaims[0]).(*karpv1.NodeClaim)
 			lastPodEventTime := nodeClaim.Status.LastPodEventTime
 
+			// wait a minute for the pod's sleep to finish, and for the nodeclaim to update
 			Eventually(func(g Gomega) {
 				pod := env.ExpectExists(pods[0]).(*corev1.Pod)
 				g.Expect(pod.Status.Phase).To(Equal(corev1.PodSucceeded))

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -370,7 +370,7 @@ var _ = Describe("Drift", func() {
 		})
 	})
 	It("should disrupt nodes that have drifted due to AMIs", func() {
-		oldCustomAMI := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersionWithOffset(1))
+		oldCustomAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersionWithOffset(1)))
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{ID: oldCustomAMI}}
 
 		env.ExpectCreated(dep, nodeClass, nodePool)
@@ -391,7 +391,6 @@ var _ = Describe("Drift", func() {
 	})
 	It("should return drifted if the AMI no longer matches the existing NodeClaims instance type", func() {
 		armAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id", env.K8sVersion()))
-		nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{ID: armAMI}}
 
 		env.ExpectCreated(dep, nodeClass, nodePool)
@@ -413,7 +412,7 @@ var _ = Describe("Drift", func() {
 	It("should not disrupt nodes that have drifted without the featureGate enabled", func() {
 		env.ExpectSettingsOverridden(corev1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=false"})
 
-		oldCustomAMI := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersionWithOffset(1))
+		oldCustomAMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersionWithOffset(1)))
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{ID: oldCustomAMI}}
 
 		env.ExpectCreated(dep, nodeClass, nodePool)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds e2e tests to verify that lastPodEvent is set at the correct times

**How was this change tested?**
FOCUS="LastPodEventTime" make e2etests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.