### PR TITLE
docs: Updated the hyperlink for nodepool disruption budgets to point to the right one

### DIFF
--- a/website/content/en/docs/concepts/disruption.md
+++ b/website/content/en/docs/concepts/disruption.md
@@ -63,7 +63,7 @@ When you run `kubectl delete node` on a node without a finalizer, the node is de
 
 ## Automated Graceful Methods
 
-Automated graceful methods, can be rate limited through [NodePool Disruption Budgets]({{<ref "#disruption-budgets" >}})
+Automated graceful methods, can be rate limited through [NodePool Disruption Budgets]({{<ref "#nodepool-disruption-budgets" >}})
 
 * [**Consolidation**]({{<ref "#consolidation" >}}): Karpenter works to actively reduce cluster cost by identifying when:
   * Nodes can be removed because the node is empty

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -63,7 +63,7 @@ When you run `kubectl delete node` on a node without a finalizer, the node is de
 
 ## Automated Graceful Methods
 
-Automated graceful methods, can be rate limited through [NodePool Disruption Budgets]({{<ref "#disruption-budgets" >}})
+Automated graceful methods, can be rate limited through [NodePool Disruption Budgets]({{<ref "#nodepool-disruption-budgets" >}})
 
 * [**Consolidation**]({{<ref "#consolidation" >}}): Karpenter works to actively reduce cluster cost by identifying when:
   * Nodes can be removed because the node is empty

--- a/website/content/en/v1.0/concepts/disruption.md
+++ b/website/content/en/v1.0/concepts/disruption.md
@@ -63,7 +63,7 @@ When you run `kubectl delete node` on a node without a finalizer, the node is de
 
 ## Automated Graceful Methods
 
-Automated graceful methods, can be rate limited through [NodePool Disruption Budgets]({{<ref "#disruption-budgets" >}})
+Automated graceful methods, can be rate limited through [NodePool Disruption Budgets]({{<ref "#nodepool-disruption-budgets" >}})
 
 * [**Consolidation**]({{<ref "#consolidation" >}}): Karpenter works to actively reduce cluster cost by identifying when:
   * Nodes can be removed because the node is empty


### PR DESCRIPTION


<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

![Screenshot 2024-11-21 at 9 39 30 AM](https://github.com/user-attachments/assets/80b01b2a-3c14-4c78-8611-e2d5be185081)
![Screenshot 2024-11-21 at 9 39 38 AM](https://github.com/user-attachments/assets/58fb8b71-d0c3-4727-ae08-85bb588d4c32)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.