### PR TITLE
Revert "chore: don't panic for a nil instance type (#7144)"

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -81,7 +81,6 @@ func NewDefaultProvider(instanceTypesCache *cache.Cache, ec2api ec2iface.EC2API,
 	}
 }
 
-// nolint:gocyclo
 func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1.EC2NodeClass) ([]*cloudprovider.InstanceType, error) {
 	p.muInstanceTypesInfo.RLock()
 	p.muInstanceTypesOfferings.RLock()
@@ -131,7 +130,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 	subnetZoneToID := lo.SliceToMap(nodeClass.Status.Subnets, func(s v1.Subnet) (string, string) {
 		return s.Zone, s.ZoneID
 	})
-	result := lo.FilterMap(p.instanceTypesInfo, func(i *ec2.InstanceTypeInfo, _ int) (*cloudprovider.InstanceType, bool) {
+	result := lo.Map(p.instanceTypesInfo, func(i *ec2.InstanceTypeInfo, _ int) *cloudprovider.InstanceType {
 		instanceTypeVCPU.With(prometheus.Labels{
 			instanceTypeLabel: *i.InstanceType,
 		}).Set(float64(lo.FromPtr(i.VCpuInfo.DefaultVCpus)))
@@ -153,11 +152,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 			}
 		})
 
-		// If the resolver returned nil, it means that the instance type shouldn't be considered
 		it := p.instanceTypesResolver.Resolve(ctx, i, zoneData, nodeClass)
-		if it == nil {
-			return nil, false
-		}
 		for _, of := range it.Offerings {
 			instanceTypeOfferingAvailable.With(prometheus.Labels{
 				instanceTypeLabel: it.Name,
@@ -170,7 +165,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 				zoneLabel:         of.Requirements.Get(corev1.LabelTopologyZone).Any(),
 			}).Set(of.Price)
 		}
-		return it, true
+		return it
 	})
 	p.instanceTypesCache.SetDefault(key, result)
 	return result, nil


### PR DESCRIPTION
This reverts commit e07b37d277e733fecb827dd69fba1fe2bb23a3e0.

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Reverting this since we should enforce an invariant that the cloud provider returns a real instance type. This prevents the CP from implementing a fix to return a nil instance type if an instance type shouldn't be used. We should opt to just mark all of the offerings as unavailable. But still allow it to be discovered. This allows us to not provision nodes that have this instance type, but still allow us to drift it if it no longer appears in describeinstancetypes

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.