### PR TITLE
chore: Limit parallelism on our GitHub action for version compatibility 

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -59,13 +59,15 @@ jobs:
       max-parallel: ${{ inputs.parallelism || 100 }}
       matrix:
         suite:
-          - name: Integration
+          - name: IPv6
             region: ${{ inputs.region }}
           - name: AMI
             region: ${{ inputs.region }}
           - name: Scheduling
             region: ${{ inputs.region }}
           - name: Storage
+            region: ${{ inputs.region }}
+          - name: Integration
             region: ${{ inputs.region }}
           - name: NodeClaim
             region: ${{ inputs.region }}
@@ -78,8 +80,6 @@ jobs:
           - name: Expiration
             region: ${{ inputs.region }}
           - name: Chaos
-            region: ${{ inputs.region }}
-          - name: IPv6
             region: ${{ inputs.region }}
           - name: Termination
             region: ${{ inputs.region }}

--- a/.github/workflows/e2e-version-compatibility-trigger.yaml
+++ b/.github/workflows/e2e-version-compatibility-trigger.yaml
@@ -43,6 +43,6 @@ jobs:
       workflow_trigger: "versionCompatibility"
       # Default to true unless using a workflow_dispatch
       cleanup: ${{ github.event_name != 'workflow_dispatch' && true || inputs.cleanup }}
-      parallelism: 2
+      parallelism: 1
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Limit the number of suites that run as part of our version compatibility testing. Prior to this change, the version compatibility workflow would create 3 suite (using [2 suites from our matrix job](https://github.com/aws/karpenter-provider-aws/blob/c7201b0a5c41befaf13ebe9bc84290878ac01dae/.github/workflows/e2e-matrix.yaml#L60) and upgrade suite). This PR will do two things: first reduce the number tests that are running at any given time from 18 suites to 12 suites, and reorder the test suites to reduce churn from similar operation correlating in one suite. 
- **Reducing the test suites from 18 -> 12:** Reducing the test runs to have at most 12 test suite running at a time. This will be to reduce the amount of transient errors due to throttling or issues caused by high request volume inside the testing account. 
- Re-order test suites: As both the upgrade and integration suite run the same set of tests(also happen to be the most aggressive), re-ordering the matrix will result the test suites to run in a staggered from each other to reduce the churn impact to the account. (should have no impact to the normal integration testing)

**How was this change tested?**
- As these changes are to the workflow, we will need to merge in the PR to test

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.