### PR TITLE
ci: Fire metric when no resources is cleaned

### DIFF
--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -90,19 +90,20 @@ func main() {
 		if err != nil {
 			resourceLogger.Errorf("%v", err)
 		}
+		cleaned := []string{}
 		resourceLogger.With("ids", ids, "count", len(ids)).Infof("discovered resourceTypes")
 		if len(ids) > 0 {
-			cleaned, err := resourceTypes[i].Cleanup(ctx, ids)
+			cleaned, err = resourceTypes[i].Cleanup(ctx, ids)
 			if err != nil {
 				resourceLogger.Errorf("%v", err)
 			}
-			// Should only fire metrics if the resource have expired
-			if lo.FromPtr(clusterName) == "" {
-				if err = metricsClient.FireMetric(ctx, sweeperCleanedResourcesTableName, fmt.Sprintf("%sDeleted", resourceTypes[i].String()), float64(len(cleaned)), lo.Ternary(resourceTypes[i].Global(), "global", cfg.Region)); err != nil {
-					resourceLogger.Errorf("%v", err)
-				}
-			}
 			resourceLogger.With("ids", cleaned, "count", len(cleaned)).Infof("deleted resourceTypes")
+		}
+		// Should only fire metrics if the resource have expired
+		if lo.FromPtr(clusterName) == "" {
+			if err = metricsClient.FireMetric(ctx, sweeperCleanedResourcesTableName, fmt.Sprintf("%sDeleted", resourceTypes[i].String()), float64(len(cleaned)), lo.Ternary(resourceTypes[i].Global(), "global", cfg.Region)); err != nil {
+				resourceLogger.Errorf("%v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Currenlty no metric is fired as part of our sweeper when no resources is being cleaned up. Adjusting script to add in zeros when we are not cleaning resources. 

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.