### PR TITLE
Allow the scheduler to be updated

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -56,6 +56,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.0.0 \
 | controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |
 | controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
+| schedulerName | string | `""` | Override the default scheduler |
 | dnsPolicy | string | `"ClusterFirst"` | Configure the DNS Policy for the pod |
 | extraVolumes | list | `[]` | Additional volumes for the pod. |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname. |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
+      {{- with .Values.schedulerName }}
+      schedulerName: {{ . | quote }}
+      {{- end }}
       containers:
         - name: controller
           securityContext:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -63,6 +63,8 @@ hostNetwork: false
 dnsPolicy: ClusterFirst
 # -- Configure DNS Config for the pod
 dnsConfig: {}
+# -- Override the default scheduler
+schedulerName: ""
 #  options:
 #    - name: ndots
 #      value: "1"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change allows the scheduler for the karpenter pods to be changed.
This is usefull when using a custom scheduler, when mixing 2 different schedulers you might run into issues with priority and preemption (one scheduler deleting a pod to make room for Karpenter, but the other scheduler quickly schedules a new pod because there is room).

**How was this change tested?**

Copy of the helm chart applied locally

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

It updates the helm chart docs, but not the karpenter docs. They have been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.