### PR TITLE
fix: allow v prefix for bottlerocket aliases

### DIFF
--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -158,27 +158,23 @@ var _ = Describe("AMI", func() {
 	})
 
 	Context("AMIFamily", func() {
-		It("should provision a node using the AL2 family", func() {
-			pod := coretest.Pod()
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
-			env.ExpectCreated(nodeClass, nodePool, pod)
-			env.EventuallyExpectHealthy(pod)
-			env.ExpectCreatedNodeCount("==", 1)
-		})
-		It("should provision a node using the AL2023 family", func() {
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
-			pod := coretest.Pod()
-			env.ExpectCreated(nodeClass, nodePool, pod)
-			env.EventuallyExpectHealthy(pod)
-			env.ExpectCreatedNodeCount("==", 1)
-		})
-		It("should provision a node using the Bottlerocket family", func() {
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "bottlerocket@latest"}}
-			pod := coretest.Pod()
-			env.ExpectCreated(nodeClass, nodePool, pod)
-			env.EventuallyExpectHealthy(pod)
-			env.ExpectCreatedNodeCount("==", 1)
-		})
+		DescribeTable(
+			"should providion a node using an alias",
+			func(alias string) {
+				pod := coretest.Pod()
+				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
+				env.ExpectCreated(nodeClass, nodePool, pod)
+				env.EventuallyExpectHealthy(pod)
+				env.ExpectCreatedNodeCount("==", 1)
+			},
+			Entry("AL2023 (latest)", "al2023@latest"),
+			Entry("AL2023 (pinned)", "al2023@v20240807"),
+			Entry("AL2 (latest)", "al2@latest"),
+			Entry("AL2 (pinned)", "al2@v20240807"),
+			Entry("Bottlerocket (latest)", "bottlerocket@latest"),
+			Entry("Bottlerocket (pinned with v prefix)", "bottlerocket@v1.21.0"),
+			Entry("Bottlerocket (pinned without v prefix)", "bottlerocket@1.21.0"),
+		)
 		It("should support Custom AMIFamily with AMI Selectors", func() {
 			al2023AMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
 			nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyCustom)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes a regression in #6726 to enable `v` prefixes for bottlerocket aliases. Additionally updates the E2E tests to ensure this doesn't regress again.

**How was this change tested?**
`make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.