### PR TITLE
feat: cache SSM calls (v0.36.x)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -31,6 +31,9 @@ const (
 	InstanceTypesAndZonesTTL = 5 * time.Minute
 	// InstanceProfileTTL is the time before we refresh checking instance profile existence at IAM
 	InstanceProfileTTL = 15 * time.Minute
+	// SSMProviderTTL is the time to drop SSM Provider data. This only queries EKS Optimized AMI
+	// releases, so we should expect this to be updated relatively infrequently.
+	SSMProviderTTL = 24 * time.Hour
 )
 
 const (

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -60,6 +60,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/securitygroup"
+	ssmp "github.com/aws/karpenter-provider-aws/pkg/providers/ssm"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/subnet"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
 )
@@ -86,6 +87,7 @@ type Operator struct {
 	VersionProvider           version.Provider
 	InstanceTypesProvider     instancetype.Provider
 	InstanceProvider          instance.Provider
+	SSMProvider               ssmp.Provider
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
@@ -142,7 +144,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		*sess.Config.Region,
 	)
 	versionProvider := version.NewDefaultProvider(operator.KubernetesInterface, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	amiProvider := amifamily.NewDefaultProvider(versionProvider, ssm.New(sess), ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	ssmProvider := ssmp.NewDefaultProvider( ssm.New(sess), cache.New(awscache.SSMProviderTTL, awscache.DefaultCleanupInterval))
+	amiProvider := amifamily.NewDefaultProvider(versionProvider, ssmProvider, ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	amiResolver := amifamily.NewResolver(amiProvider)
 	launchTemplateProvider := launchtemplate.NewDefaultProvider(
 		ctx,

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -25,8 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
@@ -34,6 +32,7 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/ssm"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -48,9 +47,9 @@ type Provider interface {
 type DefaultProvider struct {
 	sync.Mutex
 	cache           *cache.Cache
-	ssm             ssmiface.SSMAPI
 	ec2api          ec2iface.EC2API
 	cm              *pretty.ChangeMonitor
+	ssmProvider     ssm.Provider
 	versionProvider version.Provider
 }
 
@@ -102,12 +101,12 @@ func (a AMIs) MapToInstanceTypes(instanceTypes []*cloudprovider.InstanceType) ma
 	return amiIDs
 }
 
-func NewDefaultProvider(versionProvider version.Provider, ssm ssmiface.SSMAPI, ec2api ec2iface.EC2API, cache *cache.Cache) *DefaultProvider {
+func NewDefaultProvider(versionProvider version.Provider, ssmProvider ssm.Provider, ec2api ec2iface.EC2API, cache *cache.Cache) *DefaultProvider {
 	return &DefaultProvider{
 		cache:           cache,
-		ssm:             ssm,
 		ec2api:          ec2api,
 		cm:              pretty.NewChangeMonitor(),
+		ssmProvider: ssmProvider,
 		versionProvider: versionProvider,
 	}
 }
@@ -178,12 +177,11 @@ func (p *DefaultProvider) getDefaultAMIs(ctx context.Context, nodeClass *v1beta1
 }
 
 func (p *DefaultProvider) resolveSSMParameter(ctx context.Context, ssmQuery string) (string, error) {
-	output, err := p.ssm.GetParameterWithContext(ctx, &ssm.GetParameterInput{Name: aws.String(ssmQuery)})
+	imageID, err := p.ssmProvider.Get(ctx, ssmQuery)
 	if err != nil {
-		return "", fmt.Errorf("getting ssm parameter %q, %w", ssmQuery, err)
+		return "", err
 	}
-	ami := aws.StringValue(output.Parameter.Value)
-	return ami, nil
+	return imageID, nil
 }
 
 func (p *DefaultProvider) getAMIs(ctx context.Context, terms []v1beta1.AMISelectorTerm) (AMIs, error) {

--- a/pkg/providers/ssm/provider.go
+++ b/pkg/providers/ssm/provider.go
@@ -1,0 +1,61 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
+	"github.com/patrickmn/go-cache"
+	"github.com/samber/lo"
+	"knative.dev/pkg/logging"
+)
+
+type Provider interface {
+	Get(context.Context, string) (string, error)
+}
+
+type DefaultProvider struct {
+	sync.Mutex
+	cache  *cache.Cache
+	ssmapi ssmiface.SSMAPI
+}
+
+func NewDefaultProvider(ssmapi ssmiface.SSMAPI, cache *cache.Cache) *DefaultProvider {
+	return &DefaultProvider{
+		ssmapi: ssmapi,
+		cache:  cache,
+	}
+}
+
+func (p *DefaultProvider) Get(ctx context.Context, parameter string) (string, error) {
+	p.Lock()
+	defer p.Unlock()
+	if result, ok := p.cache.Get(parameter); ok {
+		return result.(string), nil
+	}
+	result, err := p.ssmapi.GetParameterWithContext(ctx, &ssm.GetParameterInput{
+		Name: lo.ToPtr(parameter),
+	})
+	if err != nil {
+		return "", fmt.Errorf("getting ssm parameter %q, %w", parameter, err)
+	}
+	p.cache.SetDefault(parameter, lo.FromPtr(result.Parameter.Value))
+	logging.FromContext(ctx).With("parameter", parameter, "value", lo.FromPtr(result.Parameter.Value)).Info("discovered ssm parameter")
+	return lo.FromPtr(result.Parameter.Value), nil
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Caches SSM parameter results for 24 hours to reduce duplicate API call volume. SSM parameter results are expected to be relatively static since we only query EKS managed SSM parameters.

**How was this change tested?**
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.