### PR TITLE
chore: handle observed generation change in operatorpkg

### DIFF
--- a/pkg/controllers/nodeclass/status/instanceprofile.go
+++ b/pkg/controllers/nodeclass/status/instanceprofile.go
@@ -39,6 +39,8 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 	} else {
 		nodeClass.Status.InstanceProfile = lo.FromPtr(nodeClass.Spec.InstanceProfile)
 	}
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeInstanceProfileReady)
+	if ok := nodeClass.StatusConditions().SetTrue(v1.ConditionTypeInstanceProfileReady); !ok {
+		return reconcile.Result{Requeue: true}, nil
+	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclass/status/securitygroup.go
+++ b/pkg/controllers/nodeclass/status/securitygroup.go
@@ -51,6 +51,8 @@ func (sg *SecurityGroup) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeCla
 			Name: *securityGroup.GroupName,
 		}
 	})
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeSecurityGroupsReady)
+	if ok := nodeClass.StatusConditions().SetTrue(v1.ConditionTypeSecurityGroupsReady); !ok {
+		return reconcile.Result{Requeue: true}, nil
+	}
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }

--- a/pkg/controllers/nodeclass/status/subnet.go
+++ b/pkg/controllers/nodeclass/status/subnet.go
@@ -55,6 +55,8 @@ func (s *Subnet) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (rec
 			ZoneID: *ec2subnet.AvailabilityZoneId,
 		}
 	})
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeSubnetsReady)
+	if ok := nodeClass.StatusConditions().SetTrue(v1.ConditionTypeSubnetsReady); !ok {
+		return reconcile.Result{Requeue: true}, nil
+	}
 	return reconcile.Result{RequeueAfter: time.Minute}, nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds requeueing to sub-reconcilers if a status `Set()` call returns false because of an observed generation mismatch.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.