### PR TITLE
chore: Drop ENILimitedPodDensity option

### DIFF
--- a/pkg/providers/amifamily/al2023.go
+++ b/pkg/providers/amifamily/al2023.go
@@ -78,16 +78,15 @@ func (a AL2023) resolvePath(architecture, variant, k8sVersion, amiVersion string
 func (a AL2023) UserData(kubeletConfig *v1.KubeletConfiguration, taints []corev1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string, instanceStorePolicy *v1.InstanceStorePolicy) bootstrap.Bootstrapper {
 	return bootstrap.Nodeadm{
 		Options: bootstrap.Options{
-			ClusterName:             a.Options.ClusterName,
-			ClusterEndpoint:         a.Options.ClusterEndpoint,
-			ClusterCIDR:             a.Options.ClusterCIDR,
-			KubeletConfig:           kubeletConfig,
-			Taints:                  taints,
-			Labels:                  labels,
-			CABundle:                caBundle,
-			AWSENILimitedPodDensity: false,
-			CustomUserData:          customUserData,
-			InstanceStorePolicy:     instanceStorePolicy,
+			ClusterName:         a.Options.ClusterName,
+			ClusterEndpoint:     a.Options.ClusterEndpoint,
+			ClusterCIDR:         a.Options.ClusterCIDR,
+			KubeletConfig:       kubeletConfig,
+			Taints:              taints,
+			Labels:              labels,
+			CABundle:            caBundle,
+			CustomUserData:      customUserData,
+			InstanceStorePolicy: instanceStorePolicy,
 		},
 	}
 }

--- a/pkg/providers/amifamily/bootstrap/bootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/bootstrap.go
@@ -28,17 +28,16 @@ import (
 
 // Options is the node bootstrapping parameters passed from Karpenter to the provisioning node
 type Options struct {
-	ClusterName             string
-	ClusterEndpoint         string
-	ClusterCIDR             *string
-	KubeletConfig           *v1.KubeletConfiguration
-	Taints                  []corev1.Taint    `hash:"set"`
-	Labels                  map[string]string `hash:"set"`
-	CABundle                *string
-	AWSENILimitedPodDensity bool
-	ContainerRuntime        *string
-	CustomUserData          *string
-	InstanceStorePolicy     *v1.InstanceStorePolicy
+	ClusterName         string
+	ClusterEndpoint     string
+	ClusterCIDR         *string
+	KubeletConfig       *v1.KubeletConfiguration
+	Taints              []corev1.Taint    `hash:"set"`
+	Labels              map[string]string `hash:"set"`
+	CABundle            *string
+	ContainerRuntime    *string
+	CustomUserData      *string
+	InstanceStorePolicy *v1.InstanceStorePolicy
 }
 
 func (o Options) kubeletExtraArgs() (args []string) {

--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -44,11 +44,8 @@ func (b Bottlerocket) Script() (string, error) {
 		return "", err
 	}
 
-	// Backwards compatibility for AWSENILimitedPodDensity flag
 	if b.KubeletConfig != nil && b.KubeletConfig.MaxPods != nil {
 		s.Settings.Kubernetes.MaxPods = aws.Int(int(lo.FromPtr(b.KubeletConfig.MaxPods)))
-	} else if !b.AWSENILimitedPodDensity {
-		s.Settings.Kubernetes.MaxPods = aws.Int(110)
 	}
 
 	if b.KubeletConfig != nil {

--- a/pkg/providers/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/eksbootstrap.go
@@ -71,7 +71,7 @@ func (e EKS) eksBootstrapScript() string {
 	if e.KubeletConfig != nil && len(e.KubeletConfig.ClusterDNS) > 0 {
 		userData.WriteString(fmt.Sprintf(" \\\n--dns-cluster-ip '%s'", e.KubeletConfig.ClusterDNS[0]))
 	}
-	if (e.KubeletConfig != nil && e.KubeletConfig.MaxPods != nil) || !e.AWSENILimitedPodDensity {
+	if e.KubeletConfig != nil && e.KubeletConfig.MaxPods != nil {
 		userData.WriteString(" \\\n--use-max-pods false")
 	}
 	if args := e.kubeletExtraArgs(); len(args) > 0 {
@@ -81,17 +81,6 @@ func (e EKS) eksBootstrapScript() string {
 		userData.WriteString(" \\\n--local-disks raid0")
 	}
 	return userData.String()
-}
-
-// kubeletExtraArgs for the EKS bootstrap.sh script uses the concept of ENI-limited pod density to set pods
-// If this argument is explicitly disabled, then set the max-pods value on the kubelet to the static value of 110
-func (e EKS) kubeletExtraArgs() []string {
-	args := e.Options.kubeletExtraArgs()
-	// Set the static value for --max-pods to 110 when AWSENILimitedPodDensity is explicitly disabled and the value isn't set
-	if !e.AWSENILimitedPodDensity && (e.KubeletConfig == nil || e.KubeletConfig.MaxPods == nil) {
-		args = append(args, "--max-pods=110")
-	}
-	return args
 }
 
 func (e EKS) mergeCustomUserData(userDatas ...string) (string, error) {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -465,7 +465,6 @@ var _ = Describe("LaunchTemplate Provider", func() {
 				{Taints: []corev1.Taint{{Key: "test-key", Value: "test-value"}}},
 				{Labels: map[string]string{"test-key": "test-value"}},
 				{CABundle: lo.ToPtr("test-bundle")},
-				{AWSENILimitedPodDensity: true},
 				{ContainerRuntime: lo.ToPtr("test-cri")},
 				{CustomUserData: lo.ToPtr("test-cidr")},
 			}
@@ -474,7 +473,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 				lt := &amifamily.LaunchTemplate{UserData: bootstrap.EKS{Options: *option}}
 				launchtemplateResult = append(launchtemplateResult, launchtemplate.LaunchTemplateName(lt))
 			}
-			Expect(len(launchtemplateResult)).To(BeNumerically("==", 10))
+			Expect(len(launchtemplateResult)).To(BeNumerically("==", 9))
 			Expect(lo.Uniq(launchtemplateResult)).To(Equal(launchtemplateResult))
 		})
 		It("should generate different launch template names based on launchtemplate option configuration", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

We had the ENILimitedPodDensity option that's continuing to be used in the code. This value cannot be any value other than `false` so it no longer makes sense to have this as an option.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.