### PR TITLE
fix: ensure alias version isn't dropped round-trip

### DIFF
--- a/pkg/apis/v1/ec2nodeclass_conversion.go
+++ b/pkg/apis/v1/ec2nodeclass_conversion.go
@@ -51,6 +51,17 @@ func (in *EC2NodeClass) ConvertTo(ctx context.Context, to apis.Convertible) erro
 		v1beta1enc.Spec.AMIFamily = lo.ToPtr(in.AMIFamily())
 	}
 
+	if term, ok := lo.Find(in.Spec.AMISelectorTerms, func(term AMISelectorTerm) bool {
+		return term.Alias != ""
+	}); ok {
+		version := AMIVersionFromAlias(term.Alias)
+		if version != "latest" {
+			v1beta1enc.Annotations = lo.Assign(v1beta1enc.Annotations, map[string]string{
+				AnnotationAliasVersionCompatibilityKey: version,
+			})
+		}
+	}
+
 	in.Spec.convertTo(&v1beta1enc.Spec)
 	in.Status.convertTo((&v1beta1enc.Status))
 	return nil
@@ -127,6 +138,7 @@ func (in *EC2NodeClassStatus) convertTo(v1beta1enc *v1beta1.EC2NodeClassStatus) 
 func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) error {
 	v1beta1enc := from.(*v1beta1.EC2NodeClass)
 	in.ObjectMeta = v1beta1enc.ObjectMeta
+	in.Annotations = lo.OmitByKeys(in.Annotations, []string{AnnotationAliasVersionCompatibilityKey})
 
 	switch lo.FromPtr(v1beta1enc.Spec.AMIFamily) {
 	case AMIFamilyAL2, AMIFamilyAL2023, AMIFamilyBottlerocket, AMIFamilyWindows2019, AMIFamilyWindows2022:
@@ -135,7 +147,11 @@ func (in *EC2NodeClass) ConvertFrom(ctx context.Context, from apis.Convertible) 
 		if len(v1beta1enc.Spec.AMISelectorTerms) == 0 {
 			in.Spec.AMIFamily = nil
 			in.Spec.AMISelectorTerms = []AMISelectorTerm{{
-				Alias: fmt.Sprintf("%s@latest", strings.ToLower(lo.FromPtr(v1beta1enc.Spec.AMIFamily))),
+				Alias: fmt.Sprintf(
+					"%s@%s",
+					strings.ToLower(lo.FromPtr(v1beta1enc.Spec.AMIFamily)),
+					lo.ValueOr(v1beta1enc.Annotations, AnnotationAliasVersionCompatibilityKey, "latest"),
+				),
 			}}
 		} else {
 			in.Spec.AMIFamily = v1beta1enc.Spec.AMIFamily

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -131,6 +131,8 @@ var (
 	AnnotationUbuntuCompatibilityAMIFamily           = "amiFamily"
 	AnnotationUbuntuCompatibilityBlockDeviceMappings = "blockDeviceMappings"
 
+	AnnotationAliasVersionCompatibilityKey = apis.CompatibilityGroup + "/v1-alias-version"
+
 	TagNodeClaim             = coreapis.Group + "/nodeclaim"
 	TagManagedLaunchTemplate = apis.Group + "/cluster"
 	TagName                  = "Name"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #6776 

**Description**
Ensures that the version pin for an alias is maintained via a compatibility annotation applied to the v1beta1 nodeclass.

**How was this change tested?**
`make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.