### PR TITLE
fix: enable migration controllers if webhooks are enabled

### DIFF
--- a/charts/karpenter/templates/clusterrole-core.yaml
+++ b/charts/karpenter/templates/clusterrole-core.yaml
@@ -68,11 +68,11 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["delete"]
+  {{- if .Values.webhook.enabled }}
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions/status"]
     resourceNames: ["ec2nodeclasses.karpenter.k8s.aws", "nodepools.karpenter.sh", "nodeclaims.karpenter.sh"]
     verbs: ["patch"]
-  {{- if .Values.webhook.enabled }}
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     resourceNames: ["ec2nodeclasses.karpenter.k8s.aws", "nodepools.karpenter.sh", "nodeclaims.karpenter.sh"]

--- a/charts/karpenter/templates/clusterrole-core.yaml
+++ b/charts/karpenter/templates/clusterrole-core.yaml
@@ -41,11 +41,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
     verbs: ["list", "watch"]
-  {{- if .Values.webhook.enabled }}
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["watch", "list"]
-  {{- end }}
+    verbs: ["get", "watch", "list"]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "list", "watch"]
@@ -75,6 +73,7 @@ rules:
   {{- if .Values.webhook.enabled }}
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
+    resourceNames: ["ec2nodeclasses.karpenter.k8s.aws", "nodepools.karpenter.sh", "nodeclaims.karpenter.sh"]
     verbs: ["update"]
   {{- end }}
   {{- with .Values.additionalClusterRoleRules -}}

--- a/charts/karpenter/templates/clusterrole-core.yaml
+++ b/charts/karpenter/templates/clusterrole-core.yaml
@@ -41,9 +41,11 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
     verbs: ["list", "watch"]
+  {{- if .Values.webhook.enabled }}
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "watch", "list"]
+  {{- end }}
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "list", "watch"]

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -44,6 +44,7 @@ func main() {
 
 	op.
 		WithControllers(ctx, corecontrollers.NewControllers(
+			ctx,
 			op.Manager,
 			op.Clock,
 			op.GetClient(),

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/pkg v0.0.0-20231010144348-ca8c009405dd
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v1.0.2
+	sigs.k8s.io/karpenter v1.0.3-0.20240930210524-ced4d37eda82
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,6 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v1.0.2 h1:llX4Sb6cLZmSZImMqFktZ3O+M8+nlc8xRcAEtfQVzCI=
-sigs.k8s.io/karpenter v1.0.2/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
 sigs.k8s.io/karpenter v1.0.3-0.20240930210524-ced4d37eda82 h1:kKll2aUiWasrhrIkZF2fwSC7T5snCirfTQV3mjn0rH4=
 sigs.k8s.io/karpenter v1.0.3-0.20240930210524-ced4d37eda82/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=

--- a/go.sum
+++ b/go.sum
@@ -763,6 +763,8 @@ sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMm
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/karpenter v1.0.2 h1:llX4Sb6cLZmSZImMqFktZ3O+M8+nlc8xRcAEtfQVzCI=
 sigs.k8s.io/karpenter v1.0.2/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
+sigs.k8s.io/karpenter v1.0.3-0.20240930210524-ced4d37eda82 h1:kKll2aUiWasrhrIkZF2fwSC7T5snCirfTQV3mjn0rH4=
+sigs.k8s.io/karpenter v1.0.3-0.20240930210524-ced4d37eda82/go.mod h1:3NLmsnHHw8p4VutpjTOPUZyhE3qH6yGTs8O94Lsu8uw=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -20,9 +20,7 @@ import (
 	"github.com/awslabs/operatorpkg/controller"
 	"github.com/awslabs/operatorpkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
-	migrationcrd "sigs.k8s.io/karpenter/pkg/controllers/migration/crd"
 	migration "sigs.k8s.io/karpenter/pkg/controllers/migration/resource"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -73,10 +71,7 @@ func NewControllers(ctx context.Context, mgr manager.Manager, sess *session.Sess
 		status.NewController[*v1.EC2NodeClass](kubeClient, mgr.GetEventRecorderFor("karpenter")),
 	}
 	if !karpoptions.FromContext(ctx).DisableWebhook {
-		controllers = append(controllers, migration.NewController[*karpv1.NodeClaim](kubeClient))
-		controllers = append(controllers, migration.NewController[*karpv1.NodePool](kubeClient))
 		controllers = append(controllers, migration.NewController[*v1.EC2NodeClass](kubeClient))
-		controllers = append(controllers, migrationcrd.NewController(kubeClient, cloudProvider))
 	}
 	if options.FromContext(ctx).InterruptionQueue != "" {
 		sqsapi := servicesqs.New(sess)

--- a/test/suites/integration/migration_test.go
+++ b/test/suites/integration/migration_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package integration_test
 
 import (
-	"fmt"
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -88,7 +87,6 @@ var _ = Describe("EC2NodeClass Migration Controller", func() {
 			crd := &apiextensionsv1.CustomResourceDefinition{}
 			Eventually(func(g Gomega) {
 				g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(item), crd)).To(Succeed())
-				fmt.Println(crd.Status.StoredVersions)
 				g.Expect(crd.Status.StoredVersions).To(HaveExactElements("v1"))
 			}).WithTimeout(time.Second * 10).Should(Succeed())
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes caches failing to sync on latest patch when webhooks are disabled by not starting migration controllers when webhooks are disabled. This also moves `crd/status` `patch` to a conditional block and scopes `crd` `update` to only Karpenter CRDs.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.