### PR TITLE
feat: add option to add custom annotations to the crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ verify: tidy download ## Verify code. Includes dependencies, linting, formatting
 	hack/validation/labels.sh
 	cp pkg/apis/crds/* charts/karpenter-crd/templates
 	hack/mutation/conversion_webhooks_injection.sh
+	hack/mutation/crd_annotations.sh
 	hack/github/dependabot.sh
 	$(foreach dir,$(MOD_DIRS),cd $(dir) && golangci-lint run $(newline))
 	@git diff --quiet ||\

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.additionalAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.15.0
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
@@ -1346,4 +1349,3 @@ spec:
           namespace: {{ .Values.webhook.serviceNamespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
-

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.additionalAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.15.0
   name: nodeclaims.karpenter.sh
 spec:
@@ -843,4 +846,3 @@ spec:
           namespace: {{ .Values.webhook.serviceNamespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
-

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.additionalAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.15.0
   name: nodepools.karpenter.sh
 spec:
@@ -1094,4 +1097,3 @@ spec:
           namespace: {{ .Values.webhook.serviceNamespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
-

--- a/charts/karpenter-crd/values.yaml
+++ b/charts/karpenter-crd/values.yaml
@@ -1,3 +1,6 @@
+# -- Additional annotations for the custom resource definitions.
+additionalAnnotations: {}
+
 webhook:
   # -- Whether to enable the webhooks and webhook permissions.
   enabled: true

--- a/hack/mutation/crd_annotations.sh
+++ b/hack/mutation/crd_annotations.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Add additional annotations variable to the CRDS
+
+CRDS="charts/karpenter-crd/templates/*.yaml"
+for CRD in $CRDS
+do
+  echo "$( awk '{print} /  annotations:/ && !n {print "    {{- with .Values.additionalAnnotations }}\n      {{- toYaml . | nindent 4 }}\n    {{- end }}"; n++}' $CRD)" > $CRD
+done


### PR DESCRIPTION
Fixes #6649 

**Description**
add an option in the value file to set custom annotations specificly to tthe custom resource definitions
so we can set in our use case the helm keep tag to ensure the crds never get deleted by an accidential uninstall

```
  annotations:
    helm.sh/resource-policy: keep
```
**How was this change tested?**
with helm template

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.