### PR TITLE
fix: update test to reduce create fleet payload size v0.36.x

### DIFF
--- a/test/suites/integration/termination_test.go
+++ b/test/suites/integration/termination_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Termination", func() {
 		env.ExpectDeleted(nodes[0])
 		env.EventuallyExpectNotFound(nodes[0])
 		Eventually(func(g Gomega) {
-			g.Expect(lo.FromPtr(env.GetInstanceByID(instanceID).State.Name)).To(Equal("shutting-down"))
+			g.Expect(lo.FromPtr(env.GetInstanceByID(instanceID).State.Name)).To(BeElementOf("shutting-down", "terminated"))
 		}, time.Second*10).Should(Succeed())
 	})
 })

--- a/test/suites/nodeclaim/garbage_collection_test.go
+++ b/test/suites/nodeclaim/garbage_collection_test.go
@@ -140,7 +140,7 @@ var _ = Describe("GarbageCollection", func() {
 		// Eventually expect the node and the instance to be removed (shutting-down)
 		env.EventuallyExpectNotFound(node)
 		Eventually(func(g Gomega) {
-			g.Expect(lo.FromPtr(env.GetInstanceByID(aws.StringValue(out.Instances[0].InstanceId)).State.Name)).To(Equal("shutting-down"))
+			g.Expect(lo.FromPtr(env.GetInstanceByID(aws.StringValue(out.Instances[0].InstanceId)).State.Name)).To(BeElementOf("shutting-down", "terminated"))
 		}, time.Second*10).Should(Succeed())
 	})
 	It("should succeed to garbage collect an Instance that was deleted without the cluster's knowledge", func() {

--- a/test/suites/nodeclaim/nodeclaim_test.go
+++ b/test/suites/nodeclaim/nodeclaim_test.go
@@ -50,6 +50,13 @@ var _ = Describe("StandaloneNodeClaim", func() {
 					},
 					{
 						NodeSelectorRequirement: v1.NodeSelectorRequirement{
+							Key:      v1.LabelArchStable,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"arm64"},
+						},
+					},
+					{
+						NodeSelectorRequirement: v1.NodeSelectorRequirement{
 							Key:      corev1beta1.CapacityTypeLabelKey,
 							Operator: v1.NodeSelectorOpIn,
 							Values:   []string{corev1beta1.CapacityTypeOnDemand},
@@ -203,6 +210,13 @@ var _ = Describe("StandaloneNodeClaim", func() {
 					},
 					{
 						NodeSelectorRequirement: v1.NodeSelectorRequirement{
+							Key:      v1.LabelArchStable,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"arm64"},
+						},
+					},
+					{
+						NodeSelectorRequirement: v1.NodeSelectorRequirement{
 							Key:      corev1beta1.CapacityTypeLabelKey,
 							Operator: v1.NodeSelectorOpIn,
 							Values:   []string{corev1beta1.CapacityTypeOnDemand},
@@ -226,7 +240,7 @@ var _ = Describe("StandaloneNodeClaim", func() {
 		env.EventuallyExpectNotFound(nodeClaim, node)
 
 		Eventually(func(g Gomega) {
-			g.Expect(lo.FromPtr(env.GetInstanceByID(instanceID).State.Name)).To(Equal("shutting-down"))
+			g.Expect(lo.FromPtr(env.GetInstanceByID(instanceID).State.Name)).To(BeElementOf("shutting-down", "terminated"))
 		}, time.Second*10).Should(Succeed())
 	})
 	It("should delete a NodeClaim from the node termination finalizer", func() {
@@ -238,6 +252,13 @@ var _ = Describe("StandaloneNodeClaim", func() {
 							Key:      v1beta1.LabelInstanceCategory,
 							Operator: v1.NodeSelectorOpIn,
 							Values:   []string{"c"},
+						},
+					},
+					{
+						NodeSelectorRequirement: v1.NodeSelectorRequirement{
+							Key:      v1.LabelArchStable,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"arm64"},
 						},
 					},
 					{
@@ -265,7 +286,7 @@ var _ = Describe("StandaloneNodeClaim", func() {
 		env.EventuallyExpectNotFound(nodeClaim, node)
 
 		Eventually(func(g Gomega) {
-			g.Expect(lo.FromPtr(env.GetInstanceByID(instanceID).State.Name)).To(Equal("shutting-down"))
+			g.Expect(lo.FromPtr(env.GetInstanceByID(instanceID).State.Name)).To(BeElementOf("shutting-down", "terminated"))
 		}, time.Second*10).Should(Succeed())
 	})
 	It("should create a NodeClaim with custom labels passed through the userData", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes issue where create fleet calls can fail. This will only fail in the test suite due to filtering being done on the scheduler side, so it only affects standalone nodeclaims (which are unsupported).

**How was this change tested?**
E2Es.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.