### PR TITLE
chore: Install toolchain files to location provided in KUBEBUILDER_ASSETS if set

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 K8S_VERSION="${K8S_VERSION:="1.29.x"}"
-KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
+KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:-/usr/local/kubebuilder/bin}"
+
 
 main() {
     tools
@@ -32,10 +33,12 @@ tools() {
 }
 
 kubebuilder() {
-    sudo mkdir -p ${KUBEBUILDER_ASSETS}
-    sudo chown "${USER}" ${KUBEBUILDER_ASSETS}
+    if ! mkdir -p ${KUBEBUILDER_ASSETS}; then
+      sudo mkdir -p ${KUBEBUILDER_ASSETS}
+      sudo chown $(whoami) ${KUBEBUILDER_ASSETS}
+    fi
     arch=$(go env GOARCH)
-    ln -sf "$(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")"/* ${KUBEBUILDER_ASSETS}
+    ln -sf $(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")/* ${KUBEBUILDER_ASSETS}
     find $KUBEBUILDER_ASSETS
 
     # Install latest binaries for 1.25.x (contains CEL fix)


### PR DESCRIPTION
Also use sudo only when necessary to create the location

Fixes #N/A

**Description**

This allows the installation of toolchain files to an arbitrary path by setting the KUBEBUILDER_ASSETS environment variable. This was done in order to avoid the use of sudo in order to create and use a system path. Backward compatibility with the original method is preserved.

**How was this change tested?**

I ran make toolchain both with and without setting the KUBEBUILDER_ASSETS environment variable. Without it set, the default location of /usr/local/kubebuilder/bin was used and I was prompted for my password by sudo. With it set to a path under my home directory, the indicated path was created without needing sudo, and all toolchain content was copied into place.

I then ran make test with KUBEBUILDER_ASSETS set to the path in my home directory and /usr/local/kubebuilder deleted to prove that everything still works.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.