### PR TITLE
test: Add testing to verify consistent generation for a no change update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v0.37.1-0.20240812014159-feb6857c0fc4
+	sigs.k8s.io/karpenter v0.37.1-0.20240812180459-92547d1f9c20
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.37.1-0.20240812014159-feb6857c0fc4 h1:ub5jM8/+jWnzJt6fCSoa3yD9qdGGphX8bK7LtSib+yk=
-sigs.k8s.io/karpenter v0.37.1-0.20240812014159-feb6857c0fc4/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
+sigs.k8s.io/karpenter v0.37.1-0.20240812180459-92547d1f9c20 h1:HA+J1LbKlvFWUT7w7EDvVmhBeAoqqPeRbqGp8NUnLnw=
+sigs.k8s.io/karpenter v0.37.1-0.20240812180459-92547d1f9c20/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/test/suites/integration/conversion_webhook_test.go
+++ b/test/suites/integration/conversion_webhook_test.go
@@ -1,0 +1,216 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	karpv1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	karptest "sigs.k8s.io/karpenter/pkg/test"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-provider-aws/pkg/test"
+)
+
+var _ = Describe("Conversion Webhooks", func() {
+	Context("NodePool", func() {
+		It("should not update a metadata generation when the same resource is applied for the v1beta1 APIs", func() {
+			// created v1beta1 resource
+
+			storedv1beta1NodePool := &karpv1beta1.NodePool{
+				ObjectMeta: karptest.ObjectMeta(),
+				Spec: karpv1beta1.NodePoolSpec{
+					Limits: karpv1beta1.Limits{
+						corev1.ResourceCPU: lo.Must(resource.ParseQuantity("20m")),
+					},
+					Disruption: karpv1beta1.Disruption{
+						ConsolidationPolicy: karpv1beta1.ConsolidationPolicyWhenEmpty,
+						ConsolidateAfter:    lo.ToPtr(karpv1beta1.MustParseNillableDuration("1h")),
+						ExpireAfter:         karpv1beta1.MustParseNillableDuration("1h"),
+					},
+					Template: karpv1beta1.NodeClaimTemplate{
+						Spec: karpv1beta1.NodeClaimSpec{
+							NodeClassRef: &karpv1beta1.NodeClassReference{
+								Name: "test-nodeclass",
+							},
+							Requirements: []karpv1beta1.NodeSelectorRequirementWithMinValues{
+								{
+									NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+										Key:      corev1.LabelOSStable,
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{string(corev1.Linux)},
+									},
+								},
+							},
+							Kubelet: &karpv1beta1.KubeletConfiguration{
+								MaxPods:     lo.ToPtr(int32(110)),
+								PodsPerCore: lo.ToPtr(int32(10)),
+								SystemReserved: map[string]string{
+									string(corev1.ResourceCPU):              "200m",
+									string(corev1.ResourceMemory):           "200Mi",
+									string(corev1.ResourceEphemeralStorage): "1Gi",
+								},
+								KubeReserved: map[string]string{
+									string(corev1.ResourceCPU):              "200m",
+									string(corev1.ResourceMemory):           "200Mi",
+									string(corev1.ResourceEphemeralStorage): "1Gi",
+								},
+								EvictionHard: map[string]string{
+									"memory.available":   "5%",
+									"nodefs.available":   "5%",
+									"nodefs.inodesFree":  "5%",
+									"imagefs.available":  "5%",
+									"imagefs.inodesFree": "5%",
+									"pid.available":      "3%",
+								},
+								EvictionSoft: map[string]string{
+									"memory.available":   "10%",
+									"nodefs.available":   "10%",
+									"nodefs.inodesFree":  "10%",
+									"imagefs.available":  "10%",
+									"imagefs.inodesFree": "10%",
+									"pid.available":      "6%",
+								},
+								EvictionSoftGracePeriod: map[string]metav1.Duration{
+									"memory.available":   {Duration: time.Minute * 2},
+									"nodefs.available":   {Duration: time.Minute * 2},
+									"nodefs.inodesFree":  {Duration: time.Minute * 2},
+									"imagefs.available":  {Duration: time.Minute * 2},
+									"imagefs.inodesFree": {Duration: time.Minute * 2},
+									"pid.available":      {Duration: time.Minute * 2},
+								},
+								EvictionMaxPodGracePeriod:   lo.ToPtr(int32(120)),
+								ImageGCHighThresholdPercent: lo.ToPtr(int32(50)),
+								ImageGCLowThresholdPercent:  lo.ToPtr(int32(10)),
+								CPUCFSQuota:                 lo.ToPtr(false),
+							},
+						},
+					},
+				},
+			}
+
+			// Use a deepcopy to make sure the nodePool object is not populated with the returned object from the APIServer
+			env.ExpectCreated(storedv1beta1NodePool.DeepCopy())
+			v1beta1NodePool := env.ExpectExists(storedv1beta1NodePool.DeepCopy()).(*karpv1beta1.NodePool)
+			Expect(v1beta1NodePool.Generation).To(BeNumerically("==", 1))
+
+			// Second apply of the same NodePool does not increase the generation
+			env.ExpectUpdated(storedv1beta1NodePool.DeepCopy())
+			v1beta1NodePool = env.ExpectExists(storedv1beta1NodePool.DeepCopy()).(*karpv1beta1.NodePool)
+			Expect(v1beta1NodePool.Generation).To(BeNumerically("==", 1))
+			Expect(v1beta1NodePool.Spec.Template.Spec.NodeClassRef.APIVersion).To(Equal(storedv1beta1NodePool.Spec.Template.Spec.NodeClassRef.APIVersion))
+			Expect(v1beta1NodePool.Spec.Disruption.ConsolidateAfter.Duration.String()).To(Equal(storedv1beta1NodePool.Spec.Disruption.ConsolidateAfter.Duration.String()))
+			Expect(v1beta1NodePool.Spec.Disruption.ExpireAfter.Duration.String()).To(Equal(storedv1beta1NodePool.Spec.Disruption.ExpireAfter.Duration.String()))
+		})
+		It("should not update a metadata generation when the same resource is applied for the v1 APIs", func() {
+			nodePool.Spec.Disruption = karpv1.Disruption{
+				ConsolidateAfter: karpv1.MustParseNillableDuration("1h"),
+			}
+			nodePool.Spec.Template.Spec.ExpireAfter = karpv1.MustParseNillableDuration("1h")
+			nodePool.Spec.Limits = karpv1.Limits{
+				corev1.ResourceCPU: lo.Must(resource.ParseQuantity("20m")),
+			}
+
+			// Use a deepcopy to make sure the nodePool object is not populated with the returned object from the APIServer
+			env.ExpectCreated(nodePool.DeepCopy())
+			v1NodePool := env.ExpectExists(nodePool).(*karpv1.NodePool)
+			Expect(v1NodePool.Generation).To(BeNumerically("==", 1))
+
+			// Second apply of the same NodePool does not increase the generation
+			env.ExpectUpdated(nodePool.DeepCopy())
+			v1NodePool = env.ExpectExists(nodePool).(*karpv1.NodePool)
+			Expect(v1NodePool.Generation).To(BeNumerically("==", 1))
+			Expect(v1NodePool.Spec.Template.Spec.NodeClassRef.Group).To(Equal(nodePool.Spec.Template.Spec.NodeClassRef.Group))
+			Expect(v1NodePool.Spec.Disruption.ConsolidateAfter.Duration.String()).To(Equal(nodePool.Spec.Disruption.ConsolidateAfter.Duration.String()))
+			Expect(v1NodePool.Spec.Template.Spec.ExpireAfter.Duration.String()).To(Equal(nodePool.Spec.Template.Spec.ExpireAfter.Duration.String()))
+		})
+	})
+	Context("EC2NodeClass", func() {
+		It("should not update a metadata generation when the same resource is applied for the v1beta1 APIs", func() {
+			// created v1beta1 resource
+			storedv1beta1nodeclass := test.BetaEC2NodeClass()
+
+			env.ExpectCreated(storedv1beta1nodeclass.DeepCopy())
+			v1beta1nodeclass := env.ExpectExists(storedv1beta1nodeclass.DeepCopy()).(*v1beta1.EC2NodeClass)
+			Expect(v1beta1nodeclass.Generation).To(BeNumerically("==", 1))
+
+			// Second apply of the same NodeClass does not increase the generation
+			env.ExpectUpdated(storedv1beta1nodeclass.DeepCopy())
+			v1beta1nodeclass = env.ExpectExists(storedv1beta1nodeclass).(*v1beta1.EC2NodeClass)
+			Expect(v1beta1nodeclass.Generation).To(BeNumerically("==", 1))
+		})
+		It("should not update a metadata generation when the same resource is applied for v1 APIs", func() {
+			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
+				MaxPods:     lo.ToPtr(int32(110)),
+				PodsPerCore: lo.ToPtr(int32(10)),
+				SystemReserved: map[string]string{
+					string(corev1.ResourceCPU):              "200m",
+					string(corev1.ResourceMemory):           "200Mi",
+					string(corev1.ResourceEphemeralStorage): "1Gi",
+				},
+				KubeReserved: map[string]string{
+					string(corev1.ResourceCPU):              "200m",
+					string(corev1.ResourceMemory):           "200Mi",
+					string(corev1.ResourceEphemeralStorage): "1Gi",
+				},
+				EvictionHard: map[string]string{
+					"memory.available":   "5%",
+					"nodefs.available":   "5%",
+					"nodefs.inodesFree":  "5%",
+					"imagefs.available":  "5%",
+					"imagefs.inodesFree": "5%",
+					"pid.available":      "3%",
+				},
+				EvictionSoft: map[string]string{
+					"memory.available":   "10%",
+					"nodefs.available":   "10%",
+					"nodefs.inodesFree":  "10%",
+					"imagefs.available":  "10%",
+					"imagefs.inodesFree": "10%",
+					"pid.available":      "6%",
+				},
+				EvictionSoftGracePeriod: map[string]metav1.Duration{
+					"memory.available":   {Duration: time.Minute * 2},
+					"nodefs.available":   {Duration: time.Minute * 2},
+					"nodefs.inodesFree":  {Duration: time.Minute * 2},
+					"imagefs.available":  {Duration: time.Minute * 2},
+					"imagefs.inodesFree": {Duration: time.Minute * 2},
+					"pid.available":      {Duration: time.Minute * 2},
+				},
+				EvictionMaxPodGracePeriod:   lo.ToPtr(int32(120)),
+				ImageGCHighThresholdPercent: lo.ToPtr(int32(50)),
+				ImageGCLowThresholdPercent:  lo.ToPtr(int32(10)),
+				CPUCFSQuota:                 lo.ToPtr(false),
+			}
+			// Use a deepcopy to make sure the nodePool object is not populated with the returned object from the APIServer
+			env.ExpectCreated(nodeClass.DeepCopy())
+			v1nodeclass := env.ExpectExists(nodeClass.DeepCopy()).(*v1.EC2NodeClass)
+			Expect(v1nodeclass.Generation).To(BeNumerically("==", 1))
+
+			// Second apply of the same NodeClass does not increase the generation
+			env.ExpectUpdated(nodeClass.DeepCopy())
+			v1nodeclass = env.ExpectExists(nodeClass.DeepCopy()).(*v1.EC2NodeClass)
+			Expect(v1nodeclass.Generation).To(BeNumerically("==", 1))
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- As part of the conversion webhooks, it is possible to apply the same resource multiple times and have the resource generation increase each time. Adding testing to make sure the resource generation does not increases for applying the same resource multiple times. 

**How was this change tested?**
- `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.