### PR TITLE
docs: Update spot-to-spot consolidation feature flag to be alpha

### DIFF
--- a/website/content/en/docs/reference/settings.md
+++ b/website/content/en/docs/reference/settings.md
@@ -43,11 +43,11 @@ Karpenter surfaces environment variables and CLI parameters to allow you to conf
 
 Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) You can enable the feature gates through the `--feature-gates` CLI environment variable or the `FEATURE_GATES` environment variable in the Karpenter deployment. For example, you can configure drift, spotToSpotConsolidation by setting the CLI argument: `--feature-gates Drift=true,SpotToSpotConsolidation=true`.
 
-| Feature                 | Default | Stage | Since   | Until   |
-|-------------------------|---------|-------|---------|---------|
-| Drift                   | false   | Alpha | v0.21.x | v0.32.x |
-| Drift                   | true    | Beta  | v0.33.x |         |
-| SpotToSpotConsolidation | false   | Beta  | v0.34.x |         |
+| Feature                 | Default | Stage  | Since   | Until   |
+|-------------------------|---------|--------|---------|---------|
+| Drift                   | false   | Alpha  | v0.21.x | v0.32.x |
+| Drift                   | true    | Beta   | v0.33.x |         |
+| SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 
 ### Batching Parameters
 

--- a/website/content/en/preview/reference/settings.md
+++ b/website/content/en/preview/reference/settings.md
@@ -43,11 +43,11 @@ Karpenter surfaces environment variables and CLI parameters to allow you to conf
 
 Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) You can enable the feature gates through the `--feature-gates` CLI environment variable or the `FEATURE_GATES` environment variable in the Karpenter deployment. For example, you can configure drift, spotToSpotConsolidation by setting the CLI argument: `--feature-gates Drift=true,SpotToSpotConsolidation=true`.
 
-| Feature                 | Default | Stage | Since   | Until   |
-|-------------------------|---------|-------|---------|---------|
-| Drift                   | false   | Alpha | v0.21.x | v0.32.x |
-| Drift                   | true    | Beta  | v0.33.x |         |
-| SpotToSpotConsolidation | false   | Beta  | v0.34.x |         |
+| Feature                 | Default | Stage  | Since   | Until   |
+|-------------------------|---------|--------|---------|---------|
+| Drift                   | false   | Alpha  | v0.21.x | v0.32.x |
+| Drift                   | true    | Beta   | v0.33.x |         |
+| SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 
 ### Batching Parameters
 

--- a/website/content/en/v0.36/reference/settings.md
+++ b/website/content/en/v0.36/reference/settings.md
@@ -43,11 +43,11 @@ Karpenter surfaces environment variables and CLI parameters to allow you to conf
 
 Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) You can enable the feature gates through the `--feature-gates` CLI environment variable or the `FEATURE_GATES` environment variable in the Karpenter deployment. For example, you can configure drift, spotToSpotConsolidation by setting the CLI argument: `--feature-gates Drift=true,SpotToSpotConsolidation=true`.
 
-| Feature                 | Default | Stage | Since   | Until   |
-|-------------------------|---------|-------|---------|---------|
-| Drift                   | false   | Alpha | v0.21.x | v0.32.x |
-| Drift                   | true    | Beta  | v0.33.x |         |
-| SpotToSpotConsolidation | false   | Beta  | v0.34.x |         |
+| Feature                 | Default | Stage  | Since   | Until   |
+|-------------------------|---------|--------|---------|---------|
+| Drift                   | false   | Alpha  | v0.21.x | v0.32.x |
+| Drift                   | true    | Beta   | v0.33.x |         |
+| SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 
 ### Batching Parameters
 

--- a/website/content/en/v0.37/reference/settings.md
+++ b/website/content/en/v0.37/reference/settings.md
@@ -43,11 +43,11 @@ Karpenter surfaces environment variables and CLI parameters to allow you to conf
 
 Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) You can enable the feature gates through the `--feature-gates` CLI environment variable or the `FEATURE_GATES` environment variable in the Karpenter deployment. For example, you can configure drift, spotToSpotConsolidation by setting the CLI argument: `--feature-gates Drift=true,SpotToSpotConsolidation=true`.
 
-| Feature                 | Default | Stage | Since   | Until   |
-|-------------------------|---------|-------|---------|---------|
-| Drift                   | false   | Alpha | v0.21.x | v0.32.x |
-| Drift                   | true    | Beta  | v0.33.x |         |
-| SpotToSpotConsolidation | false   | Beta  | v0.34.x |         |
+| Feature                 | Default | Stage  | Since   | Until   |
+|-------------------------|---------|--------|---------|---------|
+| Drift                   | false   | Alpha  | v0.21.x | v0.32.x |
+| Drift                   | true    | Beta   | v0.33.x |         |
+| SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 
 ### Batching Parameters
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Update docs to indicate that spot-to-spot consolidation is an alpha feature flag 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.