### PR TITLE
chore: Fix env vars used in e2e Karpenter install and diff test scripts

### DIFF
--- a/test/hack/e2e_scripts/diff_karpenter.sh
+++ b/test/hack/e2e_scripts/diff_karpenter.sh
@@ -1,7 +1,4 @@
 CHART="oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/karpenter/snapshot/karpenter"
-if [[ "$PRIVATE_CLUSTER" == "true" ]]; then
-  CHART="oci://$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/karpenter/snapshot/karpenter"
-fi
 
 helm diff upgrade --namespace kube-system \
 karpenter "${CHART}" \

--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -1,10 +1,13 @@
 aws eks update-kubeconfig --name "$CLUSTER_NAME"
 
-CHART="oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/karpenter/snapshot/karpenter"
+ECR_URI="oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com"
+CHART="$ECR_URI/karpenter/snapshot/karpenter"
 ADDITIONAL_FLAGS=""
-if [[ "$PRIVATE_CLUSTER" == "true" ]]; then
-  CHART="oci://$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/karpenter/snapshot/karpenter"
-  ADDITIONAL_FLAGS="--set .Values.controller.image.repository=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/karpenter/snapshot/controller --set .Values.controller.image.digest=\"\" --set .Values.postInstallHook.image.repository=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/ecr-public/bitnami/kubectl --set .Values.postInstallHook.image.digest=\"\""
+if [ "$PRIVATE_CLUSTER" == "true" ]; then
+  ADDITIONAL_FLAGS="--set .Values.controller.image.repository=$ECR_URI/karpenter/snapshot/controller \
+    --set .Values.controller.image.digest=\"\" \
+    --set .Values.postInstallHook.image.repository=$ECR_URI/ecr-public/bitnami/kubectl \
+    --set .Values.postInstallHook.image.digest=\"\""
 fi
 
 helm upgrade --install karpenter "${CHART}" \


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

Notice that the region is missing from the endpoint that is rendered in the script

![image](https://github.com/user-attachments/assets/d200e81d-46cc-4a86-9fcd-fb7b1453d833)

**Description**
- Fix env vars used in e2e Karpenter install and diff test scripts
  - Since the URI format for ECR is using the ECR DKR endpoint, there shouldn't need to be a difference between endpoints for public cluster vs private cluster (unless the images are located in a different accounts). Therefore the endpoints should be the same between public and private cluster usage which means the same account ID and region. If my understanding of https://github.com/aws/karpenter-provider-aws/blob/c92515867cb869aad4a5781c7f23aeb30063064e/.github/actions/e2e/install-karpenter/action.yaml#L51-L67 is correct - `ACCOUND_ID` and `REGION` are the account ID and region where the clusters are created whereas the `ECR_ACCOUNT_ID` and `ECR_REGION` are the account ID and region where the Helm chart and images are stored within ECR. The prior scripts were switching between a mix of cluster account ID and region and the ECR account ID and region, which not all of those values are provided to the script and resulted in incorrect template rendering

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.