### PR TITLE
feat: configure nodes to use resource name in dns

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -258,6 +258,9 @@ func (p *DefaultProvider) createLaunchTemplate(ctx context.Context, options *ami
 				InstanceMetadataTags: lo.ToPtr(ec2.InstanceMetadataTagsStateDisabled),
 			},
 			NetworkInterfaces: networkInterfaces,
+			PrivateDnsNameOptions: &ec2.LaunchTemplatePrivateDnsNameOptions{
+				HostnameType: lo.ToPtr(ec2.HostnameTypeResourceName),
+			},
 			TagSpecifications: launchTemplateDataTags,
 		},
 		TagSpecifications: []*ec2.TagSpecification{


### PR DESCRIPTION
Fixes #6097

**Description**

The default "IP name" hostname type is called out in the documentation as the legacy type, and the docs recommend using the resource name hostname type. This also makes operations easier because you can more easily determine the instance ID from the nodes list.

This patch sets the hostname type to `HostnameTypeResourceName` during launch template creation. This patch does not introduce configuration options for this change, which keeps the surface area simple and matches my interpretation of the [launch template design document](https://github.com/aws/karpenter-provider-aws/blob/main/designs/aws-launch-templates-v2.md).

**How was this change tested?**

Not tested.

**Does this change impact docs?**

- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.