### PR TITLE
Ubuntu Backport and Version Bump v0.33.x

### DIFF
--- a/charts/karpenter-crd/values.yaml
+++ b/charts/karpenter-crd/values.yaml
@@ -1,6 +1,6 @@
 webhook:
   # -- Whether to enable the webhooks and webhook permissions.
-  enabled: true
+  enabled: false
   serviceName: karpenter
   serviceNamespace: kube-system
   # -- The container port to use for the webhook.

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -64,6 +64,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podDisruptionBudget.name | string | `"karpenter"` |  |
 | podLabels | object | `{}` | Additional labels for the pod. |
+| postInstallHook.image | string | `public.ecr.aws/bitnami/kubectl:1.30` | The image to run the post-install hook. This minimally needs to have `kubectl` installed |
 | priorityClassName | string | `"system-cluster-critical"` | PriorityClass name for the pod. |
 | replicas | int | `2` | Number of replicas. |
 | revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback. |

--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -75,6 +75,17 @@ Karpenter image to use
 {{- end }}
 {{- end }}
 
+{{/*
+Karpenter post-install hook image to use
+*/}}
+{{- define "karpenter.postInstallHook.image" -}}
+{{- if .Values.postInstallHook.image.digest }}
+{{- printf "%s:%s@%s" .Values.postInstallHook.image.repository  (default (printf "v%s" .Chart.AppVersion) .Values.postInstallHook.image.tag) .Values.postInstallHook.image.digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.postInstallHook.image.repository  (default (printf "v%s" .Chart.AppVersion) .Values.postInstallHook.image.tag) }}
+{{- end }}
+{{- end }}
+
 
 {{/* Get PodDisruptionBudget API Version */}}
 {{- define "karpenter.pdb.apiVersion" -}}

--- a/charts/karpenter/templates/post-install-hook.yaml
+++ b/charts/karpenter/templates/post-install-hook.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
       - name: post-install-job
-        image: public.ecr.aws/bitnami/kubectl:1.30
+        image: {{ include "karpenter.postInstallHook.image" . }}
         command:
         - /bin/sh
         - -c

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -132,6 +132,14 @@ controller:
   healthProbe:
     # -- The container port to use for http health probe.
     port: 8081
+postInstallHook: 
+  image:
+    # -- Repository path to the post-install hook. This minimally needs to have `kubectl` installed
+    repository: public.ecr.aws/bitnami/kubectl
+    # -- Tag of the post-install hook image.
+    tag: "1.30"
+    # -- SHA256 digest of the post-install hook image.
+    digest: sha256:13a2ad1bd37ce42ee2a6f1ab0d30595f42eb7fe4a90d6ec848550524104a1ed6
 webhook:
   # -- Whether to enable the webhooks and webhook permissions.
   enabled: false

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v0.33.6-0.20240808010853-b68592b331c3
+	sigs.k8s.io/karpenter v0.33.6-0.20240812073634-d2266e58fbae
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v0.33.6-0.20240812073634-d2266e58fbae
+	sigs.k8s.io/karpenter v0.33.6-0.20240812193343-34be3540bb3c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -760,8 +760,8 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.33.6-0.20240812073634-d2266e58fbae h1:J10rnVDklc6N6pZP5qY+n4N8CQ9i1j60S2YeRQiQ25E=
-sigs.k8s.io/karpenter v0.33.6-0.20240812073634-d2266e58fbae/go.mod h1:CpSddDzJyNGROic0uqiYM/+p7c/8iO7zshDf+rd1gJY=
+sigs.k8s.io/karpenter v0.33.6-0.20240812193343-34be3540bb3c h1:mWnr502ypZlyW+NngPxMNMHEzrhI+f5KA5YHQlpACwI=
+sigs.k8s.io/karpenter v0.33.6-0.20240812193343-34be3540bb3c/go.mod h1:CpSddDzJyNGROic0uqiYM/+p7c/8iO7zshDf+rd1gJY=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/go.sum
+++ b/go.sum
@@ -760,8 +760,8 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.33.6-0.20240808010853-b68592b331c3 h1:oOGx0IVMsjhc/paRo5NidaSpkoRYG8AOoJvEK949FmE=
-sigs.k8s.io/karpenter v0.33.6-0.20240808010853-b68592b331c3/go.mod h1:CpSddDzJyNGROic0uqiYM/+p7c/8iO7zshDf+rd1gJY=
+sigs.k8s.io/karpenter v0.33.6-0.20240812073634-d2266e58fbae h1:J10rnVDklc6N6pZP5qY+n4N8CQ9i1j60S2YeRQiQ25E=
+sigs.k8s.io/karpenter v0.33.6-0.20240812073634-d2266e58fbae/go.mod h1:CpSddDzJyNGROic0uqiYM/+p7c/8iO7zshDf+rd1gJY=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -472,6 +472,12 @@ func (in *EC2NodeClass) InstanceProfileTags(clusterName string) map[string]strin
 	})
 }
 
+// UbuntuIncompatible returns true if the NodeClass has the ubuntu compatibility annotation. This will cause the NodeClass to show
+// as NotReady in its status conditions, opting its referencing NodePools out of provisioning and drift.
+func (in *EC2NodeClass) UbuntuIncompatible() bool {
+	return lo.Contains(strings.Split(in.Annotations[AnnotationUbuntuCompatibilityKey], ","), AnnotationUbuntuCompatibilityIncompatible)
+}
+
 // AMIFamily returns the family for a NodePool based on the following items, in order of precdence:
 //   - ec2nodeclass.spec.amiFamily
 //   - ec2nodeclass.spec.amiSelectorTerms[].alias

--- a/pkg/apis/v1/ec2nodeclass_conversion.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion.go
@@ -35,6 +35,11 @@ func (in *EC2NodeClass) ConvertTo(ctx context.Context, to apis.Convertible) erro
 
 	if value, ok := in.Annotations[AnnotationUbuntuCompatibilityKey]; ok {
 		compatSpecifiers := strings.Split(value, ",")
+		// Remove the `id: ami-placeholder` AMISelectorTerms that are injected to pass CRD validation at v1
+		// we don't need these in v1beta1, and should be dropped
+		if lo.Contains(compatSpecifiers, AnnotationUbuntuCompatibilityIncompatible) {
+			in.Spec.AMISelectorTerms = nil
+		}
 		// The only blockDeviceMappings present on the v1 EC2NodeClass are those that we injected during conversion.
 		// These should be dropped.
 		if lo.Contains(compatSpecifiers, AnnotationUbuntuCompatibilityBlockDeviceMappings) {
@@ -132,13 +137,6 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 			in.Spec.AMIFamily = v1beta1enc.Spec.AMIFamily
 		}
 	case AMIFamilyUbuntu:
-		// If there are no AMISelectorTerms specified, we will fail closed when converting the NodeClass. Users must
-		// pin their AMIs **before** upgrading to Karpenter v1.0.0 if they were using the Ubuntu AMIFamily.
-		// TODO: jmdeal@ verify doc link to the upgrade guide once available
-		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
-			return fmt.Errorf("converting EC2NodeClass %q from v1beta1 to v1, automatic Ubuntu AMI discovery is not supported (https://karpenter.sh/v1.0/upgrading/upgrade-guide/)", v1beta1enc.Name)
-		}
-
 		// If AMISelectorTerms were specified, we can continue to use them to discover Ubuntu AMIs and use the AL2 AMI
 		// family for bootstrapping. AL2 and Ubuntu have an identical UserData format, but do have different default
 		// BlockDeviceMappings. We'll set the BlockDeviceMappings to Ubuntu's default if no user specified
@@ -157,6 +155,16 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 				},
 			}}
 		}
+
+		// If there are no AMISelectorTerms specified, we mark the ec2nodeclass as incompatible.
+		// Karpenter will ignore incompatible ec2nodeclasses for provisioning and computing drift.
+		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
+			compatSpecifiers = append(compatSpecifiers, AnnotationUbuntuCompatibilityIncompatible)
+			in.Spec.AMISelectorTerms = []AMISelectorTerm{{
+				ID: "ami-placeholder",
+			}}
+		}
+
 		// This compatibility annotation will be used to determine if the amiFamily was mutated from Ubuntu to AL2, and
 		// if we needed to inject any blockDeviceMappings. This is required to enable a round-trip conversion.
 		in.Annotations = lo.Assign(in.Annotations, map[string]string{

--- a/pkg/apis/v1/ec2nodeclass_conversion_test.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion_test.go
@@ -432,10 +432,11 @@ var _ = Describe("Convert v1beta1 to v1 EC2NodeClass API", func() {
 				},
 			}}))
 		})
-		It("should fail to convert v1beta1 ec2nodeclass when amiFamily is Ubuntu (without amiSelectorTerms)", func() {
+		It("should convert v1beta1 ec2nodeclass when amiFamily is Ubuntu (without amiSelectorTerms) but mark incompatible", func() {
 			v1beta1ec2nodeclass.Spec.AMIFamily = lo.ToPtr(v1beta1.AMIFamilyUbuntu)
 			v1beta1ec2nodeclass.Spec.AMISelectorTerms = nil
-			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).ToNot(Succeed())
+			Expect(v1ec2nodeclass.ConvertFrom(ctx, v1beta1ec2nodeclass)).To(Succeed())
+			Expect(v1ec2nodeclass.UbuntuIncompatible()).To(BeTrue())
 		})
 		It("should convert v1beta1 ec2nodeclass user data", func() {
 			v1beta1ec2nodeclass.Spec.UserData = lo.ToPtr("test user data")

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -123,6 +123,7 @@ var (
 	AnnotationInstanceTagged                  = Group + "/tagged"
 
 	AnnotationUbuntuCompatibilityKey                 = CompatibilityGroup + "/v1beta1-ubuntu"
+	AnnotationUbuntuCompatibilityIncompatible        = "incompatible"
 	AnnotationUbuntuCompatibilityAMIFamily           = "amiFamily"
 	AnnotationUbuntuCompatibilityBlockDeviceMappings = "blockDeviceMappings"
 

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -164,8 +164,8 @@ func (env *Environment) DefaultNodePool(nodeClass *v1beta1.EC2NodeClass) *corev1
 			Values:   []string{"2"},
 		},
 	}
-	nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{}
-	nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+	nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("Never"))
+	nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 	nodePool.Spec.Limits = corev1beta1.Limits(v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1000"),
 		v1.ResourceMemory: resource.MustParse("1000Gi"),

--- a/test/suites/chaos/suite_test.go
+++ b/test/suites/chaos/suite_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Chaos", func() {
 			defer cancel()
 
 			nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(30 * time.Second)}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("30s"))
 			numPods := 1
 			dep := coretest.Deployment(coretest.DeploymentOptions{
 				Replicas: int32(numPods),

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +69,7 @@ var _ = Describe("Consolidation", func() {
 				Disruption: corev1beta1.Disruption{
 					ConsolidationPolicy: corev1beta1.ConsolidationPolicyWhenUnderutilized,
 					// Disable Consolidation until we're ready
-					ConsolidateAfter: &corev1beta1.NillableDuration{},
+					ConsolidateAfter: lo.ToPtr(corev1beta1.MustParseNillableDuration("Never")),
 				},
 				Template: corev1beta1.NodeClaimTemplate{
 					Spec: corev1beta1.NodeClaimSpec{
@@ -137,7 +138,7 @@ var _ = Describe("Consolidation", func() {
 				Disruption: corev1beta1.Disruption{
 					ConsolidationPolicy: corev1beta1.ConsolidationPolicyWhenUnderutilized,
 					// Disable Consolidation until we're ready
-					ConsolidateAfter: &corev1beta1.NillableDuration{},
+					ConsolidateAfter: lo.ToPtr(corev1beta1.MustParseNillableDuration("Never")),
 				},
 				Template: corev1beta1.NodeClaimTemplate{
 					Spec: corev1beta1.NodeClaimSpec{
@@ -258,7 +259,7 @@ var _ = Describe("Consolidation", func() {
 				Disruption: corev1beta1.Disruption{
 					ConsolidationPolicy: corev1beta1.ConsolidationPolicyWhenUnderutilized,
 					// Disable Consolidation until we're ready
-					ConsolidateAfter: &corev1beta1.NillableDuration{},
+					ConsolidateAfter: lo.ToPtr(corev1beta1.MustParseNillableDuration("Never")),
 				},
 				Template: corev1beta1.NodeClaimTemplate{
 					Spec: corev1beta1.NodeClaimSpec{

--- a/test/suites/expiration/suite_test.go
+++ b/test/suites/expiration/suite_test.go
@@ -58,7 +58,7 @@ var _ = BeforeEach(func() {
 	env.BeforeEach()
 	nodeClass = env.DefaultEC2NodeClass()
 	nodePool = env.DefaultNodePool(nodeClass)
-	nodePool.Spec.Disruption.ExpireAfter = corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
+	nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("30s")
 })
 
 var _ = AfterEach(func() { env.Cleanup() })
@@ -110,7 +110,7 @@ var _ = Describe("Expiration", func() {
 		// Set the expireAfter to "Never" to make sure new node isn't deleted
 		// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
 		// racing at the end of the E2E test, leaking node resources into subsequent tests
-		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+		nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained
@@ -151,7 +151,7 @@ var _ = Describe("Expiration", func() {
 		env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
 
 		// Set the expireAfter value to get the node deleted
-		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Minute)
+		nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("1m")
 		env.ExpectUpdated(nodePool)
 
 		// Expect that the NodeClaim will get an expired status condition
@@ -178,7 +178,7 @@ var _ = Describe("Expiration", func() {
 		// Set the expireAfter to "Never" to make sure new node isn't deleted
 		// This is CRITICAL since it prevents nodes that are immediately spun up from immediately being expired and
 		// racing at the end of the E2E test, leaking node resources into subsequent tests
-		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+		nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("Never")
 		env.ExpectUpdated(nodePool)
 
 		// After the deletion timestamp is set and all pods are drained

--- a/test/suites/integration/emptiness_test.go
+++ b/test/suites/integration/emptiness_test.go
@@ -15,8 +15,6 @@ limitations under the License.
 package integration_test
 
 import (
-	"time"
-
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/pkg/ptr"
@@ -33,7 +31,7 @@ import (
 var _ = Describe("Emptiness", func() {
 	It("should terminate an empty node", func() {
 		nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-		nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Hour * 300)}
+		nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("300h"))
 
 		const numPods = 1
 		deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
@@ -56,7 +54,7 @@ var _ = Describe("Emptiness", func() {
 		}).Should(Succeed())
 
 		By("waiting for the nodeclaim to deprovision when past its ConsolidateAfter timeout of 0")
-		nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Duration(0))}
+		nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("0s"))
 		env.ExpectUpdated(nodePool)
 
 		env.EventuallyExpectNotFound(nodeClaim, node)

--- a/test/suites/integration/validation_test.go
+++ b/test/suites/integration/validation_test.go
@@ -16,7 +16,6 @@ package integration_test
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
@@ -99,12 +98,12 @@ var _ = Describe("Validation", func() {
 		})
 		It("should error when ttlSecondAfterEmpty is negative", func() {
 			nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(-time.Second)}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("-1s"))
 			Expect(env.Client.Create(env.Context, nodePool)).ToNot(Succeed())
 		})
 		It("should error when ConsolidationPolicy=WhenUnderutilized is used with consolidateAfter", func() {
 			nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenUnderutilized
-			nodePool.Spec.Disruption.ConsolidateAfter = &corev1beta1.NillableDuration{Duration: lo.ToPtr(time.Minute)}
+			nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("1m"))
 			Expect(env.Client.Create(env.Context, nodePool)).ToNot(Succeed())
 		})
 		It("should error if imageGCHighThresholdPercent is less than imageGCLowThresholdPercent", func() {

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"knative.dev/pkg/ptr"
 
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/test"
@@ -236,8 +235,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			// Enable consolidation, emptiness, and expiration
 			nodePoolMap[consolidationValue].Spec.Disruption.ConsolidateAfter = nil
 			nodePoolMap[emptinessValue].Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-			nodePoolMap[emptinessValue].Spec.Disruption.ConsolidateAfter.Duration = ptr.Duration(0)
-			nodePoolMap[expirationValue].Spec.Disruption.ExpireAfter.Duration = ptr.Duration(0)
+			nodePoolMap[emptinessValue].Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("0s"))
+			nodePoolMap[expirationValue].Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("0s")
 			nodePoolMap[expirationValue].Spec.Limits = disableProvisioningLimits
 			// Update the drift NodeClass to start drift on Nodes assigned to this NodeClass
 			driftNodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyBottlerocket
@@ -544,7 +543,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			env.MeasureDeprovisioningDurationFor(func() {
 				By("kicking off deprovisioning emptiness by setting the ttlSecondsAfterEmpty value on the nodePool")
 				nodePool.Spec.Disruption.ConsolidationPolicy = corev1beta1.ConsolidationPolicyWhenEmpty
-				nodePool.Spec.Disruption.ConsolidateAfter.Duration = ptr.Duration(0)
+				nodePool.Spec.Disruption.ConsolidateAfter = lo.ToPtr(corev1beta1.MustParseNillableDuration("0s"))
 				env.ExpectCreatedOrUpdated(nodePool)
 
 				env.EventuallyExpectDeletedNodeCount("==", expectedNodeCount)
@@ -597,7 +596,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				// Change limits so that replacement nodes will use another nodePool.
 				nodePool.Spec.Limits = disableProvisioningLimits
 				// Enable Expiration
-				nodePool.Spec.Disruption.ExpireAfter.Duration = ptr.Duration(0)
+				nodePool.Spec.Disruption.ExpireAfter = corev1beta1.MustParseNillableDuration("0s")
 
 				noExpireNodePool := test.NodePool(*nodePool.DeepCopy())
 				noExpireNodePool.ObjectMeta = metav1.ObjectMeta{Name: test.RandomName()}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Backports #6699's conversion webhook changes, bumps sigs.k8s.io/karpenter, and disables webhooks by default

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.