### PR TITLE
ci: Enable `copyloopvar` in linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,7 @@ linters:
     - asciicheck
     - bidichk
     - errorlint
-    - exportloopref
+    - copyloopvar
     - gosec
     - revive
     - stylecheck

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -2495,7 +2495,6 @@ func generateSpotPricing(cp *cloudprovider.CloudProvider, nodePool *karpv1.NodeP
 			}
 		}
 		for _, o := range instanceType.Offerings {
-			o := o
 			if o.Requirements.Get(karpv1.CapacityTypeLabelKey).Any() != karpv1.CapacityTypeSpot {
 				continue
 			}

--- a/test/pkg/environment/common/monitor.go
+++ b/test/pkg/environment/common/monitor.go
@@ -133,7 +133,6 @@ func (m *Monitor) DeletedNodes() []*corev1.Node {
 func (m *Monitor) PendingPods(selector labels.Selector) []*corev1.Pod {
 	var pods []*corev1.Pod
 	for _, pod := range m.poll().pods.Items {
-		pod := pod
 		if pod.Status.Phase != corev1.PodPending {
 			continue
 		}
@@ -152,7 +151,6 @@ func (m *Monitor) PendingPodsCount(selector labels.Selector) int {
 func (m *Monitor) RunningPods(selector labels.Selector) []*corev1.Pod {
 	var pods []*corev1.Pod
 	for _, pod := range m.poll().pods.Items {
-		pod := pod
 		if pod.Status.Phase != corev1.PodRunning {
 			continue
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Replace `exportloopref` with `copyloopvar` (see https://go.dev/blog/loopvar-preview for more detail)

```console
cd . && golangci-lint run 
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.