### PR TITLE
Feat: Provisioning IPv6 prefix to LT if cluster is IPv6

### DIFF
--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2220,6 +2220,68 @@ essential = true
 			})
 		})
 	})
+	Context("Networking", func() {
+		Context("launch template respect to DNS ip for ipfamily selection", func() {
+			DescribeTable(
+				"should select correct ipFamily based on DNS ip",
+				func(ipFamily corev1.IPFamily) {
+					provider := launchtemplate.NewDefaultProvider(
+						ctx,
+						awsEnv.LaunchTemplateCache,
+						awsEnv.EC2API,
+						awsEnv.EKSAPI,
+						awsEnv.AMIResolver,
+						awsEnv.SecurityGroupProvider,
+						awsEnv.SubnetProvider,
+						awsEnv.LaunchTemplateProvider.CABundle,
+						make(chan struct{}),
+						net.ParseIP(lo.Ternary(ipFamily == corev1.IPv4Protocol, "10.0.100.10", "fd01:99f0:d47b::a")),
+						"https://test-cluster",
+					)
+					Expect(provider.ClusterIPFamily).To(Equal(ipFamily))
+				},
+				Entry("DNS has ipv4 address", corev1.IPv4Protocol),
+				Entry("DNS has ipv6 address", corev1.IPv6Protocol),
+			)
+		})
+		Context("should provision a v6 prefix and set v6 primary IP as true when running in an ipv6 cluster", func() {
+			DescribeTable(
+				"should set Primary IPv6 as true and provision a prefix",
+				func(isPublicAddressSet, isPublic, isEFA bool) {
+					awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("fd4b:121b:812b::a")
+					awsEnv.LaunchTemplateProvider.ClusterIPFamily = corev1.IPv6Protocol
+					if isPublicAddressSet {
+						nodeClass.Spec.AssociatePublicIPAddress = lo.ToPtr(isPublic)
+					}
+					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+					pod := coretest.UnschedulablePod(lo.Ternary(isEFA, coretest.PodOptions{
+						ResourceRequirements: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{v1.ResourceEFA: resource.MustParse("2")},
+							Limits:   corev1.ResourceList{v1.ResourceEFA: resource.MustParse("2")},
+						},
+					}, coretest.PodOptions{}))
+					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+					ExpectScheduled(ctx, env.Client, pod)
+					input := awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop()
+					if isPublicAddressSet {
+						Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress)).To(Equal(isPublic))
+						Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].Ipv6PrefixCount)).To(Equal(int32(1)))
+						Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].PrimaryIpv6)).To(BeTrue())
+					} else if !isEFA {
+						Expect(input.LaunchTemplateData.NetworkInterfaces).To(HaveLen(0))
+					} else {
+						Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].InterfaceType)).To(Equal(string(ec2types.NetworkInterfaceTypeEfa)))
+						Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].Ipv6PrefixCount)).To(Equal(int32(1)))
+						Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].PrimaryIpv6)).To(BeTrue())
+					}
+				},
+				Entry("AssociatePublicIPAddress is not set and EFA is false", false, true, false),
+				Entry("AssociatePublicIPAddress is not set and EFA is true", false, false, true),
+				Entry("AssociatePublicIPAddress is set as true and EFA is true", true, true, true),
+				Entry("AssociatePublicIPAddress is set as false and EFA is false", true, false, false),
+			)
+		})
+	})
 })
 
 // ExpectTags verifies that the expected tags are a subset of the tags found

--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -20,9 +20,15 @@ import (
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/test/pkg/environment/aws"
@@ -94,4 +100,60 @@ var _ = Describe("IPv6", func() {
 		})
 		Expect(internalIPv6Addrs).To(HaveLen(1))
 	})
+	It("should provision a static IPv6 prefix with node launch and set IPv6 as primary in the primary network interface", func() {
+		clusterDNSAddr := env.ExpectIPv6ClusterDNS()
+		nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{ClusterDNS: []string{clusterDNSAddr}}
+		Expect(disableVPCCNIProvisioning(true)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(disableVPCCNIProvisioning(false)).To(Succeed())
+		})
+		pod := coretest.Pod()
+		env.ExpectCreated(pod, nodeClass, nodePool)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+		output, err := env.EC2API.DescribeInstances(env.Context, &ec2.DescribeInstancesInput{
+			InstanceIds: []string{coretest.Pod().Spec.NodeName},
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(output.Reservations).To(HaveLen(1))
+		Expect(output.Reservations[0].Instances).To(HaveLen(1))
+		Expect(output.Reservations[0].Instances[0].NetworkInterfaces).To(HaveLen(1))
+		Expect(output.Reservations[0].Instances[0].NetworkInterfaces[0].Ipv6Prefixes).To(HaveLen(1))
+		_, hasIPv6Primary := lo.Find(output.Reservations[0].Instances[0].NetworkInterfaces[0].Ipv6Addresses, func(ip types.InstanceIpv6Address) bool {
+			return lo.FromPtr(ip.IsPrimaryIpv6)
+		})
+		Expect(hasIPv6Primary).To(BeTrue())
+	})
 })
+
+// disable VPC CNI provisioning on network interfaces and IPs
+func disableVPCCNIProvisioning(disable bool) error {
+	dsClient := env.KubeClient.AppsV1().DaemonSets("kube-system")
+	retryErr := retry.OnError(
+		retry.DefaultRetry,
+		func(err error) bool {
+			return true
+		},
+		func() error {
+			awsNode, getErr := dsClient.Get(env.Context, "aws-node", metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+
+			for i := range awsNode.Spec.Template.Spec.Containers {
+				if awsNode.Spec.Template.Spec.Containers[i].Name == "aws-node" {
+					for j := range awsNode.Spec.Template.Spec.Containers[i].Env {
+						if awsNode.Spec.Template.Spec.Containers[i].Env[j].Name == "DISABLE_NETWORK_RESOURCE_PROVISIONING" {
+							awsNode.Spec.Template.Spec.Containers[i].Env[j].Value = lo.Ternary(disable, "true", "false")
+						}
+					}
+				}
+			}
+
+			_, updateErr := dsClient.Update(env.Context, awsNode, metav1.UpdateOptions{})
+			return updateErr
+		},
+	)
+	// ignore AWS VPC CNI is not installed
+	return client.IgnoreNotFound(retryErr)
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
By provisioning a v6 prefix during launching a node, we can save all complex IP management from IPAM. Since a static v6 prefix is sufficient and simpler, we want to add it to LT creation.

To set `PrimaryIPv6` to `true` will unblock users as https://github.com/aws/containers-roadmap/issues/1653

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.