### PR TITLE
fix: Make sure EbsOptimizedInfo exists when selecting instances by EBS maximum bandwidth

### DIFF
--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -165,7 +165,7 @@ func computeRequirements(info *ec2.InstanceTypeInfo, offerings cloudprovider.Off
 		requirements.Get(v1.LabelInstanceCPUManufacturer).Insert(lowerKabobCase(aws.StringValue(info.ProcessorInfo.Manufacturer)))
 	}
 	// EBS Max Bandwidth
-	if info.EbsInfo != nil && aws.StringValue(info.EbsInfo.EbsOptimizedSupport) == ec2.EbsOptimizedSupportDefault {
+	if info.EbsInfo != nil && info.EbsInfo.EbsOptimizedInfo != nil && aws.StringValue(info.EbsInfo.EbsOptimizedSupport) == ec2.EbsOptimizedSupportDefault {
 		requirements.Get(v1.LabelInstanceEBSBandwidth).Insert(fmt.Sprint(aws.Int64Value(info.EbsInfo.EbsOptimizedInfo.MaximumBandwidthInMbps)))
 	}
 	return requirements


### PR DESCRIPTION
We observed that `g2.xlarge` has `.EbsInfo.EbsOptimizedSupport == "default"`, but no `.EbsInfo.EbsOptimizedInfo`:

```
$ aws ec2 describe-instance-types --region us-west-2 --instance-types 'g2.xlarge' | jq '.InstanceTypes[0].EbsInfo'
{
  "EbsOptimizedSupport": "default",
  "EncryptionSupport": "supported",
  "NvmeSupport": "required"
}
```

This can cause a nil pointer dereference when gathering instance info, following the support for EBS maximum bandwidth introduced in #5925 

```
{"level":"INFO","time":"2024-08-05T18:52:30.307Z","logger":"controller","message":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","commit":"490ef94","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"utility-7lkkw"},"namespace":"","name":"utility-7lkkw","reconcileID":"997d55c4-ab30-4309-a0bb-32ad3e4b89b6"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1fa3011]

goroutine 1986 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:111 +0x1e5
panic({0x26f1360?, 0x4b7d1a0?})
	runtime/panic.go:770 +0x132
github.com/aws/karpenter-provider-aws/pkg/providers/instancetype.computeRequirements(0xc00cfef400, {0x0, 0x0, 0x0}, {0xc0000560fb, 0x9}, {0x33cf790, 0xc00e9847f0})
	github.com/aws/karpenter-provider-aws/pkg/providers/instancetype/types.go:169 +0x1711
github.com/aws/karpenter-provider-aws/pkg/providers/instancetype.NewInstanceType({0x33c95d8, 0xc0088ef1a0}, 0xc00cfef400, {0xc0000560fb?, 0xc0088f8df0?}, {0xc00831a2d0, 0x1, 0x1}, 0x0, 0x0, ...)
	github.com/aws/karpenter-provider-aws/pkg/providers/instancetype/types.go:58 +0xb4
github.com/aws/karpenter-provider-aws/pkg/providers/instancetype.(*DefaultProvider).List.func2(0xc00cfef400, 0x411f45?)
	github.com/aws/karpenter-provider-aws/pkg/providers/instancetype/instancetype.go:167 +0x3a8
github.com/samber/lo.Map[...]({0xc001a31a88?, 0x316, 0x2b26360}, 0xc0088f9208?)
	github.com/samber/lo@v1.39.0/slice.go:29 +0x66
github.com/aws/karpenter-provider-aws/pkg/providers/instancetype.(*DefaultProvider).List(0xc0006e6540, {0x33c95d8, 0xc0088ef1a0}, 0x0, 0xc005a12908)
	github.com/aws/karpenter-provider-aws/pkg/providers/instancetype/instancetype.go:155 +0xf3e
github.com/aws/karpenter-provider-aws/pkg/cloudprovider.(*CloudProvider).GetInstanceTypes(0xc000a4f3e0, {0x33c95d8, 0xc0088ef1a0}, 0xc008a0a1e0)
	github.com/aws/karpenter-provider-aws/pkg/cloudprovider/cloudprovider.go:172 +0x24a
github.com/aws/karpenter-provider-aws/pkg/cloudprovider.(*CloudProvider).isAMIDrifted(0xc000a4f3e0?, {0x33c95d8?, 0xc0088ef1a0?}, 0xc0088e88c0, 0x0?, 0xc0057589a0, 0xc008a04248)
	github.com/aws/karpenter-provider-aws/pkg/cloudprovider/drift.go:70 +0x4d
github.com/aws/karpenter-provider-aws/pkg/cloudprovider.(*CloudProvider).isNodeClassDrifted(0xc000a4f3e0, {0x33c95d8, 0xc0088ef1a0}, 0xc0088e88c0, 0xc008a0a1e0, 0xc008a04248)
	github.com/aws/karpenter-provider-aws/pkg/cloudprovider/drift.go:50 +0xd7
github.com/aws/karpenter-provider-aws/pkg/cloudprovider.(*CloudProvider).IsDrifted(0xc000a4f3e0, {0x33c95d8, 0xc0088ef1a0}, 0xc0088e88c0)
	github.com/aws/karpenter-provider-aws/pkg/cloudprovider/cloudprovider.go:208 +0x35f
sigs.k8s.io/karpenter/pkg/cloudprovider/metrics.(*decorator).IsDrifted(0xc0004161f0, {0x33c95d8, 0xc0088ef1a0}, 0xc0088e88c0)
	sigs.k8s.io/karpenter@v0.37.0/pkg/cloudprovider/metrics/cloudprovider.go:151 +0x14f
sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/disruption.(*Drift).isDrifted(0xc0004162d0, {0x33c95d8, 0xc0088ef1a0}, 0xc0087cbc20, 0xc0088e88c0)
	sigs.k8s.io/karpenter@v0.37.0/pkg/controllers/nodeclaim/disruption/drift.go:104 +0xd7
sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/disruption.(*Drift).Reconcile(0xc0004162d0, {0x33c95d8, 0xc0088ef1a0}, 0xc0087cbc20, 0xc0088e88c0)
	sigs.k8s.io/karpenter@v0.37.0/pkg/controllers/nodeclaim/disruption/drift.go:67 +0x275
sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/disruption.(*Controller).Reconcile(0xc0002cf140, {0x33c95d8, 0xc0088ef050}, 0xc0088e88c0)
	sigs.k8s.io/karpenter@v0.37.0/pkg/controllers/nodeclaim/disruption/controller.go:95 +0x369
sigs.k8s.io/controller-runtime/pkg/reconcile.(*objectReconcilerAdapter[...]).Reconcile(0x339c740, {0x33c95d8, 0xc0088ef050}, {{{0x0, 0x0?}, {0xc00070e400?, 0x5?}}})
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/reconcile/reconcile.go:142 +0x194
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x33cfd88?, {0x33c95d8?, 0xc0088ef050?}, {{{0x0?, 0xb?}, {0xc00070e400?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:114 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00040cdc0, {0x33c9610, 0xc0004fd040}, {0x28a1fc0, 0xc001a9dbe0})
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:311 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00040cdc0, {0x33c9610, 0xc0004fd040})
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:261 +0x1be
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:222 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 354
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:218 +0x486
```

Add an extra check to EBS maximum bandwidth selection to make sure that this key exists.