### PR TITLE
test: deflake termination grace period tests

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -289,11 +289,7 @@ func (env *Environment) EventuallyExpectTerminatingWithTimeout(timeout time.Dura
 	Eventually(func(g Gomega) {
 		for _, pod := range pods {
 			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
-			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
-			g.Expect(pod.Status.Conditions).To(ContainElement(And(
-				HaveField("Type", Equal(corev1.DisruptionTarget)),
-				HaveField("Status", Equal(corev1.ConditionTrue)),
-			)))
+			g.Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 		}
 	}).WithTimeout(timeout).Should(Succeed())
 }

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -317,11 +317,7 @@ func (env *Environment) ConsistentlyExpectTerminatingPods(duration time.Duration
 	Consistently(func(g Gomega) {
 		for _, pod := range pods {
 			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
-			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
-			g.Expect(pod.Status.Conditions).To(ContainElement(And(
-				HaveField("Type", Equal(corev1.DisruptionTarget)),
-				HaveField("Status", Equal(corev1.ConditionTrue)),
-			)))
+			g.Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 		}
 	}, duration.String()).Should(Succeed())
 }

--- a/test/suites/termination/termination_grace_period_test.go
+++ b/test/suites/termination/termination_grace_period_test.go
@@ -33,20 +33,19 @@ import (
 var _ = Describe("TerminationGracePeriod", func() {
 	BeforeEach(func() {
 		nodePool.Spec.Template.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 30}
-		// Set the expireAfter value to get the node deleted
-		nodePool.Spec.Template.Spec.ExpireAfter = karpv1.MustParseNillableDuration("90s")
 	})
-	It("should delete pod that tolerates do-not-disrupt after termination grace period seconds", func() {
+	It("should delete pod with do-not-disrupt when it reaches its terminationGracePeriodSeconds", func() {
 		pod := coretest.UnschedulablePod(coretest.PodOptions{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 			karpv1.DoNotDisruptAnnotationKey: "true",
-		}}})
+		}}, TerminationGracePeriodSeconds: lo.ToPtr(int64(15))})
 		env.ExpectCreated(nodeClass, nodePool, pod)
 
 		nodeClaim := env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
 		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
 		env.EventuallyExpectHealthy(pod)
-		// Check that pod remains healthy until termination grace period
-		env.ConsistentlyExpectHealthyPods(time.Second*30, pod)
+
+		// Delete the nodeclaim to start the TerminationGracePeriod
+		env.ExpectDeleted(nodeClaim)
 
 		// Eventually the node will be tainted
 		Eventually(func(g Gomega) {
@@ -55,19 +54,28 @@ var _ = Describe("TerminationGracePeriod", func() {
 				return karpv1.IsDisruptingTaint(t)
 			})
 			g.Expect(ok).To(BeTrue())
-		}).Should(Succeed())
+		}).WithTimeout(3 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		// Check that pod remains healthy until termination grace period
+		// subtract the polling time of the eventually above to reduce any races.
+		env.ConsistentlyExpectHealthyPods(time.Second*15-100*time.Millisecond, pod)
 		// Both nodeClaim and node should be gone once terminationGracePeriod is reached
-		env.EventuallyExpectNotFound(nodeClaim, node)
+		env.EventuallyExpectNotFound(nodeClaim, node, pod)
 	})
 	It("should delete pod that has a pre-stop hook after termination grace period seconds", func() {
-		pod := coretest.UnschedulablePod(coretest.PodOptions{PreStopSleep: lo.ToPtr(int64(300))})
+		pod := coretest.UnschedulablePod(coretest.PodOptions{
+			PreStopSleep:                  lo.ToPtr(int64(300)),
+			TerminationGracePeriodSeconds: lo.ToPtr(int64(15)),
+			Image:                         "alpine:3.20.2",
+			Command:                       []string{"/bin/sh", "-c", "sleep 30"}})
 		env.ExpectCreated(nodeClass, nodePool, pod)
 
 		nodeClaim := env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
 		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
 		env.EventuallyExpectHealthy(pod)
-		// Check that pod remains healthy until termination grace period
-		env.ConsistentlyExpectHealthyPods(time.Second*30, pod)
+
+		// Delete the nodeclaim to start the TerminationGracePeriod
+		env.ExpectDeleted(nodeClaim)
 
 		// Eventually the node will be tainted
 		Eventually(func(g Gomega) {
@@ -76,8 +84,15 @@ var _ = Describe("TerminationGracePeriod", func() {
 				return karpv1.IsDisruptingTaint(t)
 			})
 			g.Expect(ok).To(BeTrue())
-		}).Should(Succeed())
+		}).WithTimeout(3 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		env.EventuallyExpectTerminating(pod)
+
+		// Check that pod remains healthy until termination grace period
+		// subtract the polling time of the eventually above to reduce any races.
+		env.ConsistentlyExpectTerminatingPods(time.Second*15-100*time.Millisecond, pod)
+
 		// Both nodeClaim and node should be gone once terminationGracePeriod is reached
-		env.EventuallyExpectNotFound(nodeClaim, node)
+		env.EventuallyExpectNotFound(nodeClaim, node, pod)
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Deflakes termination Grace Period e2e tests that were failing, and speeds them up by directly deleting the nodeclaim rather than waiting for 90s expiration

**How was this change tested?**
make e2etests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.