### PR TITLE
fix: "iam:PassRole" defined in CFN to work properly in AWS China

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -212,7 +212,10 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+                  "iam:PassedToService": [
+                    "ec2.amazonaws.com",
+                    "ec2.amazonaws.com.cn"
+                  ]
                 }
               }
             },

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -212,7 +212,7 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
                 }
               }
             },

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -375,7 +375,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.amazonaws.com"
+      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
     }
   }
 }

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -375,7 +375,10 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+      "iam:PassedToService": [
+        "ec2.amazonaws.com",
+        "ec2.amazonaws.com.cn"
+      ]
     }
   }
 }

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -212,7 +212,10 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+                  "iam:PassedToService": [
+                    "ec2.amazonaws.com",
+                    "ec2.amazonaws.com.cn"
+                  ]
                 }
               }
             },

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -212,7 +212,7 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
                 }
               }
             },

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -375,7 +375,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.amazonaws.com"
+      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
     }
   }
 }

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -375,7 +375,10 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+      "iam:PassedToService": [
+        "ec2.amazonaws.com",
+        "ec2.amazonaws.com.cn"
+      ]
     }
   }
 }

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -189,7 +189,10 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+                  "iam:PassedToService": [
+                    "ec2.amazonaws.com",
+                    "ec2.amazonaws.com.cn"
+                  ]
                 }
               }
             },

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -189,7 +189,7 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
                 }
               }
             },

--- a/website/content/en/v0.32/reference/cloudformation.md
+++ b/website/content/en/v0.32/reference/cloudformation.md
@@ -341,7 +341,10 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+      "iam:PassedToService": [
+        "ec2.amazonaws.com",
+        "ec2.amazonaws.com.cn"
+      ]
     }
   }
 }

--- a/website/content/en/v0.32/reference/cloudformation.md
+++ b/website/content/en/v0.32/reference/cloudformation.md
@@ -341,7 +341,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.amazonaws.com"
+      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
     }
   }
 }

--- a/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -206,7 +206,7 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
                 }
               }
             },

--- a/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -206,7 +206,10 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+                  "iam:PassedToService": [
+                    "ec2.amazonaws.com",
+                    "ec2.amazonaws.com.cn"
+                  ]
                 }
               }
             },

--- a/website/content/en/v0.36/reference/cloudformation.md
+++ b/website/content/en/v0.36/reference/cloudformation.md
@@ -367,7 +367,10 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+      "iam:PassedToService": [
+        "ec2.amazonaws.com",
+        "ec2.amazonaws.com.cn"
+      ]
     }
   }
 }

--- a/website/content/en/v0.36/reference/cloudformation.md
+++ b/website/content/en/v0.36/reference/cloudformation.md
@@ -367,7 +367,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.amazonaws.com"
+      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
     }
   }
 }

--- a/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -206,7 +206,7 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
                 }
               }
             },

--- a/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -206,7 +206,10 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+                  "iam:PassedToService": [
+                    "ec2.amazonaws.com",
+                    "ec2.amazonaws.com.cn"
+                  ]
                 }
               }
             },

--- a/website/content/en/v0.37/reference/cloudformation.md
+++ b/website/content/en/v0.37/reference/cloudformation.md
@@ -367,7 +367,10 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+      "iam:PassedToService": [
+        "ec2.amazonaws.com",
+        "ec2.amazonaws.com.cn"
+      ]
     }
   }
 }

--- a/website/content/en/v0.37/reference/cloudformation.md
+++ b/website/content/en/v0.37/reference/cloudformation.md
@@ -367,7 +367,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.amazonaws.com"
+      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
     }
   }
 }

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -212,7 +212,10 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+                  "iam:PassedToService": [
+                    "ec2.amazonaws.com",
+                    "ec2.amazonaws.com.cn"
+                  ]
                 }
               }
             },

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -212,7 +212,7 @@ Resources:
               "Action": "iam:PassRole",
               "Condition": {
                 "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+                  "iam:PassedToService": "ec2.${AWS::URLSuffix}"
                 }
               }
             },

--- a/website/content/en/v1.0/reference/cloudformation.md
+++ b/website/content/en/v1.0/reference/cloudformation.md
@@ -375,7 +375,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.amazonaws.com"
+      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
     }
   }
 }

--- a/website/content/en/v1.0/reference/cloudformation.md
+++ b/website/content/en/v1.0/reference/cloudformation.md
@@ -375,7 +375,10 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
   "Action": "iam:PassRole",
   "Condition": {
     "StringEquals": {
-      "iam:PassedToService": "ec2.${AWS::URLSuffix}"
+      "iam:PassedToService": [
+        "ec2.amazonaws.com",
+        "ec2.amazonaws.com.cn"
+      ]
     }
   }
 }


### PR DESCRIPTION
Fixes #6843

**Description**

This change fixes `User <role> is not authorized to perform: iam:PassRole on resource...` error in AWS China

**How was this change tested?**

Manually in aws-cn partition.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.