### PR TITLE
feat: add option to keep the crds with an uninstall

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+{{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+{{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+{{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter-crd/values.yaml
+++ b/charts/karpenter-crd/values.yaml
@@ -1,3 +1,7 @@
+crds:
+  # Set to true will add the "helm.sh/resource-policy": keep annotation to the CRDs.
+  # This will prevent Helm from uninstalling the CRDs.
+  keep: true
 webhook:
   # -- Whether to enable the webhooks and webhook permissions.
   enabled: true

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -96,6 +96,10 @@ extraVolumes: []
 #         audience: sts.amazonaws.com
 #         expirationSeconds: 86400
 #         path: token
+crds:
+  # Set to true will add the "helm.sh/resource-policy": keep annotation to the CRDs.
+  # This will prevent Helm from uninstalling the CRDs.
+  keep: true
 controller:
   image:
     # -- Repository path to the controller image.


### PR DESCRIPTION
Fixes #6649 

**Description**
add option to set the `helm.sh/resource-policy: keep` to the crds so it prevents deletion of those crds with an uninstall or redeployment of karpenter
to prevent node disruptions on a redeploy or removal of the karpenter crds

deleted ec2nodeclass crd > deleted nodepool > node disruptions
 
**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.