### PR TITLE
test: fix consolidation test races

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -572,17 +572,17 @@ func (env *Environment) ConsistentlyExpectNoDisruptions(nodeCount int, duration 
 	Consistently(func(g Gomega) {
 		nodeClaimList := &karpv1.NodeClaimList{}
 		g.Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
-		g.Expect(len(nodeClaimList.Items)).To(HaveLen(nodeCount))
+		g.Expect(nodeClaimList.Items).To(HaveLen(nodeCount))
 		nodeList := &corev1.NodeList{}
 		g.Expect(env.Client.List(env, nodeList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
-		g.Expect(len(nodeList.Items)).To(HaveLen(nodeCount))
+		g.Expect(nodeList.Items).To(HaveLen(nodeCount))
 		nodeList.Items = lo.Filter(nodeList.Items, func(n corev1.Node, _ int) bool {
 			_, ok := lo.Find(n.Spec.Taints, func(t corev1.Taint) bool {
-				return karpv1.DisruptedNoScheduleTaint.MatchTaint(lo.ToPtr(t))
+				return t.MatchTaint(&karpv1.DisruptedNoScheduleTaint)
 			})
 			return ok
 		})
-		g.Expect(len(nodeList.Items)).To(HaveLen(nodeCount))
+		g.Expect(nodeList.Items).To(HaveLen(0))
 	}, duration).Should(Succeed())
 }
 

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/test"
@@ -532,17 +532,17 @@ func (env *Environment) ExpectNodeCount(comparator string, count int) []*corev1.
 	return lo.ToSlicePtr(nodeList.Items)
 }
 
-func (env *Environment) ExpectNodeClaimCount(comparator string, count int) []*v1.NodeClaim {
+func (env *Environment) ExpectNodeClaimCount(comparator string, count int) []*karpv1.NodeClaim {
 	GinkgoHelper()
 
-	nodeClaimList := &v1.NodeClaimList{}
+	nodeClaimList := &karpv1.NodeClaimList{}
 	Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
 	Expect(len(nodeClaimList.Items)).To(BeNumerically(comparator, count))
 	return lo.ToSlicePtr(nodeClaimList.Items)
 }
 
-func NodeClaimNames(nodeClaims []*v1.NodeClaim) []string {
-	return lo.Map(nodeClaims, func(n *v1.NodeClaim, index int) string {
+func NodeClaimNames(nodeClaims []*karpv1.NodeClaim) []string {
+	return lo.Map(nodeClaims, func(n *karpv1.NodeClaim, index int) string {
 		return n.Name
 	})
 }
@@ -570,7 +570,7 @@ func (env *Environment) ConsistentlyExpectNodeCount(comparator string, count int
 func (env *Environment) ConsistentlyExpectNoDisruptions(nodeCount int, duration time.Duration) {
 	GinkgoHelper()
 	Consistently(func(g Gomega) {
-		nodeClaimList := &v1.NodeClaimList{}
+		nodeClaimList := &karpv1.NodeClaimList{}
 		g.Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
 		g.Expect(len(nodeClaimList.Items)).To(HaveLen(nodeCount))
 		nodeList := &corev1.NodeList{}
@@ -578,7 +578,7 @@ func (env *Environment) ConsistentlyExpectNoDisruptions(nodeCount int, duration 
 		g.Expect(len(nodeList.Items)).To(HaveLen(nodeCount))
 		nodeList.Items = lo.Filter(nodeList.Items, func(n corev1.Node, _ int) bool {
 			_, ok := lo.Find(n.Spec.Taints, func(t corev1.Taint) bool {
-				return v1.DisruptedNoScheduleTaint.MatchTaint(lo.ToPtr(t))
+				return karpv1.DisruptedNoScheduleTaint.MatchTaint(lo.ToPtr(t))
 			})
 			return ok
 		})
@@ -595,12 +595,12 @@ func (env *Environment) ConsistentlyExpectDisruptionsUntilTarget(disruptingNodes
 	// We use an eventually to exit when we detect the number of tainted/disrupted nodes matches our target.
 	Eventually(func(g Gomega) {
 		// Ensure we don't change our NodeClaims
-		nodeClaimList := &v1.NodeClaimList{}
+		nodeClaimList := &karpv1.NodeClaimList{}
 		g.Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
 		// We don't consider nodes that have the `terminating` status condition towards our budget, so we shouldn't consider these nodes in our budget.
 		removedProviderIDs := sets.Set[string]{}
-		nodeClaimList.Items = lo.Filter(nodeClaimList.Items, func(nc v1.NodeClaim, _ int) bool {
-			if !nc.StatusConditions().IsTrue(v1.ConditionTypeInstanceTerminating) {
+		nodeClaimList.Items = lo.Filter(nodeClaimList.Items, func(nc karpv1.NodeClaim, _ int) bool {
+			if !nc.StatusConditions().IsTrue(karpv1.ConditionTypeInstanceTerminating) {
 				return true
 			}
 			removedProviderIDs.Insert(nc.Status.ProviderID)
@@ -622,7 +622,7 @@ func (env *Environment) ConsistentlyExpectDisruptionsUntilTarget(disruptingNodes
 
 		nodes = lo.Filter(nodeList.Items, func(n corev1.Node, _ int) bool {
 			_, ok := lo.Find(n.Spec.Taints, func(t corev1.Taint) bool {
-				return t.MatchTaint(&v1.DisruptedNoScheduleTaint)
+				return t.MatchTaint(&karpv1.DisruptedNoScheduleTaint)
 			})
 			return ok
 		})
@@ -657,10 +657,10 @@ func (env *Environment) EventuallyExpectNodesUntaintedWithTimeout(timeout time.D
 	}).WithTimeout(timeout).Should(Succeed())
 }
 
-func (env *Environment) EventuallyExpectNodeClaimCount(comparator string, count int) []*v1.NodeClaim {
+func (env *Environment) EventuallyExpectNodeClaimCount(comparator string, count int) []*karpv1.NodeClaim {
 	GinkgoHelper()
 	By(fmt.Sprintf("waiting for nodes to be %s to %d", comparator, count))
-	nodeClaimList := &v1.NodeClaimList{}
+	nodeClaimList := &karpv1.NodeClaimList{}
 	Eventually(func(g Gomega) {
 		g.Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
 		g.Expect(len(nodeClaimList.Items)).To(BeNumerically(comparator, count),
@@ -739,65 +739,65 @@ func (env *Environment) EventuallyExpectInitializedNodeCount(comparator string, 
 	Eventually(func(g Gomega) {
 		nodes = env.Monitor.CreatedNodes()
 		nodes = lo.Filter(nodes, func(n *corev1.Node, _ int) bool {
-			return n.Labels[v1.NodeInitializedLabelKey] == "true"
+			return n.Labels[karpv1.NodeInitializedLabelKey] == "true"
 		})
 		g.Expect(len(nodes)).To(BeNumerically(comparator, count))
 	}).Should(Succeed())
 	return nodes
 }
 
-func (env *Environment) EventuallyExpectCreatedNodeClaimCount(comparator string, count int) []*v1.NodeClaim {
+func (env *Environment) EventuallyExpectCreatedNodeClaimCount(comparator string, count int) []*karpv1.NodeClaim {
 	GinkgoHelper()
 	By(fmt.Sprintf("waiting for created nodeclaims to be %s to %d", comparator, count))
-	nodeClaimList := &v1.NodeClaimList{}
+	nodeClaimList := &karpv1.NodeClaimList{}
 	Eventually(func(g Gomega) {
 		g.Expect(env.Client.List(env.Context, nodeClaimList)).To(Succeed())
 		g.Expect(len(nodeClaimList.Items)).To(BeNumerically(comparator, count))
 	}).Should(Succeed())
-	return lo.Map(nodeClaimList.Items, func(nc v1.NodeClaim, _ int) *v1.NodeClaim {
+	return lo.Map(nodeClaimList.Items, func(nc karpv1.NodeClaim, _ int) *karpv1.NodeClaim {
 		return &nc
 	})
 }
 
-func (env *Environment) EventuallyExpectNodeClaimsReady(nodeClaims ...*v1.NodeClaim) {
+func (env *Environment) EventuallyExpectNodeClaimsReady(nodeClaims ...*karpv1.NodeClaim) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
 		for _, nc := range nodeClaims {
-			temp := &v1.NodeClaim{}
+			temp := &karpv1.NodeClaim{}
 			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nc), temp)).Should(Succeed())
 			g.Expect(temp.StatusConditions().Root().IsTrue()).To(BeTrue())
 		}
 	}).Should(Succeed())
 }
 
-func (env *Environment) EventuallyExpectDrifted(nodeClaims ...*v1.NodeClaim) {
+func (env *Environment) EventuallyExpectDrifted(nodeClaims ...*karpv1.NodeClaim) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
 		for _, nc := range nodeClaims {
 			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nc), nc)).To(Succeed())
-			g.Expect(nc.StatusConditions().Get(v1.ConditionTypeDrifted).IsTrue()).To(BeTrue())
+			g.Expect(nc.StatusConditions().Get(karpv1.ConditionTypeDrifted).IsTrue()).To(BeTrue())
 		}
 	}).Should(Succeed())
 }
 
-func (env *Environment) ConsistentlyExpectNodeClaimsNotDrifted(duration time.Duration, nodeClaims ...*v1.NodeClaim) {
+func (env *Environment) ConsistentlyExpectNodeClaimsNotDrifted(duration time.Duration, nodeClaims ...*karpv1.NodeClaim) {
 	GinkgoHelper()
-	nodeClaimNames := lo.Map(nodeClaims, func(nc *v1.NodeClaim, _ int) string { return nc.Name })
+	nodeClaimNames := lo.Map(nodeClaims, func(nc *karpv1.NodeClaim, _ int) string { return nc.Name })
 	By(fmt.Sprintf("consistently expect nodeclaims %s not to be drifted for %s", nodeClaimNames, duration))
 	Consistently(func(g Gomega) {
 		for _, nc := range nodeClaims {
 			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nc), nc)).To(Succeed())
-			g.Expect(nc.StatusConditions().Get(v1.ConditionTypeDrifted)).To(BeNil())
+			g.Expect(nc.StatusConditions().Get(karpv1.ConditionTypeDrifted)).To(BeNil())
 		}
 	}, duration).Should(Succeed())
 }
 
-func (env *Environment) EventuallyExpectConsolidatable(nodeClaims ...*v1.NodeClaim) {
+func (env *Environment) EventuallyExpectConsolidatable(nodeClaims ...*karpv1.NodeClaim) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
 		for _, nc := range nodeClaims {
 			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nc), nc)).To(Succeed())
-			g.Expect(nc.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue()).To(BeTrue())
+			g.Expect(nc.StatusConditions().Get(karpv1.ConditionTypeConsolidatable).IsTrue()).To(BeTrue())
 		}
 	}).Should(Succeed())
 }
@@ -966,7 +966,7 @@ func (env *Environment) ExpectCABundle() string {
 	return base64.StdEncoding.EncodeToString(transportConfig.TLS.CAData)
 }
 
-func (env *Environment) GetDaemonSetCount(np *v1.NodePool) int {
+func (env *Environment) GetDaemonSetCount(np *karpv1.NodePool) int {
 	GinkgoHelper()
 
 	// Performs the same logic as the scheduler to get the number of daemonset
@@ -987,7 +987,7 @@ func (env *Environment) GetDaemonSetCount(np *v1.NodePool) int {
 	})
 }
 
-func (env *Environment) GetDaemonSetOverhead(np *v1.NodePool) corev1.ResourceList {
+func (env *Environment) GetDaemonSetOverhead(np *karpv1.NodePool) corev1.ResourceList {
 	GinkgoHelper()
 
 	// Performs the same logic as the scheduler to get the number of daemonset

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Consolidation", func() {
 		})
 
 	})
-	Context("Budgets", func() {
+	FContext("Budgets", func() {
 		var nodePool *karpv1.NodePool
 		var dep *appsv1.Deployment
 		var selector labels.Selector
@@ -239,7 +239,7 @@ var _ = Describe("Consolidation", func() {
 			// Update the deployment to only contain 1 replica.
 			env.ExpectUpdated(dep)
 
-			env.ConsistentlyExpectDisruptionsUntilTarget(2, 5, 0, 10*time.Minute)
+			env.ConsistentlyExpectDisruptionsUntilNoneLeft(5, 2, 10*time.Minute)
 		})
 		It("should respect budgets for non-empty delete consolidation", func() {
 			// This test will hold consolidation until we are ready to execute it
@@ -299,7 +299,7 @@ var _ = Describe("Consolidation", func() {
 			nodePool.Spec.Disruption.ConsolidateAfter = karpv1.MustParseNillableDuration("0s")
 			env.ExpectUpdated(nodePool)
 
-			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 10*time.Minute)
+			env.ConsistentlyExpectDisruptionsUntilNoneLeft(3, 2, 10*time.Minute)
 		})
 		It("should respect budgets for non-empty replace consolidation", func() {
 			appLabels := map[string]string{"app": "large-app"}
@@ -399,7 +399,8 @@ var _ = Describe("Consolidation", func() {
 			env.EventuallyExpectTaintedNodeCount("==", 3)
 			env.EventuallyExpectNodeClaimCount("==", 8)
 			env.EventuallyExpectNodeCount("==", 8)
-			env.ConsistentlyExpectDisruptionsUntilTarget(3, 5, 0, 10*time.Minute)
+
+			env.ConsistentlyExpectDisruptionsUntilNoneLeft(5, 3, 10*time.Minute)
 
 			for _, node := range originalNodes {
 				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Consolidation", func() {
 		})
 
 	})
-	FContext("Budgets", func() {
+	Context("Budgets", func() {
 		var nodePool *karpv1.NodePool
 		var dep *appsv1.Deployment
 		var selector labels.Selector

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -239,30 +239,7 @@ var _ = Describe("Consolidation", func() {
 			// Update the deployment to only contain 1 replica.
 			env.ExpectUpdated(dep)
 
-			// Ensure that we get two nodes tainted, and they have overlap during consolidation
-			env.EventuallyExpectTaintedNodeCount("==", 2)
-			nodes = env.ConsistentlyExpectDisruptionsWithNodeCount(2, 5, 5*time.Second)
-
-			// Remove the finalizer from each node so that we can terminate
-			for _, node := range nodes {
-				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
-			}
-
-			// After the deletion timestamp is set and all pods are drained
-			// the node should be gone
-			env.EventuallyExpectNotFound(nodes[0], nodes[1])
-
-			// This check ensures that we are consolidating nodes at the same time
-			env.EventuallyExpectTaintedNodeCount("==", 2)
-			nodes = env.ConsistentlyExpectDisruptionsWithNodeCount(2, 3, 5*time.Second)
-
-			for _, node := range nodes {
-				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
-			}
-			env.EventuallyExpectNotFound(nodes[0], nodes[1])
-
-			// Expect there to only be one node remaining for the last replica
-			env.ExpectNodeCount("==", 1)
+			env.ConsistentlyExpectDisruptionsUntilTarget(2, 5, 0, 10*time.Minute)
 		})
 		It("should respect budgets for non-empty delete consolidation", func() {
 			// This test will hold consolidation until we are ready to execute it
@@ -322,15 +299,7 @@ var _ = Describe("Consolidation", func() {
 			nodePool.Spec.Disruption.ConsolidateAfter = karpv1.MustParseNillableDuration("0s")
 			env.ExpectUpdated(nodePool)
 
-			// Ensure that we get two nodes tainted, and they have overlap during consolidation
-			env.EventuallyExpectTaintedNodeCount("==", 2)
-			nodes = env.ConsistentlyExpectDisruptionsWithNodeCount(2, 3, 5*time.Second)
-
-			for _, node := range nodes {
-				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
-			}
-			env.EventuallyExpectNotFound(nodes[0], nodes[1])
-			env.ExpectNodeCount("==", 1)
+			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 10*time.Minute)
 		})
 		It("should respect budgets for non-empty replace consolidation", func() {
 			appLabels := map[string]string{"app": "large-app"}
@@ -430,12 +399,14 @@ var _ = Describe("Consolidation", func() {
 			env.EventuallyExpectTaintedNodeCount("==", 3)
 			env.EventuallyExpectNodeClaimCount("==", 8)
 			env.EventuallyExpectNodeCount("==", 8)
-			env.ConsistentlyExpectDisruptionsWithNodeCount(3, 8, 5*time.Second)
+			env.ConsistentlyExpectDisruptionsUntilTarget(3, 5, 0, 10*time.Minute)
 
 			for _, node := range originalNodes {
 				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
 			}
-
+			for _, nodeClaim := range originalNodeClaims {
+				Expect(env.ExpectTestingFinalizerRemoved(nodeClaim)).To(Succeed())
+			}
 			// Eventually expect all the nodes to be rolled and completely removed
 			// Since this completes the disruption operation, this also ensures that we aren't leaking nodes into subsequent
 			// tests since nodeclaims that are actively replacing but haven't brought-up nodes yet can register nodes later

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Drift", func() {
 		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 	})
 	Context("Budgets", func() {
-		FIt("should respect budgets for empty drift", func() {
+		It("should respect budgets for empty drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				karpv1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
@@ -157,7 +157,7 @@ var _ = Describe("Drift", func() {
 
 			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 5*time.Minute)
 		})
-		FIt("should respect budgets for non-empty delete drift", func() {
+		It("should respect budgets for non-empty delete drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				karpv1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
@@ -231,7 +231,7 @@ var _ = Describe("Drift", func() {
 
 			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 5*time.Minute)
 		})
-		FIt("should respect budgets for non-empty replace drift", func() {
+		It("should respect budgets for non-empty replace drift", func() {
 			appLabels := map[string]string{"app": "large-app"}
 			nodePool.Labels = appLabels
 			// We're expecting to create 5 nodes, so we'll expect to see at most 3 nodes deleting at one time.

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Drift", func() {
 
 			env.EventuallyExpectDrifted(nodeClaims...)
 
-			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 5*time.Minute)
+			env.ConsistentlyExpectDisruptionsUntilNoneLeft(3, 2, 5*time.Minute)
 		})
 		It("should respect budgets for non-empty delete drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
@@ -229,7 +229,7 @@ var _ = Describe("Drift", func() {
 				env.ExpectUpdated(pod)
 			}
 
-			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 5*time.Minute)
+			env.ConsistentlyExpectDisruptionsUntilNoneLeft(3, 2, 5*time.Minute)
 		})
 		It("should respect budgets for non-empty replace drift", func() {
 			appLabels := map[string]string{"app": "large-app"}
@@ -276,7 +276,7 @@ var _ = Describe("Drift", func() {
 			By("drifting the nodepool")
 			nodePool.Spec.Template.Annotations = lo.Assign(nodePool.Spec.Template.Annotations, map[string]string{"test-annotation": "drift"})
 			env.ExpectUpdated(nodePool)
-			env.ConsistentlyExpectDisruptionsUntilTarget(3, 5, 0, 10*time.Minute)
+			env.ConsistentlyExpectDisruptionsUntilNoneLeft(5, 3, 10*time.Minute)
 
 			for _, node := range originalNodes {
 				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Drift", func() {
 		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 	})
 	Context("Budgets", func() {
-		It("should respect budgets for empty drift", func() {
+		FIt("should respect budgets for empty drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				karpv1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
@@ -155,24 +155,9 @@ var _ = Describe("Drift", func() {
 
 			env.EventuallyExpectDrifted(nodeClaims...)
 
-			// Ensure that we get two nodes tainted, and they have overlap during the drift
-			env.EventuallyExpectTaintedNodeCount("==", 2)
-			nodes = env.ConsistentlyExpectDisruptionsWithNodeCount(2, 3, 5*time.Second)
-
-			// Remove the finalizer from each node so that we can terminate
-			for _, node := range nodes {
-				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
-			}
-
-			// After the deletion timestamp is set and all pods are drained
-			// the node should be gone
-			env.EventuallyExpectNotFound(nodes[0], nodes[1])
-
-			nodes = env.EventuallyExpectTaintedNodeCount("==", 1)
-			Expect(env.ExpectTestingFinalizerRemoved(nodes[0])).To(Succeed())
-			env.EventuallyExpectNotFound(nodes[0])
+			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 5*time.Minute)
 		})
-		It("should respect budgets for non-empty delete drift", func() {
+		FIt("should respect budgets for non-empty delete drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				karpv1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
@@ -244,19 +229,9 @@ var _ = Describe("Drift", func() {
 				env.ExpectUpdated(pod)
 			}
 
-			// Ensure that we get two nodes tainted, and they have overlap during the drift
-			env.EventuallyExpectTaintedNodeCount("==", 2)
-			nodes = env.ConsistentlyExpectDisruptionsWithNodeCount(2, 3, 30*time.Second)
-
-			By("removing the finalizer from the nodes")
-			Expect(env.ExpectTestingFinalizerRemoved(nodes[0])).To(Succeed())
-			Expect(env.ExpectTestingFinalizerRemoved(nodes[1])).To(Succeed())
-
-			// After the deletion timestamp is set and all pods are drained
-			// the node should be gone
-			env.EventuallyExpectNotFound(nodes[0], nodes[1])
+			env.ConsistentlyExpectDisruptionsUntilTarget(2, 3, 0, 5*time.Minute)
 		})
-		It("should respect budgets for non-empty replace drift", func() {
+		FIt("should respect budgets for non-empty replace drift", func() {
 			appLabels := map[string]string{"app": "large-app"}
 			nodePool.Labels = appLabels
 			// We're expecting to create 5 nodes, so we'll expect to see at most 3 nodes deleting at one time.
@@ -301,15 +276,13 @@ var _ = Describe("Drift", func() {
 			By("drifting the nodepool")
 			nodePool.Spec.Template.Annotations = lo.Assign(nodePool.Spec.Template.Annotations, map[string]string{"test-annotation": "drift"})
 			env.ExpectUpdated(nodePool)
-
-			// Ensure that we get three nodes tainted, and they have overlap during the drift
-			env.EventuallyExpectTaintedNodeCount("==", 3)
-			env.EventuallyExpectNodeClaimCount("==", 8)
-			env.EventuallyExpectNodeCount("==", 8)
-			env.ConsistentlyExpectDisruptionsWithNodeCount(3, 8, 5*time.Second)
+			env.ConsistentlyExpectDisruptionsUntilTarget(3, 5, 0, 10*time.Minute)
 
 			for _, node := range originalNodes {
 				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
+			}
+			for _, nodeClaim := range originalNodeClaims {
+				Expect(env.ExpectTestingFinalizerRemoved(nodeClaim)).To(Succeed())
 			}
 
 			// Eventually expect all the nodes to be rolled and completely removed


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Consolidation e2e budget tests were racing, because we asserted too tightly a certain number of nodes terminating, existing, and non-draining, where we don't consider nodes that are terminating against the budget. This modifies our assertions to be looser so that they're not racey, and assert how many disruptions we're currently seeing, and accounts for the change in terminating.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.