### PR TITLE
chore: consistent userData override ordering

### DIFF
--- a/pkg/providers/amifamily/bootstrap/nodeadm.go
+++ b/pkg/providers/amifamily/bootstrap/nodeadm.go
@@ -45,10 +45,10 @@ func (n Nodeadm) Script() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parsing custom UserData, %w", err)
 	}
-	mimeArchive := mime.Archive(append([]mime.Entry{{
+	mimeArchive := mime.Archive(append(customEntries, mime.Entry{
 		ContentType: mime.ContentTypeNodeConfig,
 		Content:     nodeConfigYAML,
-	}}, customEntries...))
+	}))
 	userData, err := mimeArchive.Serialize()
 	if err != nil {
 		return "", err

--- a/pkg/providers/launchtemplate/testdata/al2023_mime_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2023_mime_userdata_merged.golden
@@ -4,6 +4,25 @@ Content-Type: multipart/mixed; boundary="//"
 --//
 Content-Type: application/node.eks.aws
 
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: test-cluster
+    clusterEndpoint: https://test-cluster
+    certificateAuthority: cluster-ca
+    cidr: 10.100.0.0/16
+  kubelet:
+    config:
+      maxPods: 42
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+echo "Hello, AL2023!"
+--//
+Content-Type: application/node.eks.aws
+
 # Karpenter Generated NodeConfig
 apiVersion: node.eks.aws/v1alpha1
 kind: NodeConfig
@@ -29,23 +48,4 @@ spec:
     flags:
     - --node-labels="karpenter.sh/capacity-type=on-demand,%s=%s,testing/cluster=unspecified"
 
---//
-Content-Type: application/node.eks.aws
-
-apiVersion: node.eks.aws/v1alpha1
-kind: NodeConfig
-spec:
-  cluster:
-    name: test-cluster
-    clusterEndpoint: https://test-cluster
-    certificateAuthority: cluster-ca
-    cidr: 10.100.0.0/16
-  kubelet:
-    config:
-      maxPods: 42
---//
-Content-Type: text/x-shellscript; charset="us-ascii"
-
-#!/bin/bash
-echo "Hello, AL2023!"
 --//--

--- a/pkg/providers/launchtemplate/testdata/al2023_shell_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2023_shell_userdata_merged.golden
@@ -2,6 +2,11 @@ MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="//"
 
 --//
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+echo "Hello, AL2023!"
+--//
 Content-Type: application/node.eks.aws
 
 # Karpenter Generated NodeConfig
@@ -29,9 +34,4 @@ spec:
     flags:
     - --node-labels="karpenter.sh/capacity-type=on-demand,%s=%s,testing/cluster=unspecified"
 
---//
-Content-Type: text/x-shellscript; charset="us-ascii"
-
-#!/bin/bash
-echo "Hello, AL2023!"
 --//--

--- a/pkg/providers/launchtemplate/testdata/al2023_yaml_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2023_yaml_userdata_merged.golden
@@ -4,6 +4,20 @@ Content-Type: multipart/mixed; boundary="//"
 --//
 Content-Type: application/node.eks.aws
 
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: test-cluster
+    clusterEndpoint: https://test-cluster
+    certificateAuthority: cluster-ca
+    cidr: 10.100.0.0/16
+  kubelet:
+    config:
+      maxPods: 42
+--//
+Content-Type: application/node.eks.aws
+
 # Karpenter Generated NodeConfig
 apiVersion: node.eks.aws/v1alpha1
 kind: NodeConfig
@@ -29,18 +43,4 @@ spec:
     flags:
     - --node-labels="karpenter.sh/capacity-type=on-demand,%s=%s,testing/cluster=unspecified"
 
---//
-Content-Type: application/node.eks.aws
-
-apiVersion: node.eks.aws/v1alpha1
-kind: NodeConfig
-spec:
-  cluster:
-    name: test-cluster
-    clusterEndpoint: https://test-cluster
-    certificateAuthority: cluster-ca
-    cidr: 10.100.0.0/16
-  kubelet:
-    config:
-      maxPods: 42
 --//--


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Changes AL2023's generated userData order to place the Karpenter generated config at the end of the MIME document. This change makes AL2023 consistent with the other AMI families (AL2, Bottlerocket, and Windows)

**How was this change tested?**
`make presubmit` and `/karpenter snapshot`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.