### PR TITLE
docs: update setup-local-disk link in nodeclasses.md

### DIFF
--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -988,7 +988,7 @@ On AL2023, Karpenter automatically configures the disks via the generated `NodeC
 
 #### Others
 
-For all other AMI families, you must configure the disks yourself. Check out the [`setup-local-disks`](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bin/setup-local-disks) script in [amazon-eks-ami](https://github.com/awslabs/amazon-eks-ami) to see how this is done for AL2.
+For all other AMI families, you must configure the disks yourself. Check out the [`setup-local-disks`](https://github.com/awslabs/amazon-eks-ami/blob/main/templates/shared/runtime/bin/setup-local-disks) script in [amazon-eks-ami](https://github.com/awslabs/amazon-eks-ami) to see how this is done for AL2.
 
 {{% alert title="Tip" color="secondary" %}}
 Since the Kubelet & Containerd will be using the instance-store filesystem, you may consider using a more minimal root volume size.


### PR DESCRIPTION
Update link to setup-local-disks

**Description**
The script was re-located in this https://github.com/awslabs/amazon-eks-ami/pull/1653/commits/3a5e466e7e23fd52696c9fd039d7eefc4f55789b commit

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.