### PR TITLE
chore: Use defined tag variables in `labels.go`

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -70,10 +70,10 @@ var (
 		// Adheres to cluster name pattern matching as specified in the API spec
 		// https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html
 		regexp.MustCompile(`^kubernetes\.io/cluster/[0-9A-Za-z][A-Za-z0-9\-_]*$`),
-		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(karpv1.NodePoolLabelKey))),
+		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(NodePoolTagKey))),
 		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(EKSClusterNameTagKey))),
-		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(LabelNodeClass))),
-		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(TagNodeClaim))),
+		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(NodeClassTagKey))),
+		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(NodeClaimTagKey))),
 	}
 	AMIFamilyBottlerocket                          = "Bottlerocket"
 	AMIFamilyAL2                                   = "AL2"
@@ -95,8 +95,6 @@ var (
 	ResourceAWSPodENI          corev1.ResourceName = "vpc.amazonaws.com/pod-eni"
 	ResourcePrivateIPv4Address corev1.ResourceName = "vpc.amazonaws.com/PrivateIPv4Address"
 	ResourceEFA                corev1.ResourceName = "vpc.amazonaws.com/efa"
-
-	EKSClusterNameTagKey = "eks:eks-cluster-name"
 
 	LabelNodeClass = apis.Group + "/ec2nodeclass"
 
@@ -126,6 +124,9 @@ var (
 	AnnotationEC2NodeClassHashVersion         = apis.Group + "/ec2nodeclass-hash-version"
 	AnnotationInstanceTagged                  = apis.Group + "/tagged"
 
-	TagNodeClaim = coreapis.Group + "/nodeclaim"
-	TagName      = "Name"
+	NodeClaimTagKey      = coreapis.Group + "/nodeclaim"
+	NameTagKey           = "Name"
+	NodePoolTagKey       = karpv1.NodePoolLabelKey
+	NodeClassTagKey      = LabelNodeClass
+	EKSClusterNameTagKey = "eks:eks-cluster-name"
 )

--- a/pkg/controllers/nodeclaim/tagging/controller.go
+++ b/pkg/controllers/nodeclaim/tagging/controller.go
@@ -99,8 +99,8 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 
 func (c *Controller) tagInstance(ctx context.Context, nc *karpv1.NodeClaim, id string) error {
 	tags := map[string]string{
-		v1.TagName:              nc.Status.NodeName,
-		v1.TagNodeClaim:         nc.Name,
+		v1.NameTagKey:           nc.Status.NodeName,
+		v1.NodeClaimTagKey:      nc.Name,
 		v1.EKSClusterNameTagKey: options.FromContext(ctx).ClusterName,
 	}
 

--- a/pkg/controllers/nodeclaim/tagging/suite_test.go
+++ b/pkg/controllers/nodeclaim/tagging/suite_test.go
@@ -118,7 +118,7 @@ var _ = Describe("TaggingController", func() {
 		ExpectObjectReconciled(ctx, env.Client, taggingController, nodeClaim)
 		Expect(nodeClaim.Annotations).To(Not(HaveKey(v1.AnnotationInstanceTagged)))
 		Expect(lo.ContainsBy(ec2Instance.Tags, func(tag ec2types.Tag) bool {
-			return *tag.Key == v1.TagName
+			return *tag.Key == v1.NameTagKey
 		})).To(BeFalse())
 	})
 
@@ -134,7 +134,7 @@ var _ = Describe("TaggingController", func() {
 		ExpectObjectReconciled(ctx, env.Client, taggingController, nodeClaim)
 		Expect(nodeClaim.Annotations).To(Not(HaveKey(v1.AnnotationInstanceTagged)))
 		Expect(lo.ContainsBy(ec2Instance.Tags, func(tag ec2types.Tag) bool {
-			return tag.Key == &v1.TagName
+			return tag.Key == &v1.NameTagKey
 		})).To(BeFalse())
 	})
 
@@ -181,7 +181,7 @@ var _ = Describe("TaggingController", func() {
 		ExpectObjectReconciled(ctx, env.Client, taggingController, nodeClaim)
 		Expect(nodeClaim.Annotations).To(Not(HaveKey(v1.AnnotationInstanceTagged)))
 		Expect(lo.ContainsBy(ec2Instance.Tags, func(tag ec2types.Tag) bool {
-			return tag.Key == &v1.TagName
+			return tag.Key == &v1.NameTagKey
 		})).To(BeFalse())
 	})
 
@@ -209,8 +209,8 @@ var _ = Describe("TaggingController", func() {
 			Expect(nodeClaim.Annotations).To(HaveKey(v1.AnnotationInstanceTagged))
 
 			expectedTags := map[string]string{
-				v1.TagName:              nodeClaim.Status.NodeName,
-				v1.TagNodeClaim:         nodeClaim.Name,
+				v1.NameTagKey:           nodeClaim.Status.NodeName,
+				v1.NodeClaimTagKey:      nodeClaim.Name,
 				v1.EKSClusterNameTagKey: options.FromContext(ctx).ClusterName,
 			}
 			ec2Instance := lo.Must(awsEnv.EC2API.Instances.Load(*ec2Instance.InstanceId)).(ec2types.Instance)
@@ -223,12 +223,12 @@ var _ = Describe("TaggingController", func() {
 				Expect(instanceTags).To(HaveKeyWithValue(tag, value))
 			}
 		},
-		Entry("with the karpenter.sh/nodeclaim tag", v1.TagName, v1.EKSClusterNameTagKey),
-		Entry("with the eks:eks-cluster-name tag", v1.TagName, v1.TagNodeClaim),
-		Entry("with the Name tag", v1.TagNodeClaim, v1.EKSClusterNameTagKey),
-		Entry("with the karpenter.sh/nodeclaim and eks:eks-cluster-name tags", v1.TagName),
-		Entry("with the Name and eks:eks-cluster-name tags", v1.TagNodeClaim),
+		Entry("with the karpenter.sh/nodeclaim tag", v1.NameTagKey, v1.EKSClusterNameTagKey),
+		Entry("with the eks:eks-cluster-name tag", v1.NameTagKey, v1.NodeClaimTagKey),
+		Entry("with the Name tag", v1.NodeClaimTagKey, v1.EKSClusterNameTagKey),
+		Entry("with the karpenter.sh/nodeclaim and eks:eks-cluster-name tags", v1.NameTagKey),
+		Entry("with the Name and eks:eks-cluster-name tags", v1.NodeClaimTagKey),
 		Entry("with the karpenter.sh/nodeclaim and Name tags", v1.EKSClusterNameTagKey),
-		Entry("with nothing to tag", v1.TagNodeClaim, v1.EKSClusterNameTagKey, v1.TagName),
+		Entry("with nothing to tag", v1.NodeClaimTagKey, v1.EKSClusterNameTagKey, v1.NameTagKey),
 	)
 })

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -150,15 +150,15 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 		Filters: []ec2types.Filter{
 			{
 				Name:   aws.String("tag-key"),
-				Values: []string{karpv1.NodePoolLabelKey},
+				Values: []string{v1.NodePoolTagKey},
 			},
 			{
 				Name:   aws.String("tag-key"),
-				Values: []string{v1.LabelNodeClass},
+				Values: []string{v1.NodeClassTagKey},
 			},
 			{
-				Name:   aws.String("tag-key"),
-				Values: []string{fmt.Sprintf("kubernetes.io/cluster/%s", options.FromContext(ctx).ClusterName)},
+				Name:   aws.String(v1.EKSClusterNameTagKey),
+				Values: []string{options.FromContext(ctx).ClusterName},
 			},
 			instanceStateFilter,
 		},

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -404,7 +404,7 @@ func (p *DefaultProvider) DeleteAll(ctx context.Context, nodeClass *v1.EC2NodeCl
 				Values: []string{clusterName},
 			},
 			{
-				Name:   aws.String(fmt.Sprintf("tag:%s", v1.LabelNodeClass)),
+				Name:   aws.String(fmt.Sprintf("tag:%s", v1.NodeClassTagKey)),
 				Values: []string{nodeClass.Name},
 			},
 		},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Update our `labels.go` to have defined tag variables in it. This cleans-up a weird cross-over that we had between labels and tags where it was difficult to delineate what a change in one would cause to the other

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.