### PR TITLE
test: fix private cluster test

### DIFF
--- a/test/suites/integration/tags_test.go
+++ b/test/suites/integration/tags_test.go
@@ -86,6 +86,9 @@ var _ = Describe("Tags", func() {
 			Expect(spotInstanceRequest.Tags).To(ContainElement(&ec2.Tag{Key: lo.ToPtr("TestTag"), Value: lo.ToPtr("TestVal")}))
 		})
 		It("should tag managed instance profiles", func() {
+			if env.PrivateCluster {
+				Skip("skipping managed instance profiles test for private cluster")
+			}
 			nodeClass.Spec.Tags["TestTag"] = "TestVal"
 			env.ExpectCreated(nodeClass)
 
@@ -97,6 +100,9 @@ var _ = Describe("Tags", func() {
 			))
 		})
 		It("should tag managed instance profiles with the eks:eks-cluster-name tag key after restart", func() {
+			if env.PrivateCluster {
+				Skip("skipping managed instance profiles test for private cluster")
+			}
 			env.ExpectCreated(nodeClass)
 			env.EventuallyExpectInstanceProfileExists(env.GetInstanceProfileName(nodeClass))
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Tests that involve checking tags on managed instance profiles for private cluster are failing. This happens because we create and manage instance profiles manually for private clusters. Skipping these tests.

**How was this change tested?**
`manually tested`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.