### PR TITLE
chore: Remove RBAC permissions for node lease garbage collection

### DIFF
--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -55,24 +55,3 @@ rules:
     resources: ["services"]
     resourceNames: ["kube-dns"]
     verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "karpenter.fullname" . }}-lease
-  namespace: kube-node-lease
-  labels:
-    {{- include "karpenter.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-rules:
-  # Read
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "list", "watch"]
-  # Write
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["delete"]

--- a/charts/karpenter/templates/rolebinding.yaml
+++ b/charts/karpenter/templates/rolebinding.yaml
@@ -37,23 +37,3 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "karpenter.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
---- 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "karpenter.fullname" . }}-lease
-  namespace: kube-node-lease
-  labels:
-    {{- include "karpenter.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "karpenter.fullname" . }}-lease
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "karpenter.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.5
-	sigs.k8s.io/karpenter v1.0.1-0.20240820174000-8e40c0c92224
+	sigs.k8s.io/karpenter v1.0.1-0.20240821214627-9469d1919054
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -762,8 +762,8 @@ sigs.k8s.io/controller-runtime v0.18.5 h1:nTHio/W+Q4aBlQMgbnC5hZb4IjIidyrizMai9P
 sigs.k8s.io/controller-runtime v0.18.5/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v1.0.1-0.20240820174000-8e40c0c92224 h1:T1OTA/jwiqWp55+gb8CCT5PoyZjIywjspe9UuLU/dgc=
-sigs.k8s.io/karpenter v1.0.1-0.20240820174000-8e40c0c92224/go.mod h1:e6yDwyO/5+h2NqTkvMmHf9ae/UnKbsOdSYuAnV0NErQ=
+sigs.k8s.io/karpenter v1.0.1-0.20240821214627-9469d1919054 h1:sazFOdf0qboIt5Zx+XPor7iX0H9zfEZCyCeuYHbhhbE=
+sigs.k8s.io/karpenter v1.0.1-0.20240821214627-9469d1919054/go.mod h1:e6yDwyO/5+h2NqTkvMmHf9ae/UnKbsOdSYuAnV0NErQ=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
We intend to drop the node lease garbage collection controller - https://github.com/kubernetes-sigs/karpenter/pull/1586
This PR removes the RBAC permissions for interacting with leases.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.