### PR TITLE
chore: Fix e2e test matrix script syntax

### DIFF
--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -2,7 +2,7 @@ aws eks update-kubeconfig --name "$CLUSTER_NAME"
 
 CHART="oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/karpenter/snapshot/karpenter"
 ADDITIONAL_FLAGS=""
-if (( "$PRIVATE_CLUSTER" == 'true' )); then
+if (( "$PRIVATE_CLUSTER" == "true" )); then
   CHART="oci://$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/karpenter/snapshot/karpenter"
   ADDITIONAL_FLAGS="--set .Values.controller.image.repository=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/karpenter/snapshot/controller --set .Values.controller.image.digest=\"\" --set .Values.postInstallHook.image.repository=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/ecr-public/bitnami/kubectl --set .Values.postInstallHook.image.digest=\"\""
 fi


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->
![image](https://github.com/user-attachments/assets/65df71f4-76ba-46c3-8b23-f88775661953)

**Description**
- Fix e2e test matrix script syntax

**How was this change tested?**

You can reproduce locally with the following:

Current, throws error:
```sh
#!/bin/bash

if (( "$PRIVATE_CLUSTER" == 'true' )); then
  echo "Private cluster is enabled"
else
  echo "Private cluster is disabled"
fi
```

Fixed, no error:
```sh
#!/bin/bash

if (( "$PRIVATE_CLUSTER" == "true" )); then
  echo "Private cluster is enabled"
else
  echo "Private cluster is disabled"
fi
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.