### PR TITLE
feat: add serviceAnnotations value to helm chart

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -78,6 +78,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.0.0 \
 | serviceAccount.annotations | object | `{}` | Additional annotations for the ServiceAccount. |
 | serviceAccount.create | bool | `true` | Specifies if a ServiceAccount should be created. |
 | serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template. |
+| serviceAnnotations | object | `{}` | Additional annotations for the service. |
 | serviceMonitor.additionalLabels | object | `{}` | Additional labels for the ServiceMonitor. |
 | serviceMonitor.enabled | bool | `false` | Specifies whether a ServiceMonitor should be created. |
 | serviceMonitor.endpointConfig | object | `{}` | Configuration on `http-metrics` endpoint for the ServiceMonitor. Not to be used to add additional endpoints. See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint |

--- a/charts/karpenter/templates/service.yaml
+++ b/charts/karpenter/templates/service.yaml
@@ -5,9 +5,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
+  {{- if or .Values.additionalAnnotations .Values.serviceAnnotations }}
   annotations:
+  {{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -31,6 +31,8 @@ serviceMonitor:
   # Not to be used to add additional endpoints.
   # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
   endpointConfig: {}
+# -- Additional annotations for the service.
+serviceAnnotations: {}
 # -- Number of replicas.
 replicas: 2
 # -- The number of old ReplicaSets to retain to allow rollback.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a `serviceAnnotations` value (similar to `podAnnotations`) to allow specifically overriding annotations on the Karpenter service, since `additionalAnnotations` is needlessly broad for that purpose. My particular use case is for prometheus metric scraping via the `prometheus.io/scrape` annotation. Takes the same approach as in [serviceaccount.yaml](https://github.com/aws/karpenter-provider-aws/blob/main/charts/karpenter/templates/serviceaccount.yaml).

**How was this change tested?**
- Installed chart on personal cluster, confirmed that annotations were applied correctly in following cases:
  - `additionalAnnotations` set, `serviceAnnotations` not set
  - `serviceAnnotations` set, `additionalAnnotations` not set
  - neither value set

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.