### PR TITLE
ci: include v prefix when install CRD chart

### DIFF
--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -4,7 +4,7 @@ aws eks update-kubeconfig --name "$CLUSTER_NAME"
 if (( "$WEBHOOKS_ENABLED" == false )); then
 helm upgrade --install karpenter-crd oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/karpenter/snapshot/karpenter-crd \
   --namespace kube-system \
-  --version "0-$(git rev-parse HEAD)" \
+  --version "v0-$(git rev-parse HEAD)" \
   --set webhook.enabled=${WEBHOOKS_ENABLED} \
   --wait
 fi


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
When installing the CRD chart for the webhook test, we must include the v prefix in the version. Otherwise, we fail open during cluster creation and install the CRDs included in the main chart (which include the webhook stanza).

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.