### PR TITLE
fix: smoke test for webhook e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -145,7 +145,7 @@ jobs:
           enable_local_zones: ${{ inputs.suite == 'LocalZone' }}
           cleanup: ${{ inputs.cleanup }}
           codebuild_role: ${{ vars[format('{0}_CODEBUILD_ROLE', inputs.codebuild_region)] }}
-          webhooks_enabled: ${{ !contains(inputs.suite, 'Webhooks') }}
+          webhooks_enabled: ${{ inputs.suite != 'Webhooks' && true }}
       - name: run tests for private cluster
         if: ${{ inputs.workflow_trigger == 'private_cluster' }}
         uses: ./.github/actions/e2e/run-tests-private-cluster

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -145,7 +145,7 @@ jobs:
           enable_local_zones: ${{ inputs.suite == 'LocalZone' }}
           cleanup: ${{ inputs.cleanup }}
           codebuild_role: ${{ vars[format('{0}_CODEBUILD_ROLE', inputs.codebuild_region)] }}
-          webhooks_enabled: ${{ inputs.suite != 'Webhooks' && true }}
+          webhooks_enabled: ${{ inputs.suite != 'Webhooks' && true }} # Set webhooks_enabled to false if running webhook smoke test suite
       - name: run tests for private cluster
         if: ${{ inputs.workflow_trigger == 'private_cluster' }}
         uses: ./.github/actions/e2e/run-tests-private-cluster

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,6 @@ verify: tidy download ## Verify code. Includes dependencies, linting, formatting
 	cp pkg/apis/crds/* charts/karpenter-crd/templates
 	hack/mutation/conversion_webhook_injection.sh
 	hack/github/dependabot.sh
-	git --no-pager diff
 	$(foreach dir,$(MOD_DIRS),cd $(dir) && golangci-lint run $(newline))
 	@git diff --quiet ||\
 		{ echo "New file modification detected in the Git working tree. Please check in before commit."; git --no-pager diff --name-only | uniq | awk '{print "  - " $$0}'; \

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ verify: tidy download ## Verify code. Includes dependencies, linting, formatting
 	cp pkg/apis/crds/* charts/karpenter-crd/templates
 	hack/mutation/conversion_webhook_injection.sh
 	hack/github/dependabot.sh
+	git --no-pager diff
 	$(foreach dir,$(MOD_DIRS),cd $(dir) && golangci-lint run $(newline))
 	@git diff --quiet ||\
 		{ echo "New file modification detected in the Git working tree. Please check in before commit."; git --no-pager diff --name-only | uniq | awk '{print "  - " $$0}'; \

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Enables smoke test for webhooks for E2E testing. This coerces the action from a string to bool

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.