### PR TITLE
chore: revert to using ssm:GetParameter

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -37,7 +37,7 @@ const (
 	AssociatePublicIPAddressTTL = 5 * time.Minute
 	// SSMGetParametersByPathTTL is the time to drop SSM Parameters by path data. This only queries EKS Optimized AMI
 	// releases, so we should expect this to be updated relatively infrequently.
-	SSMGetParametersByPathTTL = 30 * time.Minute
+	SSMGetParametersByPathTTL = 24 * time.Hour
 )
 
 const (

--- a/pkg/fake/ssmapi.go
+++ b/pkg/fake/ssmapi.go
@@ -17,14 +17,9 @@ package fake
 import (
 	"context"
 	"fmt"
-	"log"
-	"regexp"
-	"strings"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/samber/lo"
-
-	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -33,104 +28,57 @@ import (
 
 type SSMAPI struct {
 	ssmiface.SSMAPI
-	Parameters                map[string]string
-	GetParametersByPathOutput *ssm.GetParametersByPathOutput
-	WantErr                   error
+	Parameters         map[string]string
+	GetParameterOutput *ssm.GetParameterOutput
+	WantErr            error
 
-	defaultParametersForPath map[string][]*ssm.Parameter
+	defaultParameters map[string]string
 }
 
 func NewSSMAPI() *SSMAPI {
 	return &SSMAPI{
-		defaultParametersForPath: map[string][]*ssm.Parameter{},
+		defaultParameters: map[string]string{},
 	}
 }
 
-func (a SSMAPI) GetParametersByPathPagesWithContext(_ context.Context, input *ssm.GetParametersByPathInput, f func(*ssm.GetParametersByPathOutput, bool) bool, _ ...request.Option) error {
-	if !lo.FromPtr(input.Recursive) {
-		log.Fatalf("fake SSM API currently only supports GetParametersByPathPagesWithContext when recursive is true")
-	}
+func (a SSMAPI) GetParameterWithContext(_ context.Context, input *ssm.GetParameterInput, _ ...request.Option) (*ssm.GetParameterOutput, error) {
+	parameter := lo.FromPtr(input.Name)
 	if a.WantErr != nil {
-		return a.WantErr
+		return &ssm.GetParameterOutput{}, a.WantErr
 	}
-	if a.GetParametersByPathOutput != nil {
-		f(a.GetParametersByPathOutput, true)
-		return nil
+	if a.GetParameterOutput != nil {
+		return a.GetParameterOutput, nil
 	}
 	if len(a.Parameters) != 0 {
-		f(&ssm.GetParametersByPathOutput{
-			Parameters: lo.FilterMap(lo.Entries(a.Parameters), func(p lo.Entry[string, string], _ int) (*ssm.Parameter, bool) {
-				// The parameter does not start with the path
-				if !strings.HasPrefix(p.Key, lo.FromPtr(input.Path)) {
-					return nil, false
-				}
-				// The parameter starts with the input path, but the last segment of the input path is only a subset of the matching segment of the parameters path.
-				// Ex: "/aws/service/eks-optimized-ami/amazon-linux-2" is a prefix for "/aws/service/eks-optimized-ami/amazon-linux-2-gpu/..." but we shouldn't match
-				if strings.TrimPrefix(p.Key, lo.FromPtr(input.Path))[0] != '/' {
-					return nil, false
-				}
-				return &ssm.Parameter{
-					Name:  lo.ToPtr(p.Key),
-					Value: lo.ToPtr(p.Value),
-				}, true
-			}),
-		}, true)
-		return nil
-	}
-	if params := a.getDefaultParametersForPath(lo.FromPtr(input.Path)); params != nil {
-		f(&ssm.GetParametersByPathOutput{Parameters: params}, true)
-		return nil
-	}
-	return fmt.Errorf("path %q does not exist", lo.FromPtr(input.Path))
-}
-
-func (a SSMAPI) getDefaultParametersForPath(path string) []*ssm.Parameter {
-	// If we've already generated default parameters, return the same parameters across calls. This ensures we don't
-	// drift due to different results from one call to the next.
-	if params, ok := a.defaultParametersForPath[path]; ok {
-		return params
-	}
-	suffixes := map[string][]string{
-		`^\/aws\/service\/eks/optimized-ami\/.*\/amazon-linux-2$`:       []string{"recommended/image_id"},
-		`^\/aws\/service\/eks/optimized-ami\/.*\/amazon-linux-2-arm64$`: []string{"recommended/image_id"},
-		`^\/aws\/service\/eks/optimized-ami\/.*\/amazon-linux-2-gpu$`:   []string{"recommended/image_id"},
-		`^\/aws\/service\/eks/optimized-ami\/.*\/amazon-linux-2023$`: []string{
-			"x86_64/standard/recommended/image_id",
-			"arm64/standard/recommended/image_id",
-			"x86_64/nvidia/recommended/image_id",
-			"arm64/nvidia/recommended/image_id",
-			"x86_64/neuron/recommended/image_id",
-			"arm64/neuron/recommended/image_id",
-		},
-		`\/aws\/service\/bottlerocket\/aws-k8s-.*`: []string{
-			"x86_64/latest/image_id",
-			"arm64/latest/image_id",
-		},
-		`\/aws\/service\/ami-windows-latest`: lo.FlatMap(version.SupportedK8sVersions(), func(version string, _ int) []string {
-			return []string{
-				fmt.Sprintf("Windows_Server-2019-English-Core-EKS_Optimized-%s/image_id", version),
-				fmt.Sprintf("Windows_Server-2022-English-Core-EKS_Optimized-%s/image_id", version),
-			}
-		}),
-	}
-	for matchStr, suffixes := range suffixes {
-		if !regexp.MustCompile(matchStr).MatchString(path) {
-			continue
+		value, ok := a.Parameters[parameter]
+		if !ok {
+			return &ssm.GetParameterOutput{}, fmt.Errorf("parameter %q not found", lo.FromPtr(input.Name))
 		}
-		params := lo.Map(suffixes, func(suffix string, _ int) *ssm.Parameter {
-			return &ssm.Parameter{
-				Name:  lo.ToPtr(fmt.Sprintf("%s/%s", path, suffix)),
-				Value: lo.ToPtr(fmt.Sprintf("ami-%s", randomdata.Alphanumeric(16))),
-			}
-		})
-		a.defaultParametersForPath[path] = params
-		return params
+		return &ssm.GetParameterOutput{
+			Parameter: &ssm.Parameter{
+				Name:  lo.ToPtr(parameter),
+				Value: lo.ToPtr(value),
+			},
+		}, nil
 	}
-	return nil
+
+	// Cache default parameters that was successive calls for the same parameter return the same result
+	value, ok := a.defaultParameters[parameter]
+	if !ok {
+		value = fmt.Sprintf("ami-%s", randomdata.Alphanumeric(16))
+		a.defaultParameters[parameter] = value
+	}
+	return &ssm.GetParameterOutput{
+		Parameter: &ssm.Parameter{
+			Name:  lo.ToPtr(parameter),
+			Value: lo.ToPtr(value),
+		},
+	}, nil
 }
 
 func (a *SSMAPI) Reset() {
-	a.GetParametersByPathOutput = nil
 	a.Parameters = nil
+	a.GetParameterOutput = nil
 	a.WantErr = nil
+	a.defaultParameters = map[string]string{}
 }

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -17,8 +17,6 @@ package amifamily
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	corev1 "k8s.io/api/core/v1"
@@ -26,7 +24,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/samber/lo"
 
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -43,57 +40,59 @@ type AL2 struct {
 }
 
 func (a AL2) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
-	imageIDs := make([]*string, 0, 5)
-	requirements := make(map[string][]scheduling.Requirements)
-	// Example Paths:
-	// - Latest EKS 1.30 Standard Image: /aws/service/eks/optimized-ami/1.30/amazon-linux-2/recommended/image_id
-	// - Specific EKS 1.30 GPU Image: /aws/service/eks/optimized-ami/1.30/amazon-linux-2-gpu/amazon-eks-node-1.30-v20240625/image_id
-	for rootPath, variants := range map[string][]Variant{
-		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2", k8sVersion):       {VariantStandard},
-		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64", k8sVersion): {VariantStandard},
-		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu", k8sVersion):   {VariantNeuron, VariantNvidia},
+	ids := map[string][]Variant{}
+	for path, variants := range map[string][]Variant{
+		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/%s/image_id", k8sVersion, lo.Ternary(
+			amiVersion == AMIVersionLatest,
+			"recommended",
+			fmt.Sprintf("amazon-eks-node-%s-%s", k8sVersion, amiVersion),
+		)): {VariantStandard},
+		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/%s/image_id", k8sVersion, lo.Ternary(
+			amiVersion == AMIVersionLatest,
+			"recommended",
+			fmt.Sprintf("amazon-eks-arm64-node-%s-%s", k8sVersion, amiVersion),
+		)): {VariantStandard},
+		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/%s/image_id", k8sVersion, lo.Ternary(
+			amiVersion == AMIVersionLatest,
+			"recommended",
+			fmt.Sprintf("amazon-eks-gpu-node-%s-%s", k8sVersion, amiVersion),
+		)): {VariantNeuron, VariantNvidia},
 	} {
-		results, err := ssmProvider.List(ctx, rootPath)
+		imageID, err := ssmProvider.Get(ctx, path)
 		if err != nil {
-			log.FromContext(ctx).WithValues("path", rootPath, "family", "al2").Error(err, "discovering AMIs from ssm")
 			continue
 		}
-		for path, value := range results {
-			pathComponents := strings.Split(path, "/")
-			// Only select image_id paths which match the desired AMI version
-			if len(pathComponents) != 9 || pathComponents[8] != "image_id" {
-				continue
-			}
-			if av, err := a.extractAMIVersion(pathComponents[7]); err != nil || av != amiVersion {
-				continue
-			}
-			imageIDs = append(imageIDs, lo.ToPtr(value))
-			requirements[value] = lo.Map(variants, func(v Variant, _ int) scheduling.Requirements { return v.Requirements() })
-		}
+		ids[imageID] = variants
 	}
 	// Failed to discover any AMIs, we should short circuit AMI discovery
-	if len(imageIDs) == 0 {
+	if len(ids) == 0 {
 		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "al2@%s"`, amiVersion)
 	}
+
+	// Only inject requirements if we were able to discover accelerated AMIs. If we weren't, we should use the standard
+	// AMI for all nodes.
+	hasAcceleratedAMIs := lo.ContainsBy(lo.Values(ids), func(variants []Variant) bool {
+		for _, v := range variants {
+			if v != VariantStandard {
+				return true
+			}
+		}
+		return false
+	})
+	requirements := map[string][]scheduling.Requirements{}
+	if hasAcceleratedAMIs {
+		requirements = lo.MapValues(ids, func(variants []Variant, _ string) []scheduling.Requirements {
+			return lo.Map(variants, func(v Variant, _ int) scheduling.Requirements { return v.Requirements() })
+		})
+	}
+
 	return DescribeImageQuery{
 		Filters: []*ec2.Filter{{
 			Name:   lo.ToPtr("image-id"),
-			Values: imageIDs,
+			Values: lo.ToSlicePtr(lo.Keys(ids)),
 		}},
 		KnownRequirements: requirements,
 	}, nil
-}
-
-func (a AL2) extractAMIVersion(versionStr string) (string, error) {
-	if versionStr == "recommended" {
-		return AMIVersionLatest, nil
-	}
-	rgx := regexp.MustCompile(`^.*(v\d{8})$`)
-	matches := rgx.FindStringSubmatch(versionStr)
-	if len(matches) != 2 {
-		return "", fmt.Errorf("failed to extract AMI version")
-	}
-	return matches[1], nil
 }
 
 // UserData returns the exact same string for equivalent input,

--- a/pkg/providers/amifamily/al2023.go
+++ b/pkg/providers/amifamily/al2023.go
@@ -17,12 +17,9 @@ package amifamily
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 
@@ -39,71 +36,57 @@ type AL2023 struct {
 }
 
 func (a AL2023) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
-	requirements := make(map[string][]scheduling.Requirements)
-	imageIDs := make([]*string, 0, 5)
-	// Example Paths:
-	// - Latest EKS 1.30 arm64 Standard Image: /aws/service/eks/optimized-ami/1.30/amazon-linux-2023/arm64/standard/recommended/image_id
-	// - Specific EKS 1.30 amd64 Nvidia Image: /aws/service/eks/optimized-ami/1.30/amazon-linux-2023/x86_64/nvidia/amazon-eks-node-al2023-x86_64-nvidia-1.30-v20240625/image_id
-	rootPath := fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023", k8sVersion)
-	results, err := ssmProvider.List(ctx, rootPath)
-	if err != nil {
-		log.FromContext(ctx).WithValues("path", rootPath, "family", "al2023").Error(err, "discovering AMIs from ssm")
-		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "al2023@%s"`, amiVersion)
-	}
-
 	ids := map[string]Variant{}
-	for path, value := range results {
-		pathComponents := strings.Split(path, "/")
-		if len(pathComponents) != 11 || pathComponents[10] != "image_id" {
-			continue
+	for _, arch := range []string{
+		"x86_64",
+		"arm64",
+	} {
+		for _, variant := range []Variant{
+			VariantStandard,
+			VariantNvidia,
+			VariantNeuron,
+		} {
+			path := a.resolvePath(arch, string(variant), k8sVersion, amiVersion)
+			imageID, err := ssmProvider.Get(ctx, path)
+			if err != nil {
+				continue
+			}
+			ids[imageID] = variant
 		}
-		if av, err := a.extractAMIVersion(pathComponents[9]); err != nil || av != amiVersion {
-			continue
-		}
-		variant, err := NewVariant(pathComponents[8])
-		if err != nil {
-			continue
-		}
-		ids[value] = variant
+	}
+	// Failed to discover any AMIs, we should short circuit AMI discovery
+	if len(ids) == 0 {
+		return DescribeImageQuery{}, fmt.Errorf(`failed to discover AMIs for alias "al2023@%s"`, amiVersion)
 	}
 
-	// EKS doesn't currently vend any accelerated AL2023 AMIs. We should schedule all workloads to
-	// these standard AMIs until accelerated AMIs are available. This approach ensures Karpenter is
-	// forwards compatible with acclerated AMIs once they become available.
+	// Only inject requirements if we were able to discover accelerated AMIs. If we weren't, we should use the standard
+	// AMI for all nodes.
 	hasAcceleratedAMIs := lo.ContainsBy(lo.Values(ids), func(v Variant) bool {
 		return v != VariantStandard
 	})
-	for id, variant := range ids {
-		imageIDs = append(imageIDs, lo.ToPtr(id))
-		if hasAcceleratedAMIs {
-			requirements[id] = []scheduling.Requirements{variant.Requirements()}
-		}
-	}
-
-	// Failed to discover any AMIs, we should short circuit AMI discovery
-	if len(imageIDs) == 0 {
-		return DescribeImageQuery{}, fmt.Errorf(`failed to discover AMIs for alias "al2023@%s"`, amiVersion)
+	requirements := map[string][]scheduling.Requirements{}
+	if hasAcceleratedAMIs {
+		requirements = lo.MapValues(ids, func(v Variant, _ string) []scheduling.Requirements {
+			return []scheduling.Requirements{v.Requirements()}
+		})
 	}
 
 	return DescribeImageQuery{
 		Filters: []*ec2.Filter{{
 			Name:   lo.ToPtr("image-id"),
-			Values: imageIDs,
+			Values: lo.ToSlicePtr(lo.Keys(ids)),
 		}},
 		KnownRequirements: requirements,
 	}, nil
 }
 
-func (a AL2023) extractAMIVersion(versionStr string) (string, error) {
-	if versionStr == "recommended" {
-		return AMIVersionLatest, nil
-	}
-	rgx := regexp.MustCompile(`^.*(v\d{8})$`)
-	matches := rgx.FindStringSubmatch(versionStr)
-	if len(matches) != 2 {
-		return "", fmt.Errorf("failed to extract AMI version")
-	}
-	return matches[1], nil
+func (a AL2023) resolvePath(architecture, variant, k8sVersion, amiVersion string) string {
+	name := lo.Ternary(
+		amiVersion == AMIVersionLatest,
+		"recommended",
+		fmt.Sprintf("amazon-eks-node-al2023-%s-%s-%s-%s", architecture, variant, k8sVersion, amiVersion),
+	)
+	return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/%s/%s/%s/image_id", k8sVersion, architecture, variant, name)
 }
 
 func (a AL2023) UserData(kubeletConfig *v1.KubeletConfiguration, taints []corev1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string, instanceStorePolicy *v1.InstanceStorePolicy) bootstrap.Bootstrapper {

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -57,29 +57,14 @@ func (b Bottlerocket) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Pr
 		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "bottlerocket@%s"`, amiVersion)
 	}
 
-	// Only inject requirements if we were able to discover accelerated AMIs. If we weren't, we should use the standard
-	// AMI for all nodes.
-	hasAcceleratedAMIs := lo.ContainsBy(lo.Values(ids), func(variants []Variant) bool {
-		for _, v := range variants {
-			if v != VariantStandard {
-				return true
-			}
-		}
-		return false
-	})
-	requirements := map[string][]scheduling.Requirements{}
-	if hasAcceleratedAMIs {
-		requirements = lo.MapValues(ids, func(variants []Variant, _ string) []scheduling.Requirements {
-			return lo.Map(variants, func(v Variant, _ int) scheduling.Requirements { return v.Requirements() })
-		})
-	}
-
 	return DescribeImageQuery{
 		Filters: []*ec2.Filter{{
 			Name:   lo.ToPtr("image-id"),
 			Values: lo.ToSlicePtr(lo.Keys(ids)),
 		}},
-		KnownRequirements: requirements,
+		KnownRequirements: lo.MapValues(ids, func(variants []Variant, _ string) []scheduling.Requirements {
+			return lo.Map(variants, func(v Variant, _ int) scheduling.Requirements { return v.Requirements() })
+		}),
 	}, nil
 }
 

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -17,11 +17,8 @@ package amifamily
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/samber/lo"
-
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily/bootstrap"
@@ -42,39 +39,45 @@ type Bottlerocket struct {
 }
 
 func (b Bottlerocket) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
-	imageIDs := make([]*string, 0, 5)
-	requirements := make(map[string][]scheduling.Requirements)
-	// Example Paths:
-	// - Latest EKS 1.30 amd64 Standard Image: /aws/service/bottlerocket/aws-k8s-1.30/x86_64/latest/image_id
-	// - Specific EKS 1.30 arm64 Nvidia Image: /aws/service/bottlerocket/aws-k8s-1.30-nvidia/arm64/1.10.0/image_id
-	for rootPath, variants := range map[string][]Variant{
-		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s", k8sVersion):        {VariantStandard},
-		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia", k8sVersion): {VariantNeuron, VariantNvidia},
+	ids := map[string][]Variant{}
+	for path, variants := range map[string][]Variant{
+		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/%s/image_id", k8sVersion, amiVersion):        {VariantStandard},
+		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/%s/image_id", k8sVersion, amiVersion):         {VariantStandard},
+		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/%s/image_id", k8sVersion, amiVersion): {VariantNeuron, VariantNvidia},
+		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/arm64/%s/image_id", k8sVersion, amiVersion):  {VariantNeuron, VariantNvidia},
 	} {
-		results, err := ssmProvider.List(ctx, rootPath)
+		imageID, err := ssmProvider.Get(ctx, path)
 		if err != nil {
-			log.FromContext(ctx).WithValues("path", rootPath, "family", "bottlerocket").Error(err, "discovering AMIs from ssm")
 			continue
 		}
-		for path, value := range results {
-			pathComponents := strings.Split(path, "/")
-			// Only select image_id paths which match the desired AMI version
-			// Note: The SSM path doesn't prefix the version with a v, but Bottlerocket's GitHub releases do. We'll support both.
-			if len(pathComponents) != 8 || pathComponents[7] != "image_id" || pathComponents[6] != strings.TrimPrefix(amiVersion, "v") {
-				continue
-			}
-			imageIDs = append(imageIDs, lo.ToPtr(value))
-			requirements[value] = lo.Map(variants, func(v Variant, _ int) scheduling.Requirements { return v.Requirements() })
-		}
+		ids[imageID] = variants
 	}
 	// Failed to discover any AMIs, we should short circuit AMI discovery
-	if len(imageIDs) == 0 {
+	if len(ids) == 0 {
 		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "bottlerocket@%s"`, amiVersion)
 	}
+
+	// Only inject requirements if we were able to discover accelerated AMIs. If we weren't, we should use the standard
+	// AMI for all nodes.
+	hasAcceleratedAMIs := lo.ContainsBy(lo.Values(ids), func(variants []Variant) bool {
+		for _, v := range variants {
+			if v != VariantStandard {
+				return true
+			}
+		}
+		return false
+	})
+	requirements := map[string][]scheduling.Requirements{}
+	if hasAcceleratedAMIs {
+		requirements = lo.MapValues(ids, func(variants []Variant, _ string) []scheduling.Requirements {
+			return lo.Map(variants, func(v Variant, _ int) scheduling.Requirements { return v.Requirements() })
+		})
+	}
+
 	return DescribeImageQuery{
 		Filters: []*ec2.Filter{{
 			Name:   lo.ToPtr("image-id"),
-			Values: imageIDs,
+			Values: lo.ToSlicePtr(lo.Keys(ids)),
 		}},
 		KnownRequirements: requirements,
 	}, nil

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -17,8 +17,6 @@ package amifamily
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 
@@ -49,39 +47,21 @@ type Windows struct {
 }
 
 func (w Windows) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
-	requirements := make(map[string][]scheduling.Requirements)
-	imageIDs := make([]*string, 0, 5)
-	// Example Path: /aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-1.30/image_id
-	// Note: the version must be latest, this is enforced via CEL validation
-	results, err := ssmProvider.List(ctx, "/aws/service/ami-windows-latest")
+	imageID, err := ssmProvider.Get(ctx, fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-%s-English-%s-EKS_Optimized-%s/image_id", w.Version, v1.WindowsCore, k8sVersion))
 	if err != nil {
-		return DescribeImageQuery{}, fmt.Errorf("discovering AMIs from ssm")
-	}
-	for path, value := range results {
-		pathComponents := strings.Split(path, "/")
-		if len(pathComponents) != 6 || pathComponents[5] != "image_id" {
-			continue
-		}
-		matches := regexp.MustCompile(`^Windows_Server-(\d+)-English-Core-EKS_Optimized-(\d\.\d+)$`).FindStringSubmatch(pathComponents[4])
-		if len(matches) != 3 || matches[1] != w.Version || matches[2] != k8sVersion {
-			continue
-		}
-		imageIDs = append(imageIDs, lo.ToPtr(value))
-		requirements[value] = []scheduling.Requirements{scheduling.NewRequirements(
-			scheduling.NewRequirement(corev1.LabelOSStable, corev1.NodeSelectorOpIn, string(corev1.Windows)),
-			scheduling.NewRequirement(corev1.LabelWindowsBuild, corev1.NodeSelectorOpIn, w.Build),
-		)}
-	}
-	// Failed to discover any AMIs, we should short circuit AMI discovery
-	if len(imageIDs) == 0 {
 		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "windows%s@%s"`, w.Version, amiVersion)
 	}
 	return DescribeImageQuery{
 		Filters: []*ec2.Filter{&ec2.Filter{
 			Name:   lo.ToPtr("image-id"),
-			Values: imageIDs,
+			Values: []*string{lo.ToPtr(imageID)},
 		}},
-		KnownRequirements: requirements,
+		KnownRequirements: map[string][]scheduling.Requirements{
+			imageID: []scheduling.Requirements{scheduling.NewRequirements(
+				scheduling.NewRequirement(corev1.LabelOSStable, corev1.NodeSelectorOpIn, string(corev1.Windows)),
+				scheduling.NewRequirement(corev1.LabelWindowsBuild, corev1.NodeSelectorOpIn, w.Build),
+			)},
+		},
 	}, nil
 }
 

--- a/pkg/providers/ssm/provider.go
+++ b/pkg/providers/ssm/provider.go
@@ -26,7 +26,6 @@ import (
 )
 
 type Provider interface {
-	List(context.Context, string) (map[string]string, error)
 	Get(context.Context, string) (string, error)
 }
 
@@ -43,33 +42,18 @@ func NewDefaultProvider(ssmapi ssmiface.SSMAPI, cache *cache.Cache) *DefaultProv
 	}
 }
 
-func (p *DefaultProvider) Get(ctx context.Context, path string) (string, error) {
-	return "", nil
-}
-
-// List calls GetParametersByPath recursively with the provided input path.
-// The result is a map of paths to values for those paths.
-func (p *DefaultProvider) List(ctx context.Context, path string) (map[string]string, error) {
+func (p *DefaultProvider) Get(ctx context.Context, parameter string) (string, error) {
 	p.Lock()
 	defer p.Unlock()
-	if paths, ok := p.cache.Get(path); ok {
-		return paths.(map[string]string), nil
+	if result, ok := p.cache.Get(parameter); ok {
+		return result.(string), nil
 	}
-	values := map[string]string{}
-	if err := p.ssmapi.GetParametersByPathPagesWithContext(ctx, &ssm.GetParametersByPathInput{
-		Recursive: lo.ToPtr(true),
-		Path:      &path,
-	}, func(out *ssm.GetParametersByPathOutput, _ bool) bool {
-		for _, parameter := range out.Parameters {
-			if parameter.Name == nil || parameter.Value == nil {
-				continue
-			}
-			values[*parameter.Name] = *parameter.Value
-		}
-		return true
-	}); err != nil {
-		return nil, fmt.Errorf("getting ssm parameters for path %q, %w", path, err)
+	result, err := p.ssmapi.GetParameterWithContext(ctx, &ssm.GetParameterInput{
+		Name: lo.ToPtr(parameter),
+	})
+	if err != nil {
+		return "", fmt.Errorf("getting ssm parameter %q, %w", parameter, err)
 	}
-	p.cache.SetDefault(path, values)
-	return values, nil
+	p.cache.SetDefault(parameter, lo.FromPtr(result.Parameter.Value))
+	return lo.FromPtr(result.Parameter.Value), nil
 }

--- a/pkg/providers/ssm/provider.go
+++ b/pkg/providers/ssm/provider.go
@@ -27,6 +27,7 @@ import (
 
 type Provider interface {
 	List(context.Context, string) (map[string]string, error)
+	Get(context.Context, string) (string, error)
 }
 
 type DefaultProvider struct {
@@ -40,6 +41,10 @@ func NewDefaultProvider(ssmapi ssmiface.SSMAPI, cache *cache.Cache) *DefaultProv
 		ssmapi: ssmapi,
 		cache:  cache,
 	}
+}
+
+func (p *DefaultProvider) Get(ctx context.Context, path string) (string, error) {
+	return "", nil
 }
 
 // List calls GetParametersByPath recursively with the provided input path.

--- a/pkg/providers/ssm/provider.go
+++ b/pkg/providers/ssm/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Provider interface {
@@ -55,5 +56,6 @@ func (p *DefaultProvider) Get(ctx context.Context, parameter string) (string, er
 		return "", fmt.Errorf("getting ssm parameter %q, %w", parameter, err)
 	}
 	p.cache.SetDefault(parameter, lo.FromPtr(result.Parameter.Value))
+	log.FromContext(ctx).WithValues("parameter", parameter, "value", result.Parameter.Value).Info("discovered ssm parameter")
 	return lo.FromPtr(result.Parameter.Value), nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Reverts to using `ssm:GetParameter` over `ssm:GetParametersByPath` to increase granularity on caching.

**How was this change tested?**
TODO

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.