### PR TITLE
chore: Bump go.mod to use go 1.23

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws
@@ -164,23 +164,17 @@ spec:
                               gp2 volumes, this represents the baseline performance of the volume and the
                               rate at which the volume accumulates I/O credits for bursting.
 
-
                               The following are the supported values for each volume type:
-
 
                                  * gp3: 3,000-16,000 IOPS
 
-
                                  * io1: 100-64,000 IOPS
 
-
                                  * io2: 100-64,000 IOPS
-
 
                               For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
                               on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
                               Other instance families guarantee performance up to 32,000 IOPS.
-
 
                               This parameter is supported for io1, io2, and gp3 volumes only. This parameter
                               is not supported for gp2, st1, sc1, or standard volumes.
@@ -204,15 +198,11 @@ spec:
                               a volume size. The following are the supported volumes sizes for each volume
                               type:
 
-
                                  * gp2 and gp3: 1-16,384
-
 
                                  * io1 and io2: 4-16,384
 
-
                                  * st1 and sc1: 125-16,384
-
 
                                  * standard: 1-1,024
                             pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
@@ -392,13 +382,11 @@ spec:
                   description: |-
                     MetadataOptions for the generated launch template of provisioned nodes.
 
-
                     This specifies the exposure of the Instance Metadata Service to
                     provisioned EC2 nodes. For more information,
                     see Instance Metadata and User Data
                     (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
                     in the Amazon Elastic Compute Cloud User Guide.
-
 
                     Refer to recommended, security best practices
                     (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
@@ -413,7 +401,6 @@ spec:
                         HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
                         nodes. If metadata options is non-nil, but this parameter is not specified,
                         the default state is "enabled".
-
 
                         If you specify a value of "disabled", instance metadata will not be accessible
                         on the node.
@@ -450,13 +437,11 @@ spec:
                         requests. If metadata options is non-nil, but this parameter is not
                         specified, the default state is "required".
 
-
                         If the state is optional, one can choose to retrieve instance metadata with
                         or without a signed token header on the request. If one retrieves the IAM
                         role credentials without a token, the version 1.0 role credentials are
                         returned. If one retrieves the IAM role credentials using a valid signed
                         token, the version 2.0 role credentials are returned.
-
 
                         If the state is "required", one must send a signed token header with any
                         instance metadata retrieval requests. In this state, retrieving the IAM
@@ -693,12 +678,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -864,23 +844,17 @@ spec:
                               gp2 volumes, this represents the baseline performance of the volume and the
                               rate at which the volume accumulates I/O credits for bursting.
 
-
                               The following are the supported values for each volume type:
-
 
                                  * gp3: 3,000-16,000 IOPS
 
-
                                  * io1: 100-64,000 IOPS
 
-
                                  * io2: 100-64,000 IOPS
-
 
                               For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
                               on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
                               Other instance families guarantee performance up to 32,000 IOPS.
-
 
                               This parameter is supported for io1, io2, and gp3 volumes only. This parameter
                               is not supported for gp2, st1, sc1, or standard volumes.
@@ -904,15 +878,11 @@ spec:
                               a volume size. The following are the supported volumes sizes for each volume
                               type:
 
-
                                  * gp2 and gp3: 1-16,384
-
 
                                  * io1 and io2: 4-16,384
 
-
                                  * st1 and sc1: 125-16,384
-
 
                                  * standard: 1-1,024
                             pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
@@ -978,13 +948,11 @@ spec:
                   description: |-
                     MetadataOptions for the generated launch template of provisioned nodes.
 
-
                     This specifies the exposure of the Instance Metadata Service to
                     provisioned EC2 nodes. For more information,
                     see Instance Metadata and User Data
                     (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
                     in the Amazon Elastic Compute Cloud User Guide.
-
 
                     Refer to recommended, security best practices
                     (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
@@ -999,7 +967,6 @@ spec:
                         HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
                         nodes. If metadata options is non-nil, but this parameter is not specified,
                         the default state is "enabled".
-
 
                         If you specify a value of "disabled", instance metadata will not be accessible
                         on the node.
@@ -1036,13 +1003,11 @@ spec:
                         requests. If metadata options is non-nil, but this parameter is not
                         specified, the default state is "required".
 
-
                         If the state is optional, one can choose to retrieve instance metadata with
                         or without a signed token header on the request. If one retrieves the IAM
                         role credentials without a token, the version 1.0 role credentials are
                         returned. If one retrieves the IAM role credentials using a valid signed
                         token, the version 2.0 role credentials are returned.
-
 
                         If the state is "required", one must send a signed token header with any
                         instance metadata retrieval requests. In this state, retrieving the IAM
@@ -1269,12 +1234,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh
@@ -262,18 +262,14 @@ spec:
                   description: |-
                     TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
-
                     Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
 
                     This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
                     When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
 
-
                     Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
                     If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
                     that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
 
                     The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
                     If left undefined, the controller will wait indefinitely for pods to be drained.
@@ -350,12 +346,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -798,12 +789,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh
@@ -392,18 +392,14 @@ spec:
                           description: |-
                             TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
-
                             Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
 
                             This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
                             When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
 
-
                             Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
                             If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
                             that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
 
                             The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
                             If left undefined, the controller will wait indefinitely for pods to be drained.
@@ -476,12 +472,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -1047,12 +1038,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws
 
-go 1.22.5
+go 1.23.0
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
@@ -32,7 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.5
-	sigs.k8s.io/karpenter v1.0.1-0.20240815170320-bb7468a3a758
+	sigs.k8s.io/karpenter v1.0.1-0.20240820174000-8e40c0c92224
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -762,8 +762,8 @@ sigs.k8s.io/controller-runtime v0.18.5 h1:nTHio/W+Q4aBlQMgbnC5hZb4IjIidyrizMai9P
 sigs.k8s.io/controller-runtime v0.18.5/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v1.0.1-0.20240815170320-bb7468a3a758 h1:VEibnW+C/lW8QVgGlsZadhhTPXwhkR2CQj828zHu8Ao=
-sigs.k8s.io/karpenter v1.0.1-0.20240815170320-bb7468a3a758/go.mod h1:SGH7B5ZSeaCXBnwvj4cSmIPC6TqRq7kPZmQyJRdxC6k=
+sigs.k8s.io/karpenter v1.0.1-0.20240820174000-8e40c0c92224 h1:T1OTA/jwiqWp55+gb8CCT5PoyZjIywjspe9UuLU/dgc=
+sigs.k8s.io/karpenter v1.0.1-0.20240820174000-8e40c0c92224/go.mod h1:e6yDwyO/5+h2NqTkvMmHf9ae/UnKbsOdSYuAnV0NErQ=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws
@@ -164,23 +164,17 @@ spec:
                               gp2 volumes, this represents the baseline performance of the volume and the
                               rate at which the volume accumulates I/O credits for bursting.
 
-
                               The following are the supported values for each volume type:
-
 
                                  * gp3: 3,000-16,000 IOPS
 
-
                                  * io1: 100-64,000 IOPS
 
-
                                  * io2: 100-64,000 IOPS
-
 
                               For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
                               on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
                               Other instance families guarantee performance up to 32,000 IOPS.
-
 
                               This parameter is supported for io1, io2, and gp3 volumes only. This parameter
                               is not supported for gp2, st1, sc1, or standard volumes.
@@ -204,15 +198,11 @@ spec:
                               a volume size. The following are the supported volumes sizes for each volume
                               type:
 
-
                                  * gp2 and gp3: 1-16,384
-
 
                                  * io1 and io2: 4-16,384
 
-
                                  * st1 and sc1: 125-16,384
-
 
                                  * standard: 1-1,024
                             pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
@@ -392,13 +382,11 @@ spec:
                   description: |-
                     MetadataOptions for the generated launch template of provisioned nodes.
 
-
                     This specifies the exposure of the Instance Metadata Service to
                     provisioned EC2 nodes. For more information,
                     see Instance Metadata and User Data
                     (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
                     in the Amazon Elastic Compute Cloud User Guide.
-
 
                     Refer to recommended, security best practices
                     (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
@@ -413,7 +401,6 @@ spec:
                         HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
                         nodes. If metadata options is non-nil, but this parameter is not specified,
                         the default state is "enabled".
-
 
                         If you specify a value of "disabled", instance metadata will not be accessible
                         on the node.
@@ -450,13 +437,11 @@ spec:
                         requests. If metadata options is non-nil, but this parameter is not
                         specified, the default state is "required".
 
-
                         If the state is optional, one can choose to retrieve instance metadata with
                         or without a signed token header on the request. If one retrieves the IAM
                         role credentials without a token, the version 1.0 role credentials are
                         returned. If one retrieves the IAM role credentials using a valid signed
                         token, the version 2.0 role credentials are returned.
-
 
                         If the state is "required", one must send a signed token header with any
                         instance metadata retrieval requests. In this state, retrieving the IAM
@@ -693,12 +678,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -864,23 +844,17 @@ spec:
                               gp2 volumes, this represents the baseline performance of the volume and the
                               rate at which the volume accumulates I/O credits for bursting.
 
-
                               The following are the supported values for each volume type:
-
 
                                  * gp3: 3,000-16,000 IOPS
 
-
                                  * io1: 100-64,000 IOPS
 
-
                                  * io2: 100-64,000 IOPS
-
 
                               For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
                               on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
                               Other instance families guarantee performance up to 32,000 IOPS.
-
 
                               This parameter is supported for io1, io2, and gp3 volumes only. This parameter
                               is not supported for gp2, st1, sc1, or standard volumes.
@@ -904,15 +878,11 @@ spec:
                               a volume size. The following are the supported volumes sizes for each volume
                               type:
 
-
                                  * gp2 and gp3: 1-16,384
-
 
                                  * io1 and io2: 4-16,384
 
-
                                  * st1 and sc1: 125-16,384
-
 
                                  * standard: 1-1,024
                             pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
@@ -978,13 +948,11 @@ spec:
                   description: |-
                     MetadataOptions for the generated launch template of provisioned nodes.
 
-
                     This specifies the exposure of the Instance Metadata Service to
                     provisioned EC2 nodes. For more information,
                     see Instance Metadata and User Data
                     (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
                     in the Amazon Elastic Compute Cloud User Guide.
-
 
                     Refer to recommended, security best practices
                     (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
@@ -999,7 +967,6 @@ spec:
                         HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
                         nodes. If metadata options is non-nil, but this parameter is not specified,
                         the default state is "enabled".
-
 
                         If you specify a value of "disabled", instance metadata will not be accessible
                         on the node.
@@ -1036,13 +1003,11 @@ spec:
                         requests. If metadata options is non-nil, but this parameter is not
                         specified, the default state is "required".
 
-
                         If the state is optional, one can choose to retrieve instance metadata with
                         or without a signed token header on the request. If one retrieves the IAM
                         role credentials without a token, the version 1.0 role credentials are
                         returned. If one retrieves the IAM role credentials using a valid signed
                         token, the version 2.0 role credentials are returned.
-
 
                         If the state is "required", one must send a signed token header with any
                         instance metadata retrieval requests. In this state, retrieving the IAM
@@ -1269,12 +1234,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh
@@ -262,18 +262,14 @@ spec:
                   description: |-
                     TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
-
                     Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
 
                     This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
                     When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
 
-
                     Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
                     If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
                     that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
 
                     The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
                     If left undefined, the controller will wait indefinitely for pods to be drained.
@@ -350,12 +346,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -798,12 +789,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh
@@ -392,18 +392,14 @@ spec:
                           description: |-
                             TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
-
                             Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
 
                             This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
                             When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
 
-
                             Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
                             If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
                             that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
 
                             The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
                             If left undefined, the controller will wait indefinitely for pods to be drained.
@@ -476,12 +472,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -1047,12 +1038,7 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -325,14 +325,15 @@ type MetadataOptions struct {
 
 type BlockDeviceMapping struct {
 	// The device name (for example, /dev/sdh or xvdh).
-	// +required
+	// +optional
 	DeviceName *string `json:"deviceName,omitempty"`
 	// EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
 	// +kubebuilder:validation:XValidation:message="snapshotID or volumeSize must be defined",rule="has(self.snapshotID) || has(self.volumeSize)"
-	// +required
+	// +optional
 	EBS *BlockDevice `json:"ebs,omitempty"`
 	// RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
 	// configure at most one root volume in BlockDeviceMappings.
+	// +optional
 	RootVolume bool `json:"rootVolume,omitempty"`
 }
 

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -227,11 +227,11 @@ type MetadataOptions struct {
 
 type BlockDeviceMapping struct {
 	// The device name (for example, /dev/sdh or xvdh).
-	// +required
+	// +optional
 	DeviceName *string `json:"deviceName,omitempty"`
 	// EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
 	// +kubebuilder:validation:XValidation:message="snapshotID or volumeSize must be defined",rule="has(self.snapshotID) || has(self.volumeSize)"
-	// +required
+	// +optional
 	EBS *BlockDevice `json:"ebs,omitempty"`
 	// RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
 	// configure at most one root volume in BlockDeviceMappings.

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -16,6 +16,7 @@ package cloudprovider
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -103,7 +104,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 	}
 	nodeClassReady := nodeClass.StatusConditions().Get(status.ConditionReady)
 	if nodeClassReady.IsFalse() {
-		return nil, cloudprovider.NewNodeClassNotReadyError(fmt.Errorf(nodeClassReady.Message))
+		return nil, cloudprovider.NewNodeClassNotReadyError(stderrors.New(nodeClassReady.Message))
 	}
 	if nodeClassReady.IsUnknown() {
 		return nil, fmt.Errorf("resolving NodeClass readiness, NodeClass is in Ready=Unknown, %s", nodeClassReady.Message)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This updates Karpenter Provider to use the latest version of go, `go1.23`

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.