### PR TITLE
chore: Drop `ec2:DescribeAvailabilityZones` permissions

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -167,7 +167,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "*",
               "Action": [
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/docs/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/docs/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -36,7 +36,6 @@ cat << EOF > controller-policy.json
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DeleteLaunchTemplate",
                 "ec2:CreateTags",
                 "ec2:CreateLaunchTemplate",

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -298,7 +298,6 @@ This allows the Karpenter controller to do any of those read-only actions across
   "Effect": "Allow",
   "Resource": "*",
   "Action": [
-    "ec2:DescribeAvailabilityZones",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
     "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -167,7 +167,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "*",
               "Action": [
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -36,7 +36,6 @@ cat << EOF > controller-policy.json
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DeleteLaunchTemplate",
                 "ec2:CreateTags",
                 "ec2:CreateLaunchTemplate",

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -298,7 +298,6 @@ This allows the Karpenter controller to do any of those read-only actions across
   "Effect": "Allow",
   "Resource": "*",
   "Action": [
-    "ec2:DescribeAvailabilityZones",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
     "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.36/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -161,7 +161,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "*",
               "Action": [
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/v0.36/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/v0.36/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -36,7 +36,6 @@ cat << EOF > controller-policy.json
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DeleteLaunchTemplate",
                 "ec2:CreateTags",
                 "ec2:CreateLaunchTemplate",

--- a/website/content/en/v0.36/reference/cloudformation.md
+++ b/website/content/en/v0.36/reference/cloudformation.md
@@ -290,7 +290,6 @@ This allows the Karpenter controller to do any of those read-only actions across
   "Effect": "Allow",
   "Resource": "*",
   "Action": [
-    "ec2:DescribeAvailabilityZones",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
     "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.37/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -161,7 +161,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "*",
               "Action": [
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/v0.37/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/v0.37/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -36,7 +36,6 @@ cat << EOF > controller-policy.json
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DeleteLaunchTemplate",
                 "ec2:CreateTags",
                 "ec2:CreateLaunchTemplate",

--- a/website/content/en/v0.37/reference/cloudformation.md
+++ b/website/content/en/v0.37/reference/cloudformation.md
@@ -290,7 +290,6 @@ This allows the Karpenter controller to do any of those read-only actions across
   "Effect": "Allow",
   "Resource": "*",
   "Action": [
-    "ec2:DescribeAvailabilityZones",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
     "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -167,7 +167,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "*",
               "Action": [
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypeOfferings",

--- a/website/content/en/v1.0/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/v1.0/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -36,7 +36,6 @@ cat << EOF > controller-policy.json
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeAvailabilityZones",
                 "ec2:DeleteLaunchTemplate",
                 "ec2:CreateTags",
                 "ec2:CreateLaunchTemplate",

--- a/website/content/en/v1.0/reference/cloudformation.md
+++ b/website/content/en/v1.0/reference/cloudformation.md
@@ -298,7 +298,6 @@ This allows the Karpenter controller to do any of those read-only actions across
   "Effect": "Allow",
   "Resource": "*",
   "Action": [
-    "ec2:DescribeAvailabilityZones",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
     "ec2:DescribeInstanceTypeOfferings",


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

`ec2:DescribeAvailabilityZones` permission has not been needed for a little bit since we dropped this call from our GetInstanceTypes() call path. We can remove this READ permission from our policy

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.