### PR TITLE
docs: Update EBS CSI topology example and note

### DIFF
--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -445,7 +445,7 @@ provisioner: ebs.csi.aws.com
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
 - matchLabelExpressions:
-  - key: topology.ebs.csi.aws.com/zone
+  - key: topology.kubernetes.io/zone
     values: ["us-west-2a", "us-west-2b"]
 ---
 apiVersion: v1
@@ -464,7 +464,7 @@ spec:
 {{% alert title="Note" color="primary" %}}
 ☁️ AWS Specific
 
-The EBS CSI driver uses `topology.ebs.csi.aws.com/zone` instead of the standard `topology.kubernetes.io/zone` label. Karpenter is aware of label aliasing and translates this label into `topology.kubernetes.io/zone` in memory. When configuring a `StorageClass` for the EBS CSI Driver, you must use `topology.ebs.csi.aws.com/zone`.
+Volumes created by the EBS CSI driver [prior to version v1.33.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#v1330) use `topology.ebs.csi.aws.com/zone` instead of the standard `topology.kubernetes.io/zone` label. Karpenter is aware of label aliasing and translates this label into `topology.kubernetes.io/zone` in memory.
 {{% /alert %}}
 
 {{% alert title="Note" color="primary" %}}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

[As of `v1.33.0`](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#v1330), the EBS CSI Driver no longer creates volumes with a custom topology key (`topology.ebs.csi.aws.com/zone`), and instead uses the standard key (`topology.kubernetes.io/zone`).

Update the example in the docs, and change the note to include the cutoff version.

**How was this change tested?**

Largely N/A, docs change. Manually applied the example manifests to a cluster running Karpenter and the EBS CSI Driver to confirm validity.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.