### PR TITLE
chore: Added new policy to PodDisruptionBudget

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -70,6 +70,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.0.0 \
 | podAnnotations | object | `{}` | Additional annotations for the pod. |
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podDisruptionBudget.name | string | `"karpenter"` |  |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `nil` | Unhealthy pod eviction policy for the PDB. |
 | podLabels | object | `{}` | Additional labels for the pod. |
 | podSecurityContext | object | `{"fsGroup":65532}` | SecurityContext for the pod. |
 | priorityClassName | string | `"system-cluster-critical"` | PriorityClass name for the pod. |

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -70,7 +70,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.0.0 \
 | podAnnotations | object | `{}` | Additional annotations for the pod. |
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podDisruptionBudget.name | string | `"karpenter"` |  |
-| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `nil` | Unhealthy pod eviction policy for the PDB. |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `AlwaysAllow` | Unhealthy pod eviction policy for the PDB. |
 | podLabels | object | `{}` | Additional labels for the pod. |
 | podSecurityContext | object | `{"fsGroup":65532}` | SecurityContext for the pod. |
 | priorityClassName | string | `"system-cluster-critical"` | PriorityClass name for the pod. |

--- a/charts/karpenter/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter/templates/poddisruptionbudget.yaml
@@ -11,6 +11,11 @@ metadata:
   {{- end }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if ge .Capabilities.KubeVersion.Minor "27" }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  {{- end  }}
   selector:
     matchLabels:
     {{- include "karpenter.selectorLabels" . | nindent 6 }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -49,7 +49,7 @@ podAnnotations: {}
 podDisruptionBudget:
   name: karpenter
   maxUnavailable: 1
-  unhealthyPodEvictionPolicy:
+  unhealthyPodEvictionPolicy: AlwaysAllow
 # -- SecurityContext for the pod.
 podSecurityContext:
   fsGroup: 65532

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -49,6 +49,7 @@ podAnnotations: {}
 podDisruptionBudget:
   name: karpenter
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy:
 # -- SecurityContext for the pod.
 podSecurityContext:
   fsGroup: 65532


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7025 

**Description**

Added the `unhealthyPodEvictionPolicy` to the Karpenter PDB.

**How was this change tested?**

I generated a helm template file locally and tried to set `unhealthyPodEvictionPolicy` in the chart values to `AlwaysAllow`:
![Screenshot 2024-09-18 at 13 07 13](https://github.com/user-attachments/assets/a7c5ca4a-b035-45d8-ad35-f1762d841336)

I also tried not setting anything in the chart values and expected that there would be no mention of `unhealthyPodEvictionPolicy` in the spec:
![Screenshot 2024-09-18 at 13 09 35](https://github.com/user-attachments/assets/56cfec88-b620-4288-bba4-b6a9d4350f64)

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.