### PR TITLE
test: Add test for instance profile tags

### DIFF
--- a/pkg/providers/instanceprofile/suite_test.go
+++ b/pkg/providers/instanceprofile/suite_test.go
@@ -1,0 +1,103 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instanceprofile_test
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+
+	"github.com/aws/karpenter-provider-aws/pkg/apis"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/test"
+
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var ctx context.Context
+var stop context.CancelFunc
+var env *coretest.Environment
+var awsEnv *test.Environment
+var nodeClass test.TestNodeClass
+
+func TestAWS(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "InstanceProfileProvider")
+}
+
+var _ = BeforeSuite(func() {
+	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+	ctx, stop = context.WithCancel(ctx)
+	awsEnv = test.NewEnvironment(ctx, env)
+})
+
+var _ = AfterSuite(func() {
+	stop()
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = BeforeEach(func() {
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+	nodeClass = test.TestNodeClass{
+		EC2NodeClass: v1.EC2NodeClass{
+			Spec: v1.EC2NodeClassSpec{
+				AMISelectorTerms: []v1.AMISelectorTerm{{
+					Alias: "al2@latest",
+				}},
+				SubnetSelectorTerms: []v1.SubnetSelectorTerm{
+					{
+						Tags: map[string]string{
+							"*": "*",
+						},
+					},
+				},
+				SecurityGroupSelectorTerms: []v1.SecurityGroupSelectorTerm{
+					{
+						Tags: map[string]string{
+							"*": "*",
+						},
+					},
+				},
+			},
+		},
+	}
+	awsEnv.Reset()
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("InstanceProfileProvider", func() {
+	It("should not add any tags if InstanceProfileTags() returns empty map", func() {
+		instanceProfile, err := awsEnv.InstanceProfileProvider.Create(ctx, &nodeClass)
+		Expect(err).To(BeNil())
+		Expect(instanceProfile).ToNot(BeNil())
+		Expect(awsEnv.IAMAPI.InstanceProfiles[instanceProfile].Tags).To(HaveLen(0))
+	})
+})

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -139,3 +139,11 @@ func EC2NodeClassFieldIndexer(ctx context.Context) func(cache.Cache) error {
 		})
 	}
 }
+
+type TestNodeClass struct {
+	v1.EC2NodeClass
+}
+
+func (t *TestNodeClass) InstanceProfileTags(clusterName string) map[string]string {
+	return nil
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR adds a test which ensures that no instance profile tags are added if InstanceProfileTags() returns empty map.

**How was this change tested?**
`make verify`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.