### PR TITLE
feat: Enable setting schedulerName in Helm chart

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
+      {{- with .Values.schedulerName }}
+      schedulerName: {{ . | quote }}
+      {{- end }}
       containers:
         - name: controller
           securityContext:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -59,6 +59,8 @@ terminationGracePeriodSeconds:
 # -- Bind the pod to the host network.
 # This is required when using a custom CNI.
 hostNetwork: false
+# -- Specify which Kubernetes scheduler should dispatch the pod.
+schedulerName: default-scheduler
 # -- Configure the DNS Policy for the pod
 dnsPolicy: ClusterFirst
 # -- Configure DNS Config for the pod
@@ -183,6 +185,6 @@ settings:
     # -- spotToSpotConsolidation is ALPHA and is disabled by default.
     # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
     spotToSpotConsolidation: false
-     # -- nodeRepair is ALPHA and is disabled by default.
+    # -- nodeRepair is ALPHA and is disabled by default.
     # Setting this to true will enable node repair.
     nodeRepair: false


### PR DESCRIPTION
Fixes #7455

**Description**

Enables setting `schedulerName` on the Karpenter to pod to support specifying a custom scheduler.

**How was this change tested?**

```
$ helm template charts/karpenter --show-only templates/deployment.yaml
# Verified that the template contains `schedulerName: "default-scheduler"`
$ template charts/karpenter --show-only templates/deployment.yaml --set schedulerName=fargate-scheduler
# Verified that the template contains `schedulerName: "fargate-scheduler"`
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

It kinda _does_ impact documentation, namely the Helm chart README. But it appears that the Helm chart README is not up-to-date, as running `helm-docs` includes changes that are not caused by my PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.