### PR TITLE
feat: drift instance types that no longer exist

### DIFF
--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -766,6 +766,13 @@ var _ = Describe("CloudProvider", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeEmpty())
 		})
+		It("should return drifted if the instance type is not found", func() {
+			// Instance is a reference to what we return in the GetInstances call
+			nodeClaim.Labels = lo.Assign(nodeClaim.Labels, map[string]string{corev1.LabelInstanceTypeStable: coretest.RandomName()})
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isDrifted).To(Equal(cloudprovider.StaleInstanceTypeDrift))
+		})
 		It("should return drifted if the AMI is not valid", func() {
 			// Instance is a reference to what we return in the GetInstances call
 			instance.ImageId = aws.String(fake.ImageID())

--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -44,6 +44,7 @@ func ProviderID(id string) string {
 func ImageID() string {
 	return fmt.Sprintf("ami-%s", strings.ToLower(randomdata.Alphanumeric(17)))
 }
+
 func SecurityGroupID() string {
 	return fmt.Sprintf("sg-%s", randomdata.Alphanumeric(17))
 }

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -153,11 +153,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 			}
 		})
 
-		// If the resolver returned nil, it means that the instance type shouldn't be considered
 		it := p.instanceTypesResolver.Resolve(ctx, i, zoneData, nodeClass)
-		if it == nil {
-			return nil, false
-		}
 		for _, of := range it.Offerings {
 			instanceTypeOfferingAvailable.With(prometheus.Labels{
 				instanceTypeLabel: it.Name,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Makes sure that an instance type that no longer is returned in ec2 describe instance types, but may have an existing node with that instance type can still drift. Previously this would just error, resulting in users having to delete the instances themselves.

**How was this change tested?**
make presubmit

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.