### PR TITLE
fix: set post-install-hook ttlSecondsAfterFinished to 60 (#6765)

### DIFF
--- a/charts/karpenter/templates/post-install-hook.yaml
+++ b/charts/karpenter/templates/post-install-hook.yaml
@@ -12,7 +12,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       serviceAccountName: {{ include "karpenter.serviceAccountName" . }}


### PR DESCRIPTION
Fixes #6765

Fixes an argocd issue where helm hooks never finish syncing when they have `ttlSecondsAfterFinished` set to `0`.

- See related argocd issue: https://github.com/argoproj/argo-cd/issues/6880
- Suggested workaround as implemented by argocd team (set `ttlSecondsAfterFinished` to `60`: https://github.com/argoproj/argo-helm/pull/2861

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.