### PR TITLE
feat: Add support for custom ssm parameters in amiSelectorTerms

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -115,7 +115,7 @@ spec:
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
                       ssmParameterName:
-                        description: SSMParameterName is the name (or ARN) of the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+                        description: SSMParameter is the name (or ARN) of the SSM parameter containing the Image ID.
                         type: string
                       tags:
                         additionalProperties:

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -114,7 +114,7 @@ spec:
                           Owner is the owner for the ami.
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
-                      ssmParameterName:
+                      ssmParameter:
                         description: SSMParameter is the name (or ARN) of the SSM parameter containing the Image ID.
                         type: string
                       tags:
@@ -133,8 +133,8 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameterName']
-                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameterName))
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameter']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))
                     - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
                       rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
                     - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -115,7 +115,7 @@ spec:
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
                       ssmParameterName:
-                        description: SSMParameterName is the name (or ARN) or the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+                        description: SSMParameterName is the name (or ARN) of the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
                         type: string
                       tags:
                         additionalProperties:

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -114,6 +114,9 @@ spec:
                           Owner is the owner for the ami.
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
+                      ssmParameterName:
+                        description: SSMParameterName is the name (or ARN) or the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+                        type: string
                       tags:
                         additionalProperties:
                           type: string
@@ -130,8 +133,8 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
-                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameterName']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameterName))
                     - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
                       rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
                     - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -111,7 +111,7 @@ spec:
                           Owner is the owner for the ami.
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
-                      ssmParameterName:
+                      ssmParameter:
                         description: SSMParameter is the name (or ARN) of the SSM parameter containing the Image ID.
                         type: string
                       tags:
@@ -130,8 +130,8 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameterName']
-                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameterName))
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameter']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))
                     - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
                       rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
                     - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -111,6 +111,9 @@ spec:
                           Owner is the owner for the ami.
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
+                      ssmParameterName:
+                        description: SSMParameterName is the name (or ARN) or the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+                        type: string
                       tags:
                         additionalProperties:
                           type: string
@@ -127,8 +130,8 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
-                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameterName']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameterName))
                     - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
                       rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
                     - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -112,7 +112,7 @@ spec:
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
                       ssmParameterName:
-                        description: SSMParameterName is the name (or ARN) or the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+                        description: SSMParameterName is the name (or ARN) of the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
                         type: string
                       tags:
                         additionalProperties:

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -112,7 +112,7 @@ spec:
                           You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
                         type: string
                       ssmParameterName:
-                        description: SSMParameterName is the name (or ARN) of the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+                        description: SSMParameter is the name (or ARN) of the SSM parameter containing the Image ID.
                         type: string
                       tags:
                         additionalProperties:

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -227,7 +227,7 @@ type AMISelectorTerm struct {
 	// You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
 	// +optional
 	Owner string `json:"owner,omitempty"`
-	//SSMParameterName is the name (or ARN) or the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+	//SSMParameterName is the name (or ARN) of the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
 	// +optional
 	SSMParameterName string `json:"ssmParameterName,omitempty"`
 }

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -55,7 +55,7 @@ type EC2NodeClassSpec struct {
 	// +optional
 	AssociatePublicIPAddress *bool `json:"associatePublicIPAddress,omitempty"`
 	// AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
-	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name', 'alias']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))"
+	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameterName']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameterName))"
 	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))"
 	// +kubebuilder:validation:XValidation:message="'alias' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))"
 	// +kubebuilder:validation:XValidation:message="'alias' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms",rule="!(self.exists(x, has(x.alias)) && self.size() != 1)"
@@ -227,6 +227,9 @@ type AMISelectorTerm struct {
 	// You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
 	// +optional
 	Owner string `json:"owner,omitempty"`
+	//SSMParameterName is the name (or ARN) or the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+	// +optional
+	SSMParameterName string `json:"ssmParameterName,omitempty"`
 }
 
 // KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -227,9 +227,9 @@ type AMISelectorTerm struct {
 	// You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
 	// +optional
 	Owner string `json:"owner,omitempty"`
-	//SSMParameterName is the name (or ARN) of the SSM parameter containing the Image ID. The parameter data type should be aws:ec2:image
+	//SSMParameter is the name (or ARN) of the SSM parameter containing the Image ID.
 	// +optional
-	SSMParameterName string `json:"ssmParameterName,omitempty"`
+	SSMParameter string `json:"ssmParameterName,omitempty"`
 }
 
 // KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -55,7 +55,7 @@ type EC2NodeClassSpec struct {
 	// +optional
 	AssociatePublicIPAddress *bool `json:"associatePublicIPAddress,omitempty"`
 	// AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
-	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameterName']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameterName))"
+	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameter']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))"
 	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))"
 	// +kubebuilder:validation:XValidation:message="'alias' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))"
 	// +kubebuilder:validation:XValidation:message="'alias' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms",rule="!(self.exists(x, has(x.alias)) && self.size() != 1)"
@@ -229,7 +229,7 @@ type AMISelectorTerm struct {
 	Owner string `json:"owner,omitempty"`
 	//SSMParameter is the name (or ARN) of the SSM parameter containing the Image ID.
 	// +optional
-	SSMParameter string `json:"ssmParameterName,omitempty"`
+	SSMParameter string `json:"ssmParameter,omitempty"`
 }
 
 // KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -40,6 +40,7 @@ var (
 		"InvalidLaunchTemplateId.NotFound",
 		"QueueDoesNotExist",
 		"NoSuchEntity",
+		"ParameterNotFound",
 	)
 	alreadyExistsErrorCodes = sets.New[string](
 		"EntityAlreadyExists",

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -96,7 +96,7 @@ func (p *DefaultProvider) DescribeImageQueries(ctx context.Context, nodeClass *v
 		case term.ID != "":
 			idFilter.Values = append(idFilter.Values, term.ID)
 		case term.SSMParameterName != "":
-			p.updateFilterFromCustomParameter(ctx, term.SSMParameterName, idFilter)
+			p.updateFilterFromCustomParameter(ctx, term.SSMParameterName, &idFilter)
 		default:
 			query := DescribeImageQuery{
 				Owners: lo.Ternary(term.Owner != "", []string{term.Owner}, []string{}),
@@ -135,14 +135,14 @@ func (p *DefaultProvider) DescribeImageQueries(ctx context.Context, nodeClass *v
 	return queries, nil
 }
 
-func (p *DefaultProvider) updateFilterFromCustomParameter(ctx context.Context, ssmParameterName string, idFilter *ec2.Filter) {
+func (p *DefaultProvider) updateFilterFromCustomParameter(ctx context.Context, ssmParameterName string, idFilter *ec2types.Filter) {
 	imageID, err := p.ssmProvider.GetCustomParameter(ctx, ssm.Parameter{
 		Name: ssmParameterName,
 	})
 	if err != nil {
 		log.FromContext(ctx).WithValues("ssmParameterName", ssmParameterName).V(1).Error(err, "parameter not found")
 	} else {
-		idFilter.Values = append(idFilter.Values, aws.String(imageID))
+		idFilter.Values = append(idFilter.Values, imageID)
 	}
 }
 

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -23,11 +23,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	"k8s.io/utils/clock"
+
+	"github.com/aws/karpenter-provider-aws/pkg/errors"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"

--- a/pkg/providers/amifamily/suite_test.go
+++ b/pkg/providers/amifamily/suite_test.go
@@ -876,6 +876,15 @@ var _ = Describe("AMIProvider", func() {
 			Expect(amis[0].AmiID).To(Equal("amd64-ami-id"))
 			Expect(amis[0].Name).To(Equal(amd64AMI))
 		})
+		It("should not throw an error if SSM parameter is not found", func() {
+			customParameter := "/my/custom/ami/parameter"
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{
+				SSMParameter: customParameter,
+			}}
+			amis, err := awsEnv.AMIProvider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(amis).To(HaveLen(0))
+		})
 	})
 })
 

--- a/pkg/providers/ssm/provider.go
+++ b/pkg/providers/ssm/provider.go
@@ -28,6 +28,7 @@ import (
 
 type Provider interface {
 	Get(context.Context, Parameter) (string, error)
+	GetCustomParameter(context.Context, Parameter) (string, error)
 }
 
 type DefaultProvider struct {
@@ -58,5 +59,13 @@ func (p *DefaultProvider) Get(ctx context.Context, parameter Parameter) (string,
 		Value:     lo.FromPtr(result.Parameter.Value),
 	})
 	log.FromContext(ctx).WithValues("parameter", parameter.Name, "value", result.Parameter.Value).Info("discovered ssm parameter")
+	return lo.FromPtr(result.Parameter.Value), nil
+}
+
+func (p *DefaultProvider) GetCustomParameter(ctx context.Context, parameter Parameter) (string, error) {
+	result, err := p.ssmapi.GetParameter(ctx, parameter.GetParameterInput())
+	if err != nil {
+		return "", fmt.Errorf("getting ssm parameter %q, %w", parameter.Name, err)
+	}
 	return lo.FromPtr(result.Parameter.Value), nil
 }

--- a/pkg/providers/ssm/types.go
+++ b/pkg/providers/ssm/types.go
@@ -15,12 +15,19 @@ limitations under the License.
 package ssm
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/samber/lo"
 )
 
+const (
+	CustomParameterType = "custom"
+)
+
 type Parameter struct {
 	Name string
+	Type string
 	// IsMutable indicates if the value associated with an SSM parameter is expected to change. An example of a mutable
 	// parameter would be any of the "latest" or "recommended" AMI parameters which are updated each time a new AMI is
 	// released. On the otherhand, we would consider a parameter parameter for a specific AMI version to be immutable.
@@ -35,6 +42,14 @@ func (p *Parameter) GetParameterInput() *ssm.GetParameterInput {
 
 func (p *Parameter) CacheKey() string {
 	return p.Name
+}
+
+// GetCacheDuration returns the appropriate cache duration based on the parameter type
+func (p Parameter) GetCacheDuration() time.Duration {
+	if p.Type == CustomParameterType {
+		return 5 * time.Minute
+	}
+	return 24 * time.Hour
 }
 
 type CacheEntry struct {

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -273,7 +273,7 @@ var _ = Describe("AMI", func() {
 		})
 		It("should have the EC2NodeClass status for AMIs using public ssm parameter ARN", func() {
 			nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameter: fmt.Sprintf("arn:aws:ssm:%s::parameter/%s", env, ssmPath)}}
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameter: fmt.Sprintf("arn:aws:ssm:%s::parameter/%s", env.Region, ssmPath)}}
 			env.ExpectCreated(nodeClass)
 			nc := EventuallyExpectAMIsToExist(nodeClass)
 			Expect(len(nc.Status.AMIs)).To(BeNumerically("==", 1))

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -463,7 +463,6 @@ func createCustomSSMParameter(imageID *string) string {
 		Name:     awssdk.String(parameterName),
 		Value:    imageID,
 		DataType: &dataType,
-		Tier:     ssmtypes.ParameterTierAdvanced,
 		Type:     ssmtypes.ParameterTypeString,
 	})
 	Expect(err).ToNot(HaveOccurred())

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -73,9 +73,11 @@ var _ = AfterEach(func() { env.AfterEach() })
 var _ = Describe("AMI", func() {
 	var customAMI string
 	var deprecatedAMI string
+	var ssmParameter string
 	BeforeEach(func() {
 		customAMI = env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))
 		deprecatedAMI = env.GetDeprecatedAMI(customAMI, "AL2023")
+		ssmParameter = fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion())
 	})
 
 	It("should use the AMI defined by the AMI Selector Terms", func() {
@@ -149,6 +151,21 @@ var _ = Describe("AMI", func() {
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{
 			{
 				ID: customAMI,
+			},
+		}
+		pod := coretest.Pod()
+
+		env.ExpectCreated(pod, nodeClass, nodePool)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("ImageId", HaveValue(Equal(customAMI))))
+	})
+	It("should support ssm parameters", func() {
+		nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
+		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{
+			{
+				SSMParameterName: ssmParameter,
 			},
 		}
 		pod := coretest.Pod()
@@ -253,6 +270,16 @@ var _ = Describe("AMI", func() {
 			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsReady, Status: metav1.ConditionTrue})
 			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
 		})
+		It("should have the EC2NodeClass status for AMIs using ssm parameters", func() {
+			nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameterName: ssmParameter}}
+			env.ExpectCreated(nodeClass)
+			nc := EventuallyExpectAMIsToExist(nodeClass)
+			Expect(len(nc.Status.AMIs)).To(BeNumerically("==", 1))
+			Expect(nc.Status.AMIs[0].ID).To(Equal(customAMI))
+			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsReady, Status: metav1.ConditionTrue})
+			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionTrue})
+		})
 		It("should have ec2nodeClass status as not ready since AMI was not resolved", func() {
 			nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{ID: "ami-123"}}
@@ -260,6 +287,13 @@ var _ = Describe("AMI", func() {
 			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsReady, Status: metav1.ConditionFalse, Message: "AMISelector did not match any AMIs"})
 			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "ValidationSucceeded=False, AMIsReady=False"})
 
+		})
+		It("should have ec2nodeClass status as not ready since ssm parameter was not found", func() {
+			nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameterName: "parameter-123"}}
+			env.ExpectCreated(nodeClass)
+			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsReady, Status: metav1.ConditionFalse, Message: "AMISelector did not match any AMIs"})
+			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "AMIsReady=False"})
 		})
 	})
 

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -166,7 +166,7 @@ var _ = Describe("AMI", func() {
 		nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{
 			{
-				SSMParameter: fmt.Sprintf("arn:aws:ssm:%s::parameter/%s", env.Region, ssmPath),
+				SSMParameter: fmt.Sprintf("arn:aws:ssm:%s::parameter%s", env.Region, ssmPath),
 			},
 		}
 		pod := coretest.Pod()
@@ -273,7 +273,7 @@ var _ = Describe("AMI", func() {
 		})
 		It("should have the EC2NodeClass status for AMIs using public ssm parameter ARN", func() {
 			nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameter: fmt.Sprintf("arn:aws:ssm:%s::parameter/%s", env.Region, ssmPath)}}
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameter: fmt.Sprintf("arn:aws:ssm:%s::parameter%s", env.Region, ssmPath)}}
 			env.ExpectCreated(nodeClass)
 			nc := EventuallyExpectAMIsToExist(nodeClass)
 			Expect(len(nc.Status.AMIs)).To(BeNumerically("==", 1))
@@ -294,7 +294,7 @@ var _ = Describe("AMI", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameter: "parameter-123"}}
 			env.ExpectCreated(nodeClass)
 			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsReady, Status: metav1.ConditionFalse, Message: "AMISelector did not match any AMIs"})
-			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "AMIsReady=False"})
+			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "ValidationSucceeded=False, AMIsReady=False"})
 		})
 	})
 

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -289,13 +289,6 @@ var _ = Describe("AMI", func() {
 			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "ValidationSucceeded=False, AMIsReady=False"})
 
 		})
-		It("should have ec2nodeClass status as not ready since ssm parameter was not found", func() {
-			nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{SSMParameter: "parameter-123"}}
-			env.ExpectCreated(nodeClass)
-			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsReady, Status: metav1.ConditionFalse, Message: "AMISelector did not match any AMIs"})
-			ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: status.ConditionReady, Status: metav1.ConditionFalse, Message: "ValidationSucceeded=False, AMIsReady=False"})
-		})
 	})
 
 	Context("UserData", func() {

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -100,12 +100,13 @@ spec:
   amiSelectorTerms:
     # Select on any AMI that has both the `karpenter.sh/discovery: ${CLUSTER_NAME}`
     # AND `environment: test` tags OR any AMI with the name `my-ami` OR an AMI with
-    # ID `ami-123`
+    # ID `ami-123` OR an AMI with ID matching the value of my-custom-parameter
     - tags:
         karpenter.sh/discovery: "${CLUSTER_NAME}"
         environment: test
     - name: my-ami
     - id: ami-123
+    - ssmParameterName: my-custom-parameter # ssm parameter name or ARN
     # Select EKS optimized AL2023 AMIs with version `v20240703`. This term is mutually
     # exclusive and can't be specified with other terms.
     # - alias: al2023@v20240703
@@ -728,12 +729,13 @@ The example below shows how this selection logic is fulfilled.
 amiSelectorTerms:
   # Select on any AMI that has both the `karpenter.sh/discovery: ${CLUSTER_NAME}`
   # AND `environment: test` tags OR any AMI with the name `my-ami` OR an AMI with
-  # ID `ami-123`
+  # ID `ami-123` OR an AMI with ID matching the value of my-custom-parameter
   - tags:
       karpenter.sh/discovery: "${CLUSTER_NAME}"
       environment: test
   - name: my-ami
   - id: ami-123
+  - ssmParameterName: my-custom-parameter # ssm parameter name or ARN
   # Select EKS optimized AL2023 AMIs with version `v20240807`. This term is mutually
   # exclusive and can't be specified with other terms.
   # - alias: al2023@v20240807
@@ -865,6 +867,12 @@ Specify using ids:
     - id: "ami-456"
 ```
 
+Specify using custom ssm parameter name or ARN:
+```yaml
+  amiSelectorTerms:
+    - ssmParameterName: "my-custom-parameter"
+```
+
 ## spec.capacityReservationSelectorTerms
 
 <i class="fa-solid fa-circle-info"></i> <b>Feature State: </b> [Alpha]({{<ref "../reference/settings#feature-gates" >}})
@@ -913,7 +921,6 @@ spec:
   - tags:
       key: foo
     ownerID: 012345678901
-```
 
 ## spec.tags
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -106,7 +106,7 @@ spec:
         environment: test
     - name: my-ami
     - id: ami-123
-    - ssmParameterName: my-custom-parameter # ssm parameter name or ARN
+    - ssmParameter: my-custom-parameter # ssm parameter name or ARN
     # Select EKS optimized AL2023 AMIs with version `v20240703`. This term is mutually
     # exclusive and can't be specified with other terms.
     # - alias: al2023@v20240703
@@ -735,7 +735,7 @@ amiSelectorTerms:
       environment: test
   - name: my-ami
   - id: ami-123
-  - ssmParameterName: my-custom-parameter # ssm parameter name or ARN
+  - ssmParameter: my-custom-parameter # ssm parameter name or ARN
   # Select EKS optimized AL2023 AMIs with version `v20240807`. This term is mutually
   # exclusive and can't be specified with other terms.
   # - alias: al2023@v20240807
@@ -870,7 +870,7 @@ Specify using ids:
 Specify using custom ssm parameter name or ARN:
 ```yaml
   amiSelectorTerms:
-    - ssmParameterName: "my-custom-parameter"
+    - ssmParameter: "my-custom-parameter"
 ```
 
 ## spec.capacityReservationSelectorTerms

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -921,6 +921,7 @@ spec:
   - tags:
       key: foo
     ownerID: 012345678901
+```
 
 ## spec.tags
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -873,6 +873,10 @@ Specify using custom ssm parameter name or ARN:
     - ssmParameter: "my-custom-parameter"
 ```
 
+{{% alert title="Note" color="primary" %}}
+When using a custom SSM parameter, you'll need to expand the `ssm:GetParameter` permissions on the Karpenter IAM role to include your custom parameter, as the default policy only allows access to the AWS public parameters.
+{{% /alert %}}
+
 ## spec.capacityReservationSelectorTerms
 
 <i class="fa-solid fa-circle-info"></i> <b>Feature State: </b> [Alpha]({{<ref "../reference/settings#feature-gates" >}})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #3657 

**Description**

Adds `ssmParameter` to `amiSelectorTerms` to allow Karpenter to read a custom ssm parameter to get the AMI Image ID.

Karpenter already has ssm parameter IAM permissions and a ssm provider class as it's used to retrieve the public ssm params for alias based amiSelectorTerms.

**How was this change tested?**
- `make test`
- tested in an EKS cluster

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.