### PR TITLE
Ubuntu Backport and Version Bump v0.34.x

### DIFF
--- a/charts/karpenter-crd/values.yaml
+++ b/charts/karpenter-crd/values.yaml
@@ -1,6 +1,6 @@
 webhook:
   # -- Whether to enable the webhooks and webhook permissions.
-  enabled: true
+  enabled: false
   serviceName: karpenter
   serviceNamespace: kube-system
   # -- The container port to use for the webhook.

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v0.34.7-0.20240808010849-b2f81828aff0
+	sigs.k8s.io/karpenter v0.34.7-0.20240812074104-8d610f09d15e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -760,8 +760,8 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.34.7-0.20240808010849-b2f81828aff0 h1:TKHTIERNLqGkRDdaFAXl8EIOtuP4sblyXsk1KPa3goU=
-sigs.k8s.io/karpenter v0.34.7-0.20240808010849-b2f81828aff0/go.mod h1:YznL/hZkxTt5DMABADIwPoaf1tqWBZQA8Y1jSd3P1ZM=
+sigs.k8s.io/karpenter v0.34.7-0.20240812074104-8d610f09d15e h1:oUcdy3YLRF1vfEZ5+ti3HyNsqYRN2WQ9PeMASDzjpOQ=
+sigs.k8s.io/karpenter v0.34.7-0.20240812074104-8d610f09d15e/go.mod h1:YznL/hZkxTt5DMABADIwPoaf1tqWBZQA8Y1jSd3P1ZM=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -472,6 +472,12 @@ func (in *EC2NodeClass) InstanceProfileTags(clusterName string) map[string]strin
 	})
 }
 
+// UbuntuIncompatible returns true if the NodeClass has the ubuntu compatibility annotation. This will cause the NodeClass to show
+// as NotReady in its status conditions, opting its referencing NodePools out of provisioning and drift.
+func (in *EC2NodeClass) UbuntuIncompatible() bool {
+	return lo.Contains(strings.Split(in.Annotations[AnnotationUbuntuCompatibilityKey], ","), AnnotationUbuntuCompatibilityIncompatible)
+}
+
 // AMIFamily returns the family for a NodePool based on the following items, in order of precdence:
 //   - ec2nodeclass.spec.amiFamily
 //   - ec2nodeclass.spec.amiSelectorTerms[].alias

--- a/pkg/apis/v1/ec2nodeclass_conversion.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion.go
@@ -35,6 +35,11 @@ func (in *EC2NodeClass) ConvertTo(ctx context.Context, to apis.Convertible) erro
 
 	if value, ok := in.Annotations[AnnotationUbuntuCompatibilityKey]; ok {
 		compatSpecifiers := strings.Split(value, ",")
+		// Remove the `id: ami-placeholder` AMISelectorTerms that are injected to pass CRD validation at v1
+		// we don't need these in v1beta1, and should be dropped
+		if lo.Contains(compatSpecifiers, AnnotationUbuntuCompatibilityIncompatible) {
+			in.Spec.AMISelectorTerms = nil
+		}
 		// The only blockDeviceMappings present on the v1 EC2NodeClass are those that we injected during conversion.
 		// These should be dropped.
 		if lo.Contains(compatSpecifiers, AnnotationUbuntuCompatibilityBlockDeviceMappings) {
@@ -133,13 +138,6 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 			in.Spec.AMIFamily = v1beta1enc.Spec.AMIFamily
 		}
 	case AMIFamilyUbuntu:
-		// If there are no AMISelectorTerms specified, we will fail closed when converting the NodeClass. Users must
-		// pin their AMIs **before** upgrading to Karpenter v1.0.0 if they were using the Ubuntu AMIFamily.
-		// TODO: jmdeal@ verify doc link to the upgrade guide once available
-		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
-			return fmt.Errorf("converting EC2NodeClass %q from v1beta1 to v1, automatic Ubuntu AMI discovery is not supported (https://karpenter.sh/v1.0/upgrading/upgrade-guide/)", v1beta1enc.Name)
-		}
-
 		// If AMISelectorTerms were specified, we can continue to use them to discover Ubuntu AMIs and use the AL2 AMI
 		// family for bootstrapping. AL2 and Ubuntu have an identical UserData format, but do have different default
 		// BlockDeviceMappings. We'll set the BlockDeviceMappings to Ubuntu's default if no user specified
@@ -158,6 +156,16 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 				},
 			}}
 		}
+
+		// If there are no AMISelectorTerms specified, we mark the ec2nodeclass as incompatible.
+		// Karpenter will ignore incompatible ec2nodeclasses for provisioning and computing drift.
+		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
+			compatSpecifiers = append(compatSpecifiers, AnnotationUbuntuCompatibilityIncompatible)
+			in.Spec.AMISelectorTerms = []AMISelectorTerm{{
+				ID: "ami-placeholder",
+			}}
+		}
+
 		// This compatibility annotation will be used to determine if the amiFamily was mutated from Ubuntu to AL2, and
 		// if we needed to inject any blockDeviceMappings. This is required to enable a round-trip conversion.
 		in.Annotations = lo.Assign(in.Annotations, map[string]string{

--- a/pkg/apis/v1/ec2nodeclass_conversion_test.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion_test.go
@@ -437,10 +437,11 @@ var _ = Describe("Convert v1beta1 to v1 EC2NodeClass API", func() {
 				},
 			}}))
 		})
-		It("should fail to convert v1beta1 ec2nodeclass when amiFamily is Ubuntu (without amiSelectorTerms)", func() {
+		It("should convert v1beta1 ec2nodeclass when amiFamily is Ubuntu (without amiSelectorTerms) but mark incompatible", func() {
 			v1beta1ec2nodeclass.Spec.AMIFamily = lo.ToPtr(v1beta1.AMIFamilyUbuntu)
 			v1beta1ec2nodeclass.Spec.AMISelectorTerms = nil
-			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).ToNot(Succeed())
+			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).To(Succeed())
+			Expect(v1ec2nodeclass.UbuntuIncompatible()).To(BeTrue())
 		})
 		It("should convert v1beta1 ec2nodeclass user data", func() {
 			v1beta1ec2nodeclass.Spec.UserData = lo.ToPtr("test user data")

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -123,6 +123,7 @@ var (
 	AnnotationInstanceTagged                  = Group + "/tagged"
 
 	AnnotationUbuntuCompatibilityKey                 = CompatibilityGroup + "/v1beta1-ubuntu"
+	AnnotationUbuntuCompatibilityIncompatible        = "incompatible"
 	AnnotationUbuntuCompatibilityAMIFamily           = "amiFamily"
 	AnnotationUbuntuCompatibilityBlockDeviceMappings = "blockDeviceMappings"
 

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -164,8 +164,8 @@ func (env *Environment) DefaultNodePool(nodeClass *v1beta1.EC2NodeClass) *corev1
 			Values:   []string{"2"},
 		},
 	}
-	nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{}
-	nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+	nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("Never"))
+	nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 	nodePool.Spec.Limits = corev1beta1.Limits(v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1000"),
 		v1.ResourceMemory: resource.MustParse("1000Gi"),

--- a/test/suites/chaos/suite_test.go
+++ b/test/suites/chaos/suite_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Chaos", func() {
 			defer cancel()
 
 			nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(30 * time.Second)}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("30s"))
 			numPods := 1
 			dep := coretest.Deployment(coretest.DeploymentOptions{
 				Replicas: int32(numPods),

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Consolidation", func() {
 		})
 		It("should respect budgets for non-empty delete consolidation", func() {
 			// This test will hold consolidation until we are ready to execute it
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("Never"))
 
 			nodePool = test.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
@@ -219,7 +219,7 @@ var _ = Describe("Consolidation", func() {
 		It("should respect budgets for non-empty replace consolidation", func() {
 			appLabels := map[string]string{"app": "large-app"}
 			// This test will hold consolidation until we are ready to execute it
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("Never"))
 
 			nodePool = test.ReplaceRequirements(nodePool,
 				v1.NodeSelectorRequirement{
@@ -398,7 +398,7 @@ var _ = Describe("Consolidation", func() {
 					Disruption: corev1beta1.Disruption{
 						ConsolidationPolicy: corev1beta1.ConsolidationPolicyWhenUnderutilized,
 						// Disable Consolidation until we're ready
-						ConsolidateAfter: &corev1beta1.NillableDuration{},
+						ConsolidateAfter: lo.ToPtr(corev1beta1.MustParseNillableDuration("Never")),
 					},
 					Template: corev1beta1.NodeClaimTemplate{
 						Spec: corev1beta1.NodeClaimSpec{
@@ -470,7 +470,7 @@ var _ = Describe("Consolidation", func() {
 					Disruption: corev1beta1.Disruption{
 						ConsolidationPolicy: corev1beta1.ConsolidationPolicyWhenUnderutilized,
 						// Disable Consolidation until we're ready
-						ConsolidateAfter: &corev1beta1.NillableDuration{},
+						ConsolidateAfter: lo.ToPtr(corev1beta1.MustParseNillableDuration("Never")),
 					},
 					Template: corev1beta1.NodeClaimTemplate{
 						Spec: corev1beta1.NodeClaimSpec{
@@ -593,7 +593,7 @@ var _ = Describe("Consolidation", func() {
 				Disruption: corev1beta1.Disruption{
 					ConsolidationPolicy: corev1beta1.ConsolidationPolicyWhenUnderutilized,
 					// Disable Consolidation until we're ready
-					ConsolidateAfter: &corev1beta1.NillableDuration{},
+					ConsolidateAfter: lo.ToPtr(corev1beta1.MustParseNillableDuration("Never")),
 				},
 				Template: corev1beta1.NodeClaimTemplate{
 					Spec: corev1beta1.NodeClaimSpec{

--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeEach(func() {
 	env.BeforeEach()
 	nodeClass = env.DefaultEC2NodeClass()
 	nodePool = env.DefaultNodePool(nodeClass)
-	nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
+	nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("30s")
 })
 
 var _ = AfterEach(func() { env.Cleanup() })
@@ -106,7 +106,7 @@ var _ = Describe("Expiration", func() {
 			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
 				Nodes: "100%",
 			}}
-			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{}
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 
 			// Create a deployment with one pod to create one node.
 			dep = coretest.Deployment(coretest.DeploymentOptions{
@@ -155,7 +155,7 @@ var _ = Describe("Expiration", func() {
 			env.ExpectUpdated(node)
 
 			By("enabling expiration")
-			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("30s")
 			env.ExpectUpdated(nodePool)
 
 			// Expect that both of the nodes are expired, but not being disrupted
@@ -187,7 +187,7 @@ var _ = Describe("Expiration", func() {
 			nodePool.Spec.Disruption.Budgets = []corev1beta1.Budget{{
 				Nodes: "50%",
 			}}
-			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{}
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 
 			numPods = 6
 			dep = coretest.Deployment(coretest.DeploymentOptions{
@@ -228,7 +228,7 @@ var _ = Describe("Expiration", func() {
 			env.ExpectDeleted(dep)
 
 			By("enabling expiration")
-			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("30s")
 			env.ExpectUpdated(nodePool)
 
 			env.EventuallyExpectExpired(nodeClaims...)
@@ -266,7 +266,7 @@ var _ = Describe("Expiration", func() {
 				Nodes: "50%",
 			}}
 			// disable expiration so that we can enable it later when we want.
-			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{}
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 			numPods = 9
 			dep = coretest.Deployment(coretest.DeploymentOptions{
 				Replicas: int32(numPods),
@@ -312,7 +312,7 @@ var _ = Describe("Expiration", func() {
 
 			By("expiring the nodes")
 			// expire the nodeclaims
-			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("30s")
 			env.ExpectUpdated(nodePool)
 
 			env.EventuallyExpectExpired(nodeClaims...)
@@ -398,7 +398,7 @@ var _ = Describe("Expiration", func() {
 			}
 
 			By("enabling expiration")
-			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{Duration: lo.ToPtr(30 * time.Second)}
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("30s")
 			env.ExpectUpdated(nodePool)
 
 			// Ensure that we get two nodes tainted, and they have overlap during the expiration
@@ -410,7 +410,7 @@ var _ = Describe("Expiration", func() {
 			// Set the expireAfter to "Never" to make sure new node isn't deleted
 			// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
 			// racing at the end of the E2E test, leaking node resources into subsequent tests
-			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+			nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 			env.ExpectUpdated(nodePool)
 
 			for _, node := range nodes {
@@ -487,7 +487,7 @@ var _ = Describe("Expiration", func() {
 		// Set the expireAfter to "Never" to make sure new node isn't deleted
 		// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
 		// racing at the end of the E2E test, leaking node resources into subsequent tests
-		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+		nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained
@@ -528,7 +528,7 @@ var _ = Describe("Expiration", func() {
 		env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
 
 		// Set the expireAfter value to get the node deleted
-		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Minute)
+		nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("1m")
 		env.ExpectUpdated(nodePool)
 
 		env.EventuallyExpectExpired(nodeClaim)
@@ -551,7 +551,7 @@ var _ = Describe("Expiration", func() {
 		// Set the expireAfter to "Never" to make sure new node isn't deleted
 		// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
 		// racing at the end of the E2E test, leaking node resources into subsequent tests
-		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+		nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained

--- a/test/suites/integration/emptiness_test.go
+++ b/test/suites/integration/emptiness_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Emptiness", func() {
 	var numPods int
 	BeforeEach(func() {
 		nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-		nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Duration(0))}
+		nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("0s"))
 
 		numPods = 1
 		dep = test.Deployment(test.DeploymentOptions{
@@ -97,7 +97,7 @@ var _ = Describe("Emptiness", func() {
 		})
 	})
 	It("should terminate an empty node", func() {
-		nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Hour * 300)}
+		nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("300h"))
 
 		const numPods = 1
 		deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
@@ -116,7 +116,7 @@ var _ = Describe("Emptiness", func() {
 		env.EventuallyExpectEmpty(nodeClaim)
 
 		By("waiting for the nodeclaim to deprovision when past its ConsolidateAfter timeout of 0")
-		nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Duration(0))}
+		nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("0s"))
 		env.ExpectUpdated(nodePool)
 
 		env.EventuallyExpectNotFound(nodeClaim, node)

--- a/test/suites/integration/validation_test.go
+++ b/test/suites/integration/validation_test.go
@@ -16,7 +16,6 @@ package integration_test
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
@@ -99,12 +98,12 @@ var _ = Describe("Validation", func() {
 		})
 		It("should error when ttlSecondAfterEmpty is negative", func() {
 			nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(-time.Second)}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("-1s"))
 			Expect(env.Client.Create(env.Context, nodePool)).ToNot(Succeed())
 		})
 		It("should error when ConsolidationPolicy=WhenUnderutilized is used with consolidateAfter", func() {
 			nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenUnderutilized
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Minute)}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("1m"))
 			Expect(env.Client.Create(env.Context, nodePool)).ToNot(Succeed())
 		})
 		It("should error if imageGCHighThresholdPercent is less than imageGCLowThresholdPercent", func() {

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"knative.dev/pkg/ptr"
 
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/test"
@@ -236,8 +235,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			// Enable consolidation, emptiness, and expiration
 			nodePoolMap[consolidationValue].Spec.Disruption.ConsolidateAfter = nil
 			nodePoolMap[emptinessValue].Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-			nodePoolMap[emptinessValue].Spec.Disruption.ConsolidateAfter.Duration = ptr.Duration(0)
-			nodePoolMap[expirationValue].Spec.Disruption.ExpireAfter.Duration = ptr.Duration(0)
+			nodePoolMap[emptinessValue].Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("0s"))
+			nodePoolMap[expirationValue].Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("0s")
 			nodePoolMap[expirationValue].Spec.Limits = disableProvisioningLimits
 			// Update the drift NodeClass to start drift on Nodes assigned to this NodeClass
 			driftNodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyBottlerocket
@@ -544,7 +543,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			env.MeasureDeprovisioningDurationFor(func() {
 				By("kicking off deprovisioning emptiness by setting the ttlSecondsAfterEmpty value on the nodePool")
 				nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-				nodePool.Spec.Disruption.ConsolidateAfter.Duration = ptr.Duration(0)
+				nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("0s"))
 				env.ExpectCreatedOrUpdated(nodePool)
 
 				env.EventuallyExpectDeletedNodeCount("==", expectedNodeCount)
@@ -597,13 +596,13 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				// Change limits so that replacement nodes will use another nodePool.
 				nodePool.Spec.Limits = disableProvisioningLimits
 				// Enable Expiration
-				nodePool.Spec.Disruption.ExpireAfter.Duration = ptr.Duration(0)
+				nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("0s")
 
 				noExpireNodePool := test.NodePool(*nodePool.DeepCopy())
 
 				// Disable Expiration
-				noExpireNodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{}
-				noExpireNodePool.Spec.Disruption.ExpireAfter.Duration = nil
+				noExpireNodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("Never"))
+				noExpireNodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 
 				noExpireNodePool.ObjectMeta = metav1.ObjectMeta{Name: test.RandomName()}
 				noExpireNodePool.Spec.Template.Spec.Kubelet = &corev1beta1.KubeletConfiguration{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Backports #6699's conversion webhook updates, bumps sigs.k8s.io/karpenter, and disables webhooks in the CRD chart by default.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.