### PR TITLE
fix: Fix error checking ordering for DescribeInstances

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -157,7 +157,7 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 				Values: []string{v1.NodeClassTagKey},
 			},
 			{
-				Name:   aws.String(v1.EKSClusterNameTagKey),
+				Name:   aws.String(fmt.Sprintf("tag:%s", v1.EKSClusterNameTagKey)),
 				Values: []string{options.FromContext(ctx).ClusterName},
 			},
 			instanceStateFilter,
@@ -166,10 +166,10 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
-		out.Reservations = append(out.Reservations, page.Reservations...)
 		if err != nil {
 			return nil, fmt.Errorf("describing ec2 instances, %w", err)
 		}
+		out.Reservations = append(out.Reservations, page.Reservations...)
 	}
 	instances, err := instancesFromOutput(out)
 	return instances, cloudprovider.IgnoreNodeClaimNotFoundError(err)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

If `DescribeInstances` fails to return any response, we were checking the error in the wrong order. This also ensures that we are filtering by the correct tag key

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.