### PR TITLE
chore: add support for `nodeSelector` to post-install hook

### DIFF
--- a/charts/karpenter/templates/post-install-hook.yaml
+++ b/charts/karpenter/templates/post-install-hook.yaml
@@ -21,6 +21,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: post-install-job
         image: {{ include "karpenter.postInstallHook.image" . }}


### PR DESCRIPTION
**Description**

The default image for the post-install hook runs exclusively on `amd64`. Without the ability to define a `nodeSelector`, scheduling it onto the appropriate node pool(s) is challenging. This pull request introduces support for `nodeSelector` in the post-install hook. To maintain consistency, I have extended the existing approach used for `tolerations`, which inherit their values from the deployment, rather than defining a new field.

This change is not associated with any existing issues. If you find it irrelevant, I will close it.

Thank you in advance for reviewing.

**How was this change tested?**

The chart was packaged and pushed to our internal registry.

**Does this change impact docs?**
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.