### PR TITLE
fix: race condition in lease cleanup

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -296,13 +296,14 @@ func (env *Environment) EventuallyExpectTerminatingWithTimeout(timeout time.Dura
 
 func (env *Environment) EventuallyExpectNoLeakedKubeNodeLease() {
 	GinkgoHelper()
-	// expect no kube node lease to be leaked
-	leases := &coordinationv1.LeaseList{}
-	Expect(env.Client.List(env.Context, leases, client.InNamespace("kube-node-lease"))).To(Succeed())
-	leakedLeases := lo.Filter(leases.Items, func(l coordinationv1.Lease, _ int) bool {
-		return l.OwnerReferences == nil
-	})
-	Expect(leakedLeases).To(HaveLen(0))
+	Eventually(func(g Gomega) {
+		leases := &coordinationv1.LeaseList{}
+		Expect(env.Client.List(env.Context, leases, client.InNamespace("kube-node-lease"))).To(Succeed())
+		leakedLeases := lo.Filter(leases.Items, func(l coordinationv1.Lease, _ int) bool {
+			return l.OwnerReferences == nil
+		})
+		Expect(leakedLeases).To(HaveLen(0))
+	}).WithTimeout(-1).Should(Succeed())
 }
 
 func (env *Environment) EventuallyExpectHealthyWithTimeout(timeout time.Duration, pods ...*corev1.Pod) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes race condition where we can list leases before they are cleaned up and then fail the test.

**How was this change tested?**
snapshot testing

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.