### PR TITLE
chore: Always disable instance metadata tags

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -250,6 +250,12 @@ func (p *DefaultProvider) createLaunchTemplate(ctx context.Context, options *ami
 				HttpProtocolIpv6:        options.MetadataOptions.HTTPProtocolIPv6,
 				HttpPutResponseHopLimit: options.MetadataOptions.HTTPPutResponseHopLimit,
 				HttpTokens:              options.MetadataOptions.HTTPTokens,
+				// We statically set the InstanceMetadataTags to "disabled" for all new instances since
+				// account-wide defaults can override instance defaults on metadata settings
+				// This can cause instance failure on accounts that default to instance tags since Karpenter
+				// can't support instance tags with its current tags (e.g. kubernetes.io/cluster/*, karpenter.k8s.aws/ec2nodeclass)
+				// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html#instance-metadata-options-order-of-precedence
+				InstanceMetadataTags: lo.ToPtr(ec2.InstanceMetadataTagsStateDisabled),
 			},
 			NetworkInterfaces: networkInterfaces,
 			TagSpecifications: launchTemplateDataTags,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change always disables instance metadata tags. Not passing this setting _explicitly_ to the instance launch can cause an account that [has configured account defaults for instance metadata settings](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html#instance-metadata-options-order-of-precedence) to override the instance default. If the account default has IMDS tags set to `enabled`, EC2 will use this, causing Karpenter to fail to launch instances with

```
  - lastTransitionTime: "2024-09-15T05:00:09Z"
    message: 'creating instance, with fleet error(s), InvalidParameterValue: ''kubernetes.io/cluster/scale-test''
      is not a valid tag key. Tag keys must match pattern ([0-9a-zA-Z\\-_+=,.@:]{1,255}),
      and must not be a reserved name (''.'', ''..'', ''_index''); RequestLimitExceeded:
      Request limit exceeded.'
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.