### PR TITLE
feat: add support for extraManifests to create NodePools and EC2NodeClasses during Helm Install

### DIFF
--- a/charts/karpenter/templates/extra-manifests.yaml
+++ b/charts/karpenter/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{- range .Values.extraManifests }}
+{{- $manifest := tpl . $ }}
+{{ $manifest | nindent 0 }}
+---
+{{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -194,3 +194,57 @@ settings:
     # -- spotToSpotConsolidation is ALPHA and is disabled by default.
     # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
     spotToSpotConsolidation: false
+extraManifests: []
+  # - |
+  #   apiVersion: karpenter.k8s.aws/v1beta1
+  #   kind: EC2NodeClass
+  #   metadata:
+  #     name: my-cluster
+  #   spec:
+  #     amiFamily: Bottlerocket
+  #     role: my-cluster-eks-nodes
+  #     securityGroupSelectorTerms:
+  #     - id: sg-08719fac0804e48e5
+  #     subnetSelectorTerms:
+  #     - tags:
+  #         karpenter.sh/discovery: my-cluster
+  #     tags:
+  #       Name: my-cluster
+  # - |
+  #   apiVersion: karpenter.sh/v1beta1
+  #   kind: NodePool
+  #   metadata:
+  #     name: default
+  #   spec:
+  #     disruption:
+  #       consolidationPolicy: WhenUnderutilized
+  #       expireAfter: Never
+  #     limits:
+  #       cpu: 100
+  #       memory: 4000Gi
+  #     template:
+  #       metadata: {}
+  #       spec:
+  #         nodeClassRef:
+  #           name: my-cluster
+  #         requirements:
+  #         - key: karpenter.k8s.aws/instance-family
+  #           operator: In
+  #           values:
+  #           - m5
+  #           - c5
+  #         - key: karpenter.sh/capacity-type
+  #           operator: In
+  #           values:
+  #           - spot
+  #         - key: karpenter.k8s.aws/instance-size
+  #           operator: In
+  #           values:
+  #           - large
+  #           - 2xlarge
+  #         - key: topology.kubernetes.io/zone
+  #           operator: In
+  #           values:
+  #           - us-east-1a
+  #           - us-east-1b
+  #           - us-east-1c


### PR DESCRIPTION
This PR introduces a new feature to the Karpenter Helm chart that allows users to specify custom extraManifests within the values.yaml file. This enables the creation of NodePools and EC2NodeClasses directly during the Helm apply process.


The feature is useful for users who need to set up specific configurations for their clusters, such as defining instance types, capacity types, and network settings for their nodes, without having to apply these manifests separately.

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

The change was tested by:

Deploying the Helm chart with extraManifests configured in the values.yaml file.
Verifying that the specified NodePools and EC2NodeClasses were correctly created and applied during the Helm apply process.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No