### PR TITLE
chore: Include post upgrade on Helm Hook

### DIFF
--- a/charts/karpenter/templates/post-install-hook.yaml
+++ b/charts/karpenter/templates/post-install-hook.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-delete-policy": hook-failed
     {{- with .Values.additionalAnnotations }}
@@ -30,9 +30,9 @@ spec:
         - -c
         - |
           if  "{{ .Values.webhook.enabled }}" == "true"; then 
-            kubectl patch customresourcedefinitions nodepools.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"webhook":{"clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
-            kubectl patch customresourcedefinitions nodeclaims.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"webhook":{"clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
-            kubectl patch customresourcedefinitions ec2nodeclasses.karpenter.k8s.aws  --type='merge' -p '{"spec":{"conversion":{"webhook":{"clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
+            kubectl patch customresourcedefinitions nodepools.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
+            kubectl patch customresourcedefinitions nodeclaims.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
+            kubectl patch customresourcedefinitions ec2nodeclasses.karpenter.k8s.aws  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
           else
             echo "disabled webhooks"
             kubectl patch customresourcedefinitions nodepools.karpenter.sh  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Support upgrade and rollback with Karpenter with the helm chart for the CRDs
- Updated the image to use `public.ecr.aws/bitnami/kubectl:1.30`

**How was this change tested?**
- Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.