### PR TITLE
chore: add markers to metrics for generating stability in docs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,3 +116,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace sigs.k8s.io/karpenter => github.com/jigisha620/karpenter v0.0.0-20240807185928-4c8ac02f529d

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jigisha620/karpenter v0.0.0-20240807185928-4c8ac02f529d h1:iWOwCEZYkVauBdh30adN4c7wEQR6TwrdnBnuGX5L6UI=
+github.com/jigisha620/karpenter v0.0.0-20240807185928-4c8ac02f529d/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -761,8 +763,6 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.37.1-0.20240806233449-dd09b2d65869 h1:6Y7MPoaSqp1pZ38c1CoL9jS5LgXKeRVqPZ0U4eu5pQg=
-sigs.k8s.io/karpenter v0.37.1-0.20240806233449-dd09b2d65869/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/batcher/metrics.go
+++ b/pkg/batcher/metrics.go
@@ -40,14 +40,14 @@ var (
 		Name:      "batch_time_seconds",
 		Help:      "Duration of the batching window per batcher",
 		Buckets:   metrics.DurationBuckets(),
-	}, []string{batcherNameLabel})
+	}, []string{batcherNameLabel}) //stability=BETA
 	batchSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
 		Subsystem: batcherSubsystem,
 		Name:      "batch_size",
 		Help:      "Size of the request batch per batcher",
 		Buckets:   SizeBuckets(),
-	}, []string{batcherNameLabel})
+	}, []string{batcherNameLabel}) //stability=BETA
 )
 
 func init() {

--- a/pkg/controllers/interruption/metrics.go
+++ b/pkg/controllers/interruption/metrics.go
@@ -35,7 +35,7 @@ var (
 			Help:      "Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.",
 		},
 		[]string{messageTypeLabel},
-	)
+	) //stability=STABLE
 	deletedMessages = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
@@ -43,7 +43,7 @@ var (
 			Name:      "deleted_messages_total",
 			Help:      "Count of messages deleted from the SQS queue.",
 		},
-	)
+	) //stability=STABLE
 	messageLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
@@ -52,7 +52,7 @@ var (
 			Help:      "Amount of time an interruption message is on the queue before it is processed by karpenter.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-	)
+	) //stability=STABLE
 )
 
 func init() {

--- a/pkg/providers/instancetype/metrics.go
+++ b/pkg/providers/instancetype/metrics.go
@@ -39,7 +39,7 @@ var (
 		[]string{
 			instanceTypeLabel,
 		},
-	)
+	) //stability=BETA
 	instanceTypeMemory = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
@@ -50,7 +50,7 @@ var (
 		[]string{
 			instanceTypeLabel,
 		},
-	)
+	) //stability=BETA
 	instanceTypeOfferingAvailable = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
@@ -63,7 +63,7 @@ var (
 			capacityTypeLabel,
 			zoneLabel,
 		},
-	)
+	) //stability=BETA
 	instanceTypeOfferingPriceEstimate = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
@@ -75,7 +75,7 @@ var (
 			instanceTypeLabel,
 			capacityTypeLabel,
 			zoneLabel,
-		})
+		}) //stability=BETA
 )
 
 func init() {

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -122,15 +122,15 @@ The number of pods currently waiting to be scheduled.
 
 ### `karpenter_nodepools_usage`
 The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
-- Stability Level: ALPHA
+- Stability Level: STABLE
 
 ### `karpenter_nodepools_limit`
 Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
-- Stability Level: ALPHA
+- Stability Level: STABLE
 
 ### `karpenter_nodepools_allowed_disruptions`
 The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
-- Stability Level: ALPHA
+- Stability Level: STABLE
 
 ## Interruption Metrics
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Added markers to metrics for stability and updated the metrics generator script to assign stability by reading markers.

**How was this change tested?**
`make docgen`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.