### PR TITLE
feat: convert unpinned Ubuntu EC2NodeClasses

### DIFF
--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -474,6 +474,11 @@ func (in *EC2NodeClass) InstanceProfileTags(clusterName string) map[string]strin
 	})
 }
 
+// UbuntuIncompatible
+func (in *EC2NodeClass) UbuntuIncompatible() bool {
+	return lo.Contains(strings.Split(in.Annotations[AnnotationUbuntuCompatibilityKey], ","), AnnotationUbuntuCompatibilityIncompatible)
+}
+
 // AMIFamily returns the family for a NodePool based on the following items, in order of precdence:
 //   - ec2nodeclass.spec.amiFamily
 //   - ec2nodeclass.spec.amiSelectorTerms[].alias

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -474,7 +474,8 @@ func (in *EC2NodeClass) InstanceProfileTags(clusterName string) map[string]strin
 	})
 }
 
-// UbuntuIncompatible
+// UbuntuIncompatible returns true if the NodeClass has the ubuntu compatibility annotation. This will cause the NodeClass to show
+// as NotReady in its status conditions, opting its referencing NodePools out of provisioning and drift.
 func (in *EC2NodeClass) UbuntuIncompatible() bool {
 	return lo.Contains(strings.Split(in.Annotations[AnnotationUbuntuCompatibilityKey], ","), AnnotationUbuntuCompatibilityIncompatible)
 }

--- a/pkg/apis/v1/ec2nodeclass_conversion.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion.go
@@ -162,7 +162,6 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 
 		// If there are no AMISelectorTerms specified, we mark the ec2nodeclass as incompatible.
 		// Karpenter will ignore incompatible ec2nodeclasses for provisioning and computing drift.
-		// Users should pin their AMIs **before** upgrading to v1.0.0 if they were using the Ubuntu AMIFamily.
 		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
 			compatSpecifiers = append(compatSpecifiers, AnnotationUbuntuCompatibilityIncompatible)
 			in.Spec.AMISelectorTerms = []AMISelectorTerm{{

--- a/pkg/apis/v1/ec2nodeclass_conversion.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion.go
@@ -35,6 +35,9 @@ func (in *EC2NodeClass) ConvertTo(ctx context.Context, to apis.Convertible) erro
 
 	if value, ok := in.Annotations[AnnotationUbuntuCompatibilityKey]; ok {
 		compatSpecifiers := strings.Split(value, ",")
+		if lo.Contains(compatSpecifiers, AnnotationUbuntuCompatibilityIncompatible) {
+			in.Spec.AMISelectorTerms = nil
+		}
 		// The only blockDeviceMappings present on the v1 EC2NodeClass are those that we injected during conversion.
 		// These should be dropped.
 		if lo.Contains(compatSpecifiers, AnnotationUbuntuCompatibilityBlockDeviceMappings) {
@@ -136,13 +139,6 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 			in.Spec.AMIFamily = v1beta1enc.Spec.AMIFamily
 		}
 	case AMIFamilyUbuntu:
-		// If there are no AMISelectorTerms specified, we will fail closed when converting the NodeClass. Users must
-		// pin their AMIs **before** upgrading to Karpenter v1.0.0 if they were using the Ubuntu AMIFamily.
-		// TODO: jmdeal@ verify doc link to the upgrade guide once available
-		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
-			return fmt.Errorf("converting EC2NodeClass %q from v1beta1 to v1, automatic Ubuntu AMI discovery is not supported (https://karpenter.sh/v1.0/upgrading/upgrade-guide/)", v1beta1enc.Name)
-		}
-
 		// If AMISelectorTerms were specified, we can continue to use them to discover Ubuntu AMIs and use the AL2 AMI
 		// family for bootstrapping. AL2 and Ubuntu have an identical UserData format, but do have different default
 		// BlockDeviceMappings. We'll set the BlockDeviceMappings to Ubuntu's default if no user specified
@@ -161,6 +157,16 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 				},
 			}}
 		}
+		// If there are no AMISelectorTerms specified, we will fail closed when converting the NodeClass. Users must
+		// pin their AMIs **before** upgrading to Karpenter v1.0.0 if they were using the Ubuntu AMIFamily.
+		// TODO: jmdeal@ verify doc link to the upgrade guide once available
+		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
+			compatSpecifiers = append(compatSpecifiers, AnnotationUbuntuCompatibilityIncompatible)
+			in.Spec.AMISelectorTerms = []AMISelectorTerm{{
+				ID: "ami-placeholder",
+			}}
+		}
+
 		// This compatibility annotation will be used to determine if the amiFamily was mutated from Ubuntu to AL2, and
 		// if we needed to inject any blockDeviceMappings. This is required to enable a round-trip conversion.
 		in.Annotations = lo.Assign(in.Annotations, map[string]string{

--- a/pkg/apis/v1/ec2nodeclass_conversion_test.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion_test.go
@@ -462,7 +462,8 @@ var _ = Describe("Convert v1beta1 to v1 EC2NodeClass API", func() {
 		It("should fail to convert v1beta1 ec2nodeclass when amiFamily is Ubuntu (without amiSelectorTerms)", func() {
 			v1beta1ec2nodeclass.Spec.AMIFamily = lo.ToPtr(v1beta1.AMIFamilyUbuntu)
 			v1beta1ec2nodeclass.Spec.AMISelectorTerms = nil
-			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).ToNot(Succeed())
+			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).To(Succeed())
+			Expect(v1ec2nodeclass.UbuntuIncompatible()).To(BeTrue())
 		})
 		It("should convert v1beta1 ec2nodeclass user data", func() {
 			v1beta1ec2nodeclass.Spec.UserData = lo.ToPtr("test user data")

--- a/pkg/apis/v1/ec2nodeclass_conversion_test.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion_test.go
@@ -459,7 +459,7 @@ var _ = Describe("Convert v1beta1 to v1 EC2NodeClass API", func() {
 				},
 			}}))
 		})
-		It("should fail to convert v1beta1 ec2nodeclass when amiFamily is Ubuntu (without amiSelectorTerms)", func() {
+		It("should convert v1beta1 ec2nodeclass when amiFamily is Ubuntu (without amiSelectorTerms) but mark incompatible", func() {
 			v1beta1ec2nodeclass.Spec.AMIFamily = lo.ToPtr(v1beta1.AMIFamilyUbuntu)
 			v1beta1ec2nodeclass.Spec.AMISelectorTerms = nil
 			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).To(Succeed())

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -127,6 +127,7 @@ var (
 	AnnotationInstanceTagged                  = apis.Group + "/tagged"
 
 	AnnotationUbuntuCompatibilityKey                 = apis.CompatibilityGroup + "/v1beta1-ubuntu"
+	AnnotationUbuntuCompatibilityIncompatible        = "incompatible"
 	AnnotationUbuntuCompatibilityAMIFamily           = "amiFamily"
 	AnnotationUbuntuCompatibilityBlockDeviceMappings = "blockDeviceMappings"
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -90,7 +90,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 
 	// TODO: Remove this once support for conversion webhooks is dropped
 	if nodeClass.UbuntuIncompatible() {
-		return nil, fmt.Errorf("EC2NodeClass %q is incompatible with Karpenter v1, specify amiSelectorTerms", nodeClass.Name)
+		return nil, fmt.Errorf("EC2NodeClass %q is incompatible with Karpenter v1, specify your Ubuntu AMIs in your AMISelectorTerms", nodeClass.Name)
 	}
 	// TODO: Remove this after v1
 	nodePool, err := utils.ResolveNodePoolFromNodeClaim(ctx, c.kubeClient, nodeClaim)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -77,6 +77,7 @@ func New(instanceTypeProvider instancetype.Provider, instanceProvider instance.P
 }
 
 // Create a NodeClaim given the constraints.
+// nolint: gocyclo
 func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*karpv1.NodeClaim, error) {
 	nodeClass, err := c.resolveNodeClassFromNodeClaim(ctx, nodeClaim)
 	if err != nil {
@@ -87,6 +88,10 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("resolving node class, %w", err))
 	}
 
+	// TODO: Remove this once support for conversion webhooks is dropped
+	if nodeClass.UbuntuIncompatible() {
+		return nil, fmt.Errorf("EC2NodeClass %q is incompatible with Karpenter v1, specify amiSelectorTerms", nodeClass.Name)
+	}
 	// TODO: Remove this after v1
 	nodePool, err := utils.ResolveNodePoolFromNodeClaim(ctx, c.kubeClient, nodeClaim)
 	if err != nil {

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -90,7 +90,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 
 	// TODO: Remove this once support for conversion webhooks is dropped
 	if nodeClass.UbuntuIncompatible() {
-		return nil, fmt.Errorf("EC2NodeClass %q is incompatible with Karpenter v1, specify your Ubuntu AMIs in your AMISelectorTerms", nodeClass.Name)
+		return nil, cloudprovider.NewNodeClassNotReadyError(fmt.Errorf("EC2NodeClass %q is incompatible with Karpenter v1, specify your Ubuntu AMIs in your AMISelectorTerms", nodeClass.Name))
 	}
 	// TODO: Remove this after v1
 	nodePool, err := utils.ResolveNodePoolFromNodeClaim(ctx, c.kubeClient, nodeClaim)

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -202,7 +202,7 @@ var _ = Describe("CloudProvider", func() {
 		nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationUbuntuCompatibilityKey: v1.AnnotationUbuntuCompatibilityIncompatible})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)
 		_, err := cloudProvider.Create(ctx, nodeClaim)
-		Expect(err).To(HaveOccurred())
+		Expect(corecloudprovider.IsNodeClassNotReadyError(err)).To(BeTrue())
 	})
 	It("should not proceed with instance creation if NodeClass is unknown", func() {
 		nodeClass.StatusConditions().SetUnknown(opstatus.ConditionReady)

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -197,6 +197,13 @@ var _ = Describe("CloudProvider", func() {
 		Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypes(ctx)).To(Succeed())
 		Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypeOfferings(ctx)).To(Succeed())
 	})
+	// TODO: remove after v1
+	It("should fail instance creation if NodeClass has ubuntu incompatible annotation", func() {
+		nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationUbuntuCompatibilityKey: v1.AnnotationUbuntuCompatibilityIncompatible})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)
+		_, err := cloudProvider.Create(ctx, nodeClaim)
+		Expect(err).To(HaveOccurred())
+	})
 	It("should not proceed with instance creation if NodeClass is unknown", func() {
 		nodeClass.StatusConditions().SetUnknown(opstatus.ConditionReady)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)

--- a/pkg/controllers/nodeclass/status/ami.go
+++ b/pkg/controllers/nodeclass/status/ami.go
@@ -36,7 +36,7 @@ type AMI struct {
 
 func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	if nodeClass.UbuntuIncompatible() {
-		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "AMINotFound", "Ubuntu AMI discovery is unsupported, refer to the upgrade guide (https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-100)")
+		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "AMINotFound", "Ubuntu AMI discovery is not supported at v1, refer to the upgrade guide (https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-100)")
 		return reconcile.Result{}, nil
 	}
 	amis, err := a.amiProvider.List(ctx, nodeClass)

--- a/pkg/controllers/nodeclass/status/ami.go
+++ b/pkg/controllers/nodeclass/status/ami.go
@@ -35,6 +35,10 @@ type AMI struct {
 }
 
 func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
+	if nodeClass.UbuntuIncompatible() {
+		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "AMINotFound", "Ubuntu AMI discovery is unsupported, refer to the upgrade guide (https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-100)")
+		return reconcile.Result{}, nil
+	}
 	amis, err := a.amiProvider.List(ctx, nodeClass)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("getting amis, %w", err)

--- a/pkg/controllers/nodeclass/status/ami_test.go
+++ b/pkg/controllers/nodeclass/status/ami_test.go
@@ -97,7 +97,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		cond := nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady)
 		Expect(cond.IsTrue()).To(BeFalse())
-		Expect(cond.Message).To(Equal("Ubuntu AMI discovery is unsupported, refer to the upgrade guide (https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-100)"))
+		Expect(cond.Message).To(Equal("Ubuntu AMI discovery is not supported at v1, refer to the upgrade guide (https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-100)"))
 		Expect(cond.Reason).To(Equal("AMINotFound"))
 
 	})

--- a/pkg/controllers/nodeclass/status/ami_test.go
+++ b/pkg/controllers/nodeclass/status/ami_test.go
@@ -89,6 +89,18 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 			},
 		})
 	})
+	It("should fail to resolve AMIs if the nodeclass has ubuntu incompatible annotation", func() {
+		nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2)
+		nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationUbuntuCompatibilityKey: v1.AnnotationUbuntuCompatibilityIncompatible})
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		cond := nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady)
+		Expect(cond.IsTrue()).To(BeFalse())
+		Expect(cond.Message).To(Equal("Ubuntu AMI discovery is unsupported, refer to the upgrade guide (https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-100)"))
+		Expect(cond.Reason).To(Equal("AMINotFound"))
+
+	})
 	It("should resolve amiSelector AMIs and requirements into status", func() {
 		version := lo.Must(awsEnv.VersionProvider.Get(ctx))
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -636,7 +636,7 @@ For [private clusters](https://docs.aws.amazon.com/eks/latest/userguide/private-
 
 ## spec.amiSelectorTerms
 
-AMI Selector Terms are __required__ and are used to configure AMIs for Karpenter to use. AMIs are discovered through alias, id, owner, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). 
+AMI Selector Terms are __required__ and are used to configure AMIs for Karpenter to use. AMIs are discovered through alias, id, owner, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
 
 This selection logic is modeled as terms, where each term contains multiple conditions that must all be satisfied for the selector to match. Effectively, all requirements within a single term are ANDed together. It's possible that you may want to select on two different AMIs that have unrelated requirements. In this case, you can specify multiple terms which will be ORed together to form your selection logic. The example below shows how this selection logic is fulfilled.
 
@@ -855,17 +855,6 @@ spec:
         encrypted: true
 ```
 
-### Ubuntu (not supported)
-```yaml
-spec:
-  blockDeviceMappings:
-    - deviceName: /dev/sda1
-      ebs:
-        volumeSize: 20Gi
-        volumeType: gp3
-        encrypted: true
-```
-
 ### Windows2019/Windows2022
 ```yaml
 spec:
@@ -965,7 +954,7 @@ For more examples on configuring fields for different AMI families, see the [exa
 
 Karpenter will merge the userData you specify with the default userData for that AMIFamily. See the [AMIFamily]({{< ref "#specamifamily" >}}) section for more details on these defaults. View the sections below to understand the different merge strategies for each AMIFamily.
 
-### AL2/Ubuntu
+### AL2
 
 * Your UserData can be in the [MIME multi part archive](https://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-archive) format.
 * Karpenter will transform your custom user-data as a MIME part, if necessary, and then merge a final MIME part to the end of your UserData parts which will bootstrap the worker node. Karpenter will have full control over all the parameters being passed to the bootstrap script.

--- a/website/content/en/preview/upgrading/v1-migration.md
+++ b/website/content/en/preview/upgrading/v1-migration.md
@@ -143,7 +143,7 @@ for [EKS Pod Identity ABAC policies](https://docs.aws.amazon.com/eks/latest/user
    To continue using Ubuntu AMIs you will need to specify an AMI using `amiSelectorTerms`.
 
    UserData generation can be achieved using the AL2 AMIFamily which, at the time of writing, has an identical UserData format.
-   However, compatibility is not guaranteed long-term and changes to either AL2 or Ubuntu's UserData format my introduce incompatibilities.
+   However, compatibility is not guaranteed long-term and changes to either AL2 or Ubuntu's UserData format may introduce incompatibilities.
    If this occurs, the Custom AMIFamily should be used for Ubuntu and UserData will need to be entirely maintained by the user.
 
    If you are upgrading to `v1.0.0` and already have v1beta1 Ubuntu EC2NodeClasses, all you need to do is specify `amiSelectorTerms` and Karpenter will translate your NodeClasses to the v1 equivalent (as shown below).

--- a/website/content/en/preview/upgrading/v1-migration.md
+++ b/website/content/en/preview/upgrading/v1-migration.md
@@ -26,7 +26,7 @@ Please read through the entire procedure before beginning the upgrade. There are
 1. Determine the current Karpenter version:
    ```bash
    kubectl get pod -A | grep karpenter
-   kubectl describe pod -n karpenter karpenter-xxxxxxxxxx-xxxxx | grep Image: 
+   kubectl describe pod -n karpenter karpenter-xxxxxxxxxx-xxxxx | grep Image:
    ```
    Sample output:
    ```bash
@@ -137,8 +137,20 @@ for [EKS Pod Identity ABAC policies](https://docs.aws.amazon.com/eks/latest/user
 
 * **metadataOptions could break workloads**: If you have workload pods that are not using `hostNetworking`, the updated default `metadataOptions` could cause your containers to break when you apply new EC2NodeClasses on v1.
 
-* **Support for native Ubuntu AMI selection is dropped**: If you are using Ubuntu and not using `amiSelectorTerms`, be aware that Karpenter v1 no longer natively supports Ubuntu. To continue using Ubuntu in v1, you can update `amiSelectorTerms` in your EC2NodeClasses to identify Ubuntu as the AMI you want to use. See [reimplement amiFamily](https://github.com/aws/karpenter-provider-aws/pull/6569) for an example. Once you have done that, you can leave the amiFamily as Ubuntu and proceed to upgrading to v1. This will result in the following transformation:
+* **Ubuntu AMIFamily Removed**:
+
+   Support for automatic AMI selection and UserData generation for Ubuntu has been dropped with Karpenter `v1.0.0`.
+   To continue using Ubuntu AMIs you will need to specify an AMI using `amiSelectorTerms`.
+
+   UserData generation can be achieved using the AL2 AMIFamily which, at the time of writing, has an identical UserData format.
+   However, compatibility is not guaranteed long-term and changes to either AL2 or Ubuntu's UserData format my introduce incompatibilities.
+   If this occurs, the Custom AMIFamily should be used for Ubuntu and UserData will need to be entirely maintained by the user.
+
+   If you are upgrading to `v1.0.0` and already have v1beta1 Ubuntu EC2NodeClasses, all you need to do is specify `amiSelectorTerms` and Karpenter will translate your NodeClasses to the v1 equivalent (as shown below).
+   Failure to specify `amiSelectorTerms` will result in the EC2NodeClass and all associated NodePools going unready.
+
    ```yaml
+   # Original v1beta1 EC2NodeClass
    version: karpenter.k8s.aws/v1beta1
    kind: EC2NodeClass
    spec:
@@ -164,10 +176,9 @@ for [EKS Pod Identity ABAC policies](https://docs.aws.amazon.com/eks/latest/user
          volumeType: gp3
          volumeSize: 20Gi
    ```
-   **NOTE**: If you do not specify `amiSelectorTerms` before upgrading with the Ubuntu `amiFamily`, the conversion webhook will fail. If you do this, update your EC2NodeClass to specify amiSelectorTerms on v1beta1, resolving the conversion webhook failures.
 
 * **amiSelectorTerms and amiFamily**: For v1, `amiFamily` is no longer required if you instead specify an `alias` in `amiSelectorTerms` in your `EC2NodeClass`. You need to update your `amiSelectorTerms` and `amiFamily` if you are using:
-   * A Custom amiFamily. You must ensure that the node you add the `karpenter.sh/unregistered` taint in your UserData.
+   * A Custom amiFamily. You must ensure that the node you add the `karpenter.sh/unregistered:NoExecute` taint in your UserData.
    * An Ubuntu AMI, as described earlier.
 
 ### Before upgrading to `v1.1.0`
@@ -188,36 +199,36 @@ without having drift or having any additional NodePools or EC2NodeClasses config
 Karpenter will crash on upgrade if NodePool resources contain this annotation. Users should make sure that their kubelet configurations are migrated prior to upgrading to properly drift their nodes to the correct configurations.
 
 ### Downgrading
-// TODO 
+// TODO
 
 ## Full Changelog
-* Features: 
+* Features:
   * AMI Selector Terms has a new Alias field which can only be set by itself in `EC2NodeClass.Spec.AMISelectorTerms`
   * Disruption Budgets by Reason was added to `NodePool.Spec.Disruption.Budgets`
   * TerminationGracePeriod was added to `NodePool.Spec.Template.Spec`.
   * LOG_OUTPUT_PATHS and LOG_ERROR_OUTPUT_PATHS environment variables added
 * API Rename: NodePool’s ConsolidationPolicy `WhenUnderutilized` is now renamed to `WhenEmptyOrUnderutilized`
-* Behavior Changes: 
+* Behavior Changes:
   * Expiration is now forceful and begins draining as soon as it’s expired. Karpenter does not wait for replacement capacity to be available before draining, but will start provisioning a replacement as soon as the node is expired and begins draining.
-  * Karpenter's generated NodeConfig now takes precedence when generating UserData with the AL2023 `amiFamily`. If you're setting any values managed by Karpenter in your AL2023 UserData, configure these through Karpenter natively (e.g. kubelet configuration fields). 
-  * Karpenter now adds a `karpenter.sh/unregistered` taint to nodes in injected UserData when using alias in AMISelectorTerms or non-Custom AMIFamily. When using `amiFamily: Custom`, users will need to add this taint into their UserData, where Karpenter will automatically remove it when provisioning nodes. 
-* API Moves: 
+  * Karpenter's generated NodeConfig now takes precedence when generating UserData with the AL2023 `amiFamily`. If you're setting any values managed by Karpenter in your AL2023 UserData, configure these through Karpenter natively (e.g. kubelet configuration fields).
+  * Karpenter now adds a `karpenter.sh/unregistered` taint to nodes in injected UserData when using alias in AMISelectorTerms or non-Custom AMIFamily. When using `amiFamily: Custom`, users will need to add this taint into their UserData, where Karpenter will automatically remove it when provisioning nodes.
+* API Moves:
   * ExpireAfter has moved from the `NodePool.Spec.Disruption` block to `NodePool.Spec.Template.Spec`, and is now a drift-able field.
   * `Kubelet` was moved to the EC2NodeClass from the NodePool.
 * RBAC changes: added `delete pods` | added `get, patch crds` | added `update nodes` | removed `create nodes`
-* Breaking API (Manual Migration Needed): 
+* Breaking API (Manual Migration Needed):
   * Ubuntu is dropped as a first class supported AMI Family
   * `karpenter.sh/do-not-consolidate` (annotation), `karpenter.sh/do-not-evict` (annotation), and `karpenter.sh/managed-by` (tag) are all removed. `karpenter.sh/managed-by`, which currently stores the cluster name in its value, will be replaced by eks:eks-cluster-name
   * The taint used to mark nodes for disruption and termination changed from `karpenter.sh/disruption=disrupting:NoSchedule` to `karpenter.sh/disrupted:NoSchedule`. It is not recommended to tolerate this taint, however, if you were tolerating it in your applications, you'll need to adjust your taints to reflect this.
-* Environment Variable Changes: 
+* Environment Variable Changes:
   * Environment Variable Changes
   * LOGGING_CONFIG, ASSUME_ROLE_ARN, ASSUME_ROLE_DURATION Dropped
   * LEADER_ELECT renamed to DISABLE_LEADER_ELECTION
   * `FEATURE_GATES.DRIFT=true` was dropped and promoted to Stable, and cannot be disabled.
       * Users currently opting out of drift, disabling the drift feature flag will no longer be able to do so.
-* Defaults changed: 
+* Defaults changed:
   * API: Karpenter will drop support for IMDS access from containers by default on new EC2NodeClasses by updating the default of `httpPutResponseHopLimit` from 2 to 1.
-  * API: ConsolidateAfter is required. Users couldn’t set this before with ConsolidationPolicy: WhenUnderutilized, where this is now required. Users can set it to 0 to have the same behavior as in v1beta1. 
+  * API: ConsolidateAfter is required. Users couldn’t set this before with ConsolidationPolicy: WhenUnderutilized, where this is now required. Users can set it to 0 to have the same behavior as in v1beta1.
   * API: All `NodeClassRef` fields are now all required, and apiVersion has been renamed to group
   * API: AMISelectorTerms are required. Setting an Alias cannot be done with any other type of term, and must match the AMI Family that's set or be Custom.
   * Helm: Deployment spec TopologySpreadConstraint to have required zonal spread over preferred. Users who had one node running their Karpenter deployments need to either:
@@ -225,7 +236,7 @@ Karpenter will crash on upgrade if NodePool resources contain this annotation. U
     * Scale down their Karpenter replicas from 2 to 1 in the helm chart
     * Edit and relax the topology spread constraint in their helm chart from DoNotSchedule to ScheduleAnyway
   * Helm/Binary: `controller.METRICS_PORT` default changed back to 8080
- 
+
 ### Updated metrics
 
 Changes to Karpenter metrics from v1beta1 to v1 are shown in the following tables.

--- a/website/content/en/preview/upgrading/v1-migration.md
+++ b/website/content/en/preview/upgrading/v1-migration.md
@@ -142,12 +142,12 @@ for [EKS Pod Identity ABAC policies](https://docs.aws.amazon.com/eks/latest/user
    Support for automatic AMI selection and UserData generation for Ubuntu has been dropped with Karpenter `v1.0.0`.
    To continue using Ubuntu AMIs you will need to specify an AMI using `amiSelectorTerms`.
 
-   UserData generation can be achieved using the AL2 AMIFamily which, at the time of writing, has an identical UserData format.
+   UserData generation can be achieved using the AL2 AMIFamily which has an identical UserData format.
    However, compatibility is not guaranteed long-term and changes to either AL2 or Ubuntu's UserData format may introduce incompatibilities.
    If this occurs, the Custom AMIFamily should be used for Ubuntu and UserData will need to be entirely maintained by the user.
 
    If you are upgrading to `v1.0.0` and already have v1beta1 Ubuntu EC2NodeClasses, all you need to do is specify `amiSelectorTerms` and Karpenter will translate your NodeClasses to the v1 equivalent (as shown below).
-   Failure to specify `amiSelectorTerms` will result in the EC2NodeClass and all associated NodePools going unready.
+   Failure to specify `amiSelectorTerms` will result in the EC2NodeClass and all referencing NodePools to show as NotReady, causing Karpenter to ignore these NodePools and EC2NodeClasses for Provisioning and Drift.
 
    ```yaml
    # Original v1beta1 EC2NodeClass
@@ -211,7 +211,7 @@ Karpenter will crash on upgrade if NodePool resources contain this annotation. U
 * Behavior Changes:
   * Expiration is now forceful and begins draining as soon as it’s expired. Karpenter does not wait for replacement capacity to be available before draining, but will start provisioning a replacement as soon as the node is expired and begins draining.
   * Karpenter's generated NodeConfig now takes precedence when generating UserData with the AL2023 `amiFamily`. If you're setting any values managed by Karpenter in your AL2023 UserData, configure these through Karpenter natively (e.g. kubelet configuration fields).
-  * Karpenter now adds a `karpenter.sh/unregistered` taint to nodes in injected UserData when using alias in AMISelectorTerms or non-Custom AMIFamily. When using `amiFamily: Custom`, users will need to add this taint into their UserData, where Karpenter will automatically remove it when provisioning nodes.
+  * Karpenter now adds a `karpenter.sh/unregistered:NoExecute` taint to nodes in injected UserData when using alias in AMISelectorTerms or non-Custom AMIFamily. When using `amiFamily: Custom`, users will need to add this taint into their UserData, where Karpenter will automatically remove it when provisioning nodes.
 * API Moves:
   * ExpireAfter has moved from the `NodePool.Spec.Disruption` block to `NodePool.Spec.Template.Spec`, and is now a drift-able field.
   * `Kubelet` was moved to the EC2NodeClass from the NodePool.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates the EC2NodeClass conversion to successfully convert unpinned Ubuntu NodeClasses. This changes the failure mode from failing at conversion, to failing at NodeClass readiness. 

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.