### PR TITLE
chore: Only support `Ready` Node Condition for Node Repair

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -254,16 +254,6 @@ func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 			ConditionStatus:    corev1.ConditionFalse,
 			TolerationDuration: 30 * time.Minute,
 		},
-		{
-			ConditionType:      corev1.NodeDiskPressure,
-			ConditionStatus:    corev1.ConditionTrue,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      corev1.NodeMemoryPressure,
-			ConditionStatus:    corev1.ConditionTrue,
-			TolerationDuration: 30 * time.Minute,
-		},
 	}
 }
 

--- a/test/suites/integration/repair_policy_test.go
+++ b/test/suites/integration/repair_policy_test.go
@@ -78,16 +78,6 @@ var _ = Describe("Repair Policy", func() {
 			Status:             corev1.ConditionFalse,
 			LastTransitionTime: metav1.Time{Time: time.Now().Add(-31 * time.Minute)},
 		}),
-		Entry("DiskPressure", corev1.NodeCondition{
-			Type:               corev1.NodeDiskPressure,
-			Status:             corev1.ConditionTrue,
-			LastTransitionTime: metav1.Time{Time: time.Now().Add(-31 * time.Minute)},
-		}),
-		Entry("MemoryPressure", corev1.NodeCondition{
-			Type:               corev1.NodeMemoryPressure,
-			Status:             corev1.ConditionTrue,
-			LastTransitionTime: metav1.Time{Time: time.Now().Add(-31 * time.Minute)},
-		}),
 	)
 	It("should ignore disruption budgets", func() {
 		nodePool.Spec.Disruption.Budgets = []karpenterv1.Budget{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Dropping support for DiskPressure and MemoryPressure

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.