### PR TITLE
chore: Allow to configure resources for the post-install-hook pod

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -75,6 +75,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.0.0 \
 | postInstallHook.image.digest | string | `"sha256:13a2ad1bd37ce42ee2a6f1ab0d30595f42eb7fe4a90d6ec848550524104a1ed6"` | SHA256 digest of the post-install hook image. |
 | postInstallHook.image.repository | string | `"public.ecr.aws/bitnami/kubectl"` | Repository path to the post-install hook. This minimally needs to have `kubectl` installed |
 | postInstallHook.image.tag | string | `"1.30"` | Tag of the post-install hook image. |
+| postInstallHook.resources | object | `{}` | Resources for the post-install-hook pod. |
 | priorityClassName | string | `"system-cluster-critical"` | PriorityClass name for the pod. |
 | replicas | int | `2` | Number of replicas. |
 | revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback. |

--- a/charts/karpenter/templates/post-install-hook.yaml
+++ b/charts/karpenter/templates/post-install-hook.yaml
@@ -42,7 +42,7 @@ spec:
                 kubectl patch customresourcedefinitions nodeclaims.karpenter.sh  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
                 kubectl patch customresourcedefinitions ec2nodeclasses.karpenter.k8s.aws  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
               {{- end }}
-          {{- with .Values.controller.resources }}
+          {{- with .Values.postInstallHook.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/karpenter/templates/post-install-hook.yaml
+++ b/charts/karpenter/templates/post-install-hook.yaml
@@ -26,20 +26,23 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - name: post-install-job
-        image: {{ include "karpenter.postInstallHook.image" . }}
-        command:
-        - /bin/sh
-        - -c
-        - |
-          {{- if .Values.webhook.enabled }}
-            kubectl patch customresourcedefinitions nodepools.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
-            kubectl patch customresourcedefinitions nodeclaims.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
-            kubectl patch customresourcedefinitions ec2nodeclasses.karpenter.k8s.aws  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
-          {{- else }}
-            echo "disabled webhooks"
-            kubectl patch customresourcedefinitions nodepools.karpenter.sh  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
-            kubectl patch customresourcedefinitions nodeclaims.karpenter.sh  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
-            kubectl patch customresourcedefinitions ec2nodeclasses.karpenter.k8s.aws  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
+        - name: post-install-job
+          image: {{ include "karpenter.postInstallHook.image" . }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              {{- if .Values.webhook.enabled }}
+                kubectl patch customresourcedefinitions nodepools.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
+                kubectl patch customresourcedefinitions nodeclaims.karpenter.sh  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
+                kubectl patch customresourcedefinitions ec2nodeclasses.karpenter.k8s.aws  --type='merge' -p '{"spec":{"conversion":{"strategy": "Webhook", "webhook":{"conversionReviewVersions": ["v1beta1", "v1"], "clientConfig":{"service":{"name":"{{ include "karpenter.fullname" . }}", "port": {{ .Values.webhook.port }} ,"namespace": "{{ .Release.Namespace }}"}}}}}}'
+              {{- else }}
+                echo "disabled webhooks"
+                kubectl patch customresourcedefinitions nodepools.karpenter.sh  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
+                kubectl patch customresourcedefinitions nodeclaims.karpenter.sh  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
+                kubectl patch customresourcedefinitions ec2nodeclasses.karpenter.k8s.aws  --type='json' -p '[{'op': 'remove', 'path': '/spec/conversion'}]'
+              {{- end }}
+          {{- with .Values.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -145,6 +145,17 @@ postInstallHook:
     tag: "1.30"
     # -- SHA256 digest of the post-install hook image.
     digest: sha256:13a2ad1bd37ce42ee2a6f1ab0d30595f42eb7fe4a90d6ec848550524104a1ed6
+  # -- Resources for the post-install-hook pod.
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  #  requests:
+  #    cpu: 25m
+  #    memory: 64Mi
+  #  limits:
+  #    memory: 128Mi
 webhook:
   # -- Whether to enable the webhooks and webhook permissions.
   enabled: true


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

**Description**

This allows to define the postInstallHook resources so policies on our cluster can be met that require us to define resources for any container.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.