### PR TITLE
docs: invalid Getting Started NodePool yaml

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,14 +23,15 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1
+        group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: default
+      expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
-    expireAfter: 720h # 30 * 24h = 720h
+    consolidateAfter: 1m
 ---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass

--- a/website/content/en/docs/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/docs/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,14 +23,15 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1
+        group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: default
+      expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
-    expireAfter: 720h # 30 * 24h = 720h
+    consolidateAfter: 1m
 ---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,14 +23,15 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1
+        group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: default
+      expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
-    expireAfter: 720h # 30 * 24h = 720h
+    consolidateAfter: 1m
 ---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass

--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,14 +23,15 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1
+        group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: default
+      expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
-    expireAfter: 720h # 30 * 24h = 720h
+    consolidateAfter: 1m
 ---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -23,14 +23,15 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1
+        group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: default
+      expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
-    expireAfter: 720h # 30 * 24h = 720h
+    consolidateAfter: 1m
 ---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass

--- a/website/content/en/v1.0/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
+++ b/website/content/en/v1.0/getting-started/migrating-from-cas/scripts/step10-create-nodepool.sh
@@ -23,14 +23,15 @@ spec:
           operator: Gt
           values: ["2"]
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1
+        group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: default
+      expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
-    expireAfter: 720h # 30 * 24h = 720h
+    consolidateAfter: 1m
 ---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass


### PR DESCRIPTION
Fixes #N/A 

**Description**
Nodepool's yaml in Getting Started doesn't have a v1 spec

**How was this change tested?**
Deployed NodePool.yaml and checked

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.