### PR TITLE
chore: enforce Windows version via CEL

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -95,6 +95,8 @@ spec:
                             rule: self.matches('^[a-zA-Z0-9]*@.*$')
                           - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
                             rule: self.find('^[^@]+') in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.find(''^[^@]+'') in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'': true'
                       id:
                         description: ID is the ami id in EC2
                         pattern: ami-[0-9a-z]+

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -92,11 +92,11 @@ spec:
                         type: string
                         x-kubernetes-validations:
                           - message: '''alias'' is improperly formatted, must match the format ''family@version'''
-                            rule: self.matches('^[a-zA-Z0-9]*@.*$')
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
                           - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
-                            rule: self.find('^[^@]+') in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
                           - message: windows families may only specify version 'latest'
-                            rule: 'self.find(''^[^@]+'') in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'': true'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
                       id:
                         description: ID is the ami id in EC2
                         pattern: ami-[0-9a-z]+

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -95,6 +95,8 @@ spec:
                             rule: self.matches('^[a-zA-Z0-9]*@.*$')
                           - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
                             rule: self.find('^[^@]+') in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.find(''^[^@]+'') in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'': true'
                       id:
                         description: ID is the ami id in EC2
                         pattern: ami-[0-9a-z]+

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -92,11 +92,11 @@ spec:
                         type: string
                         x-kubernetes-validations:
                           - message: '''alias'' is improperly formatted, must match the format ''family@version'''
-                            rule: self.matches('^[a-zA-Z0-9]*@.*$')
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
                           - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
-                            rule: self.find('^[^@]+') in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
                           - message: windows families may only specify version 'latest'
-                            rule: 'self.find(''^[^@]+'') in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'': true'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
                       id:
                         description: ID is the ami id in EC2
                         pattern: ami-[0-9a-z]+

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -180,6 +180,7 @@ type AMISelectorTerm struct {
 	// Note: The Windows families do **not** support version pinning, and only latest may be used.
 	// +kubebuilder:validation:XValidation:message="'alias' is improperly formatted, must match the format 'family@version'",rule="self.matches('^[a-zA-Z0-9]*@.*$')"
 	// +kubebuilder:validation:XValidation:message="family is not supported, must be one of the following: 'al2', 'al2023', 'bottlerocket', 'windows2019', 'windows2022'",rule="self.find('^[^@]+') in ['al2','al2023','bottlerocket','windows2019','windows2022']"
+	// +kubebuilder:validation:XValidation:message="windows families may only specify version 'latest'",rule="self.find('^[^@]+') in ['windows2019','windows2022'] ? self.split('@')[1] == 'latest': true"
 	// +kubebuilder:validation:MaxLength=30
 	// +optional
 	Alias string `json:"alias,omitempty"`

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -178,9 +178,9 @@ type AMISelectorTerm struct {
 	// The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
 	// The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
 	// Note: The Windows families do **not** support version pinning, and only latest may be used.
-	// +kubebuilder:validation:XValidation:message="'alias' is improperly formatted, must match the format 'family@version'",rule="self.matches('^[a-zA-Z0-9]*@.*$')"
-	// +kubebuilder:validation:XValidation:message="family is not supported, must be one of the following: 'al2', 'al2023', 'bottlerocket', 'windows2019', 'windows2022'",rule="self.find('^[^@]+') in ['al2','al2023','bottlerocket','windows2019','windows2022']"
-	// +kubebuilder:validation:XValidation:message="windows families may only specify version 'latest'",rule="self.find('^[^@]+') in ['windows2019','windows2022'] ? self.split('@')[1] == 'latest': true"
+	// +kubebuilder:validation:XValidation:message="'alias' is improperly formatted, must match the format 'family@version'",rule="self.matches('^[a-zA-Z0-9]+@.+$')"
+	// +kubebuilder:validation:XValidation:message="family is not supported, must be one of the following: 'al2', 'al2023', 'bottlerocket', 'windows2019', 'windows2022'",rule="self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']"
+	// +kubebuilder:validation:XValidation:message="windows families may only specify version 'latest'",rule="self.split('@')[0] in ['windows2019','windows2022'] ? self.split('@')[1] == 'latest' : true"
 	// +kubebuilder:validation:MaxLength=30
 	// +optional
 	Alias string `json:"alias,omitempty"`

--- a/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
@@ -604,6 +604,15 @@ var _ = Describe("CEL/Validation", func() {
 			nc.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "ubuntu@latest"}}
 			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
 		})
+		DescribeTable(
+			"should fail when specifying non-latest versions with Windows aliases",
+			func(alias string) {
+				nc.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
+				Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
+			},
+			Entry("Windows2019", "windows2019@v1.0.0"),
+			Entry("Windows2022", "windows2022@v1.0.0"),
+		)
 	})
 	Context("Kubelet", func() {
 		It("should fail on kubeReserved with invalid keys", func() {

--- a/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
@@ -600,6 +600,18 @@ var _ = Describe("CEL/Validation", func() {
 			Entry("windows2019 (latest)", "windows2019@latest", v1.AMIFamilyWindows2019),
 			Entry("windows2022 (latest)", "windows2022@latest", v1.AMIFamilyWindows2022),
 		)
+		DescribeTable(
+			"should fail for incorrectly formatted aliases",
+			func(aliases ...string) {
+				for _, alias := range aliases {
+					nc.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
+					Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
+				}
+			},
+			Entry("missing family", "@latest"),
+			Entry("missing version", "al2023", "al2023@"),
+			Entry("invalid separator", "al2023-latest"),
+		)
 		It("should fail for an alias with an invalid family", func() {
 			nc.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "ubuntu@latest"}}
 			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -51,11 +51,8 @@ type Windows struct {
 func (w Windows) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
 	requirements := make(map[string][]scheduling.Requirements)
 	imageIDs := make([]*string, 0, 5)
-	// SSM aliases are only maintained for the latest Windows AMI releases
-	if amiVersion != AMIVersionLatest {
-		return DescribeImageQuery{}, fmt.Errorf(`discovering AMIs for alias "windows%s@%s", %q is not a supported version`, w.Version, amiVersion, amiVersion)
-	}
 	// Example Path: /aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-1.30/image_id
+	// Note: the version must be latest, this is enforced via CEL validation
 	results, err := ssmProvider.List(ctx, "/aws/service/ami-windows-latest")
 	if err != nil {
 		return DescribeImageQuery{}, fmt.Errorf("discovering AMIs from ssm")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
When using a Windows alias, the only version that may be specified is 'latest'. This PR moves this check from runtime to validation time via a CEL check.

**How was this change tested?**
`make presubmit` and `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.