### PR TITLE
docs: Add EBS CSI driver `httpPutResponseHopLimit` note

### DIFF
--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -885,6 +885,12 @@ spec:
     httpTokens: required
 ```
 
+{{% alert title="Note" colwor="primary" %}}
+
+When using EBS CSI driver, `httpPutResponseHopLimit: 1` will prevent the driver from accessing IMDSv2 if run inside a container with the default IMDSv2 configuration. See [EBS CSI Driver documentation](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#imds-ec2-metadata) for more.
+
+{{% /alert %}}
+
 ## spec.blockDeviceMappings
 
 The `blockDeviceMappings` field in an `EC2NodeClass` can be used to control the [Elastic Block Storage (EBS) volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html#instance-block-device-mapping) that Karpenter attaches to provisioned nodes. Karpenter uses default block device mappings for the AMIFamily specified. For example, the `Bottlerocket` AMI Family defaults with two block device mappings, one for Bottlerocket's control volume and the other for container resources such as images and logs.

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -885,6 +885,12 @@ spec:
     httpTokens: required
 ```
 
+{{% alert title="Note" colwor="primary" %}}
+
+When using EBS CSI driver, `httpPutResponseHopLimit: 1` will prevent the driver from accessing IMDSv2 if run inside a container with the default IMDSv2 configuration. See [EBS CSI Driver documentation](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#imds-ec2-metadata) for more.
+
+{{% /alert %}}
+
 ## spec.blockDeviceMappings
 
 The `blockDeviceMappings` field in an `EC2NodeClass` can be used to control the [Elastic Block Storage (EBS) volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html#instance-block-device-mapping) that Karpenter attaches to provisioned nodes. Karpenter uses default block device mappings for the AMIFamily specified. For example, the `Bottlerocket` AMI Family defaults with two block device mappings, one for Bottlerocket's control volume and the other for container resources such as images and logs.

--- a/website/content/en/v1.0/concepts/nodeclasses.md
+++ b/website/content/en/v1.0/concepts/nodeclasses.md
@@ -886,6 +886,12 @@ spec:
     httpTokens: required
 ```
 
+{{% alert title="Note" colwor="primary" %}}
+
+When using EBS CSI driver, `httpPutResponseHopLimit: 1` will prevent the driver from accessing IMDSv2 if run inside a container with the default IMDSv2 configuration. See [EBS CSI Driver documentation](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#imds-ec2-metadata) for more.
+
+{{% /alert %}}
+
 ## spec.blockDeviceMappings
 
 The `blockDeviceMappings` field in an `EC2NodeClass` can be used to control the [Elastic Block Storage (EBS) volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html#instance-block-device-mapping) that Karpenter attaches to provisioned nodes. Karpenter uses default block device mappings for the AMIFamily specified. For example, the `Bottlerocket` AMI Family defaults with two block device mappings, one for Bottlerocket's control volume and the other for container resources such as images and logs.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7200 

**Description**
- Adding a note for customers that use EBS CSI driver with default MDSv2 configuration 

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.