### PR TITLE
chore: Alow service namespace override

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1303,7 +1303,7 @@ spec:
       clientConfig:
         service:
           name: {{ .Values.webhook.serviceName }}
-          namespace: {{ .Release.Namespace }}
+          namespace: {{ .Values.webhook.serviceNamespace | default .Release.Namespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
 

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -826,7 +826,7 @@ spec:
       clientConfig:
         service:
           name: {{ .Values.webhook.serviceName }}
-          namespace: {{ .Release.Namespace }}
+          namespace: {{ .Values.webhook.serviceNamespace | default .Release.Namespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
 

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -1077,7 +1077,7 @@ spec:
       clientConfig:
         service:
           name: {{ .Values.webhook.serviceName }}
-          namespace: {{ .Release.Namespace }}
+          namespace: {{ .Values.webhook.serviceNamespace | default .Release.Namespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
 

--- a/charts/karpenter-crd/values.yaml
+++ b/charts/karpenter-crd/values.yaml
@@ -2,5 +2,6 @@ webhook:
   # -- Whether to enable the webhooks.
   enabled: true
   serviceName: karpenter
+  serviceNamespace: ""
   # -- The container port to use for the webhook.
   port: 8443

--- a/hack/mutation/conversion_webhooks_injection.sh
+++ b/hack/mutation/conversion_webhooks_injection.sh
@@ -18,7 +18,7 @@ echo "{{- if .Values.webhook.enabled }}
       clientConfig:
         service:
           name: {{ .Values.webhook.serviceName }}
-          namespace: {{ .Release.Namespace }}
+          namespace: {{ .Values.webhook.serviceNamespace | default .Release.Namespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
 " >>  charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -33,7 +33,7 @@ echo "{{- if .Values.webhook.enabled }}
       clientConfig:
         service:
           name: {{ .Values.webhook.serviceName }}
-          namespace: {{ .Release.Namespace }}
+          namespace: {{ .Values.webhook.serviceNamespace | default .Release.Namespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
 " >>  charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -48,7 +48,7 @@ echo "{{- if .Values.webhook.enabled }}
       clientConfig:
         service:
           name: {{ .Values.webhook.serviceName }}
-          namespace: {{ .Release.Namespace }}
+          namespace: {{ .Values.webhook.serviceNamespace | default .Release.Namespace }}
           port: {{ .Values.webhook.port }}
 {{- end }}
 " >>  charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Allow `webhook.serviceNamespace` override in conversion block

**How was this change tested?**

`helm upgrade --install karpenter-crd ./charts/karpenter-crd

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.