### PR TITLE
docs: Fix doc link references to preview

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
@@ -1,4 +1,4 @@
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml  > $TEMPOUT \
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml  > $TEMPOUT \
 && aws cloudformation deploy \
   --stack-name "Karpenter-${CLUSTER_NAME}" \
   --template-file "${TEMPOUT}" \

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -1,4 +1,4 @@
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
 && aws cloudformation deploy \
   --stack-name "Karpenter-${CLUSTER_NAME}" \
   --template-file "${TEMPOUT}" \

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step03-iam-cloud-formation.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step03-iam-cloud-formation.sh
@@ -1,6 +1,6 @@
 TEMPOUT="$(mktemp)"
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
 && aws cloudformation deploy \
   --stack-name "Karpenter-${CLUSTER_NAME}" \
   --template-file "${TEMPOUT}" \

--- a/website/content/en/docs/getting-started/migrating-from-cas/scripts/step09-deploy.sh
+++ b/website/content/en/docs/getting-started/migrating-from-cas/scripts/step09-deploy.sh
@@ -1,8 +1,8 @@
 kubectl create namespace "${KARPENTER_NAMESPACE}" || true
 kubectl create -f \
-    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/pkg/apis/crds/karpenter.sh_nodepools.yaml"
+    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v${KARPENTER_VERSION}/pkg/apis/crds/karpenter.sh_nodepools.yaml"
 kubectl create -f \
-    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml"
+    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v${KARPENTER_VERSION}/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml"
 kubectl create -f \
-    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/pkg/apis/crds/karpenter.sh_nodeclaims.yaml"
+    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v${KARPENTER_VERSION}/pkg/apis/crds/karpenter.sh_nodeclaims.yaml"
 kubectl apply -f karpenter.yaml

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
@@ -1,4 +1,4 @@
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml  > $TEMPOUT \
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml  > $TEMPOUT \
 && aws cloudformation deploy \
   --stack-name "Karpenter-${CLUSTER_NAME}" \
   --template-file "${TEMPOUT}" \

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -1,4 +1,4 @@
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
 && aws cloudformation deploy \
   --stack-name "Karpenter-${CLUSTER_NAME}" \
   --template-file "${TEMPOUT}" \

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step03-iam-cloud-formation.sh
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step03-iam-cloud-formation.sh
@@ -1,6 +1,6 @@
 TEMPOUT="$(mktemp)"
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter-provider-aws/v"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml  > "${TEMPOUT}" \
 && aws cloudformation deploy \
   --stack-name "Karpenter-${CLUSTER_NAME}" \
   --template-file "${TEMPOUT}" \

--- a/website/content/en/v1.0/getting-started/migrating-from-cas/scripts/step09-deploy.sh
+++ b/website/content/en/v1.0/getting-started/migrating-from-cas/scripts/step09-deploy.sh
@@ -1,8 +1,8 @@
 kubectl create namespace "${KARPENTER_NAMESPACE}" || true
 kubectl create -f \
-    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/pkg/apis/crds/karpenter.sh_nodepools.yaml"
+    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v${KARPENTER_VERSION}/pkg/apis/crds/karpenter.sh_nodepools.yaml"
 kubectl create -f \
-    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml"
+    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v${KARPENTER_VERSION}/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml"
 kubectl create -f \
-    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v1.0.0/pkg/apis/crds/karpenter.sh_nodeclaims.yaml"
+    "https://raw.githubusercontent.com/aws/karpenter-provider-aws/v${KARPENTER_VERSION}/pkg/apis/crds/karpenter.sh_nodeclaims.yaml"
 kubectl apply -f karpenter.yaml


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #6790

**Description**

Fixes references that were erroneously overridden from preview to v1.0.0

**How was this change tested?**

- `make presubmit`
- Viewed the preview docs

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.