### PR TITLE
chore: Update so NodeClassNotReady is returned when NodeClass is failing

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -587,19 +587,6 @@ spec:
                               Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
                             pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
                             type: string
-                          reasons:
-                            description: |-
-                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
-                              Otherwise, this will apply to each reason defined.
-                              allowed reasons are Underutilized, Empty, and Drifted.
-                            items:
-                              description: DisruptionReason defines valid reasons for disruption budgets.
-                              enum:
-                                - Underutilized
-                                - Empty
-                                - Drifted
-                              type: string
-                            type: array
                           schedule:
                             description: |-
                               Schedule specifies when a budget begins being active, following

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v0.37.1-0.20240802193020-c4607677888c
+	sigs.k8s.io/karpenter v0.37.1-0.20240802212156-fdb3813913a0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.37.1-0.20240802193020-c4607677888c h1:756WIgC9T0bNw1FT8kSpgxh/ghocymrYNbV9FG+lLyI=
-sigs.k8s.io/karpenter v0.37.1-0.20240802193020-c4607677888c/go.mod h1:ue5E/FLsbpgHQK8q0l3dfJjRK0iiZ017JloLnj94dZM=
+sigs.k8s.io/karpenter v0.37.1-0.20240802212156-fdb3813913a0 h1:RoNC5GgusOjuwiYznX2OJrzK8SuwFMwUjh9PxeBTaPM=
+sigs.k8s.io/karpenter v0.37.1-0.20240802212156-fdb3813913a0/go.mod h1:ue5E/FLsbpgHQK8q0l3dfJjRK0iiZ017JloLnj94dZM=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -587,19 +587,6 @@ spec:
                               Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
                             pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
                             type: string
-                          reasons:
-                            description: |-
-                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
-                              Otherwise, this will apply to each reason defined.
-                              allowed reasons are Underutilized, Empty, and Drifted.
-                            items:
-                              description: DisruptionReason defines valid reasons for disruption budgets.
-                              enum:
-                                - Underutilized
-                                - Empty
-                                - Drifted
-                              type: string
-                            type: array
                           schedule:
                             description: |-
                               Schedule specifies when a budget begins being active, following

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -97,10 +97,10 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 		return nil, err
 	}
 	nodeClassReady := nodeClass.StatusConditions().Get(status.ConditionReady)
-	if !nodeClassReady.IsTrue() {
-		if nodeClassReady.IsFalse() {
-			return nil, cloudprovider.NewNodeClassNotReadyError(fmt.Errorf(nodeClassReady.Message))
-		}
+	if nodeClassReady.IsFalse() {
+		return nil, cloudprovider.NewNodeClassNotReadyError(fmt.Errorf(nodeClassReady.Message))
+	}
+	if nodeClassReady.IsUnknown() {
 		return nil, fmt.Errorf("resolving NodeClass readiness, NodeClass is in Ready=Unknown, %s", nodeClassReady.Message)
 	}
 	instanceTypes, err := c.resolveInstanceTypes(ctx, nodeClaim, nodeClass)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -98,7 +98,10 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 	}
 	nodeClassReady := nodeClass.StatusConditions().Get(status.ConditionReady)
 	if !nodeClassReady.IsTrue() {
-		return nil, fmt.Errorf("resolving ec2nodeclass, %s", nodeClassReady.Message)
+		if nodeClassReady.IsFalse() {
+			return nil, cloudprovider.NewNodeClassNotReadyError(fmt.Errorf(nodeClassReady.Message))
+		}
+		return nil, fmt.Errorf("resolving NodeClass readiness, NodeClass is in Ready=Unknown, %s", nodeClassReady.Message)
 	}
 	instanceTypes, err := c.resolveInstanceTypes(ctx, nodeClaim, nodeClass)
 	if err != nil {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -299,8 +299,9 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			Expect(*launchTemplate.LaunchTemplateSpecification.Version).To(Equal("$Latest"))
 		})
 	})
-	It("should fail to provision if the instance profile isn't defined", func() {
+	It("should fail to provision if the instance profile isn't ready", func() {
 		nodeClass.Status.InstanceProfile = ""
+		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeInstanceProfileReady, "reason", "message")
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 		pod := coretest.UnschedulablePod()
 		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
@@ -309,6 +310,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 	It("should use the instance profile on the EC2NodeClass when specified", func() {
 		nodeClass.Spec.Role = ""
 		nodeClass.Spec.InstanceProfile = aws.String("overridden-profile")
+		nodeClass.Status.InstanceProfile = "overridden-profile"
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 		pod := coretest.UnschedulablePod()
 		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates our code so that we intentionally delete a NodeClaim when we know that the NodeClass is in a False state. This ensures that we retry the NodeClaim as quickly as possible by rescheduling it to another NodePool that has a NodeClaim that is ready.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.