### PR TITLE
fix(0.37.x): discover deprecated EKS optimized AMIs

### DIFF
--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -146,8 +146,9 @@ func (p *DefaultProvider) getDefaultAMIs(ctx context.Context, nodeClass *v1beta1
 	}
 	// Resolve Name and CreationDate information into the DefaultAMIs
 	if err = p.ec2api.DescribeImagesPagesWithContext(ctx, &ec2.DescribeImagesInput{
-		Filters:    []*ec2.Filter{{Name: aws.String("image-id"), Values: aws.StringSlice(lo.Map(res, func(a AMI, _ int) string { return a.AmiID }))}},
-		MaxResults: aws.Int64(500),
+		Filters:           []*ec2.Filter{{Name: aws.String("image-id"), Values: aws.StringSlice(lo.Map(res, func(a AMI, _ int) string { return a.AmiID }))}},
+		MaxResults:        aws.Int64(500),
+		IncludeDeprecated: lo.ToPtr(true),
 	}, func(page *ec2.DescribeImagesOutput, _ bool) bool {
 		for i := range page.Images {
 			for j := range res {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
In the event of an AMI deprecation, we may not discover the new SSM parameter for up to 24 hours. Rather than failing to provision for those 24 hours, we'll continue to discover and use the deprecated AMI. This only impacts those using Karpetner's automatic AMI upgrade system which is not meant for production workloads.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.