### PR TITLE
chore: update the flowschema api version from v1beta3 to v1

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
@@ -1,6 +1,6 @@
 cat <<EOF | envsubst | kubectl apply -f -
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-leader-election
@@ -13,22 +13,23 @@ spec:
   rules:
   - resourceRules:
     - apiGroups:
-        - coordination.k8s.io
+      - coordination.k8s.io
       namespaces:
-        - '*'
+      - '*'
       resources:
-        - leases
+      - leases
       verbs:
-        - get
-        - create
-        - update
+      - get
+      - create
+      - update
     subjects:
-      - kind: ServiceAccount
-        serviceAccount:
-          name: karpenter
-          namespace: "${KARPENTER_NAMESPACE}"
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
+
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-workload
@@ -39,24 +40,24 @@ spec:
   priorityLevelConfiguration:
     name: workload-high
   rules:
-    - nonResourceRules:
-        - nonResourceURLs:
-            - '*'
-          verbs:
-            - '*'
-      resourceRules:
-        - apiGroups:
-            - '*'
-          clusterScope: true
-          namespaces:
-            - '*'
-          resources:
-            - '*'
-          verbs:
-            - '*'
-      subjects:
-        - kind: ServiceAccount
-          serviceAccount:
-            name: karpenter
-            namespace: "${KARPENTER_NAMESPACE}"
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
 EOF

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
@@ -1,6 +1,6 @@
 cat <<EOF | envsubst | kubectl apply -f -
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-leader-election
@@ -13,22 +13,23 @@ spec:
   rules:
   - resourceRules:
     - apiGroups:
-        - coordination.k8s.io
+      - coordination.k8s.io
       namespaces:
-        - '*'
+      - '*'
       resources:
-        - leases
+      - leases
       verbs:
-        - get
-        - create
-        - update
+      - get
+      - create
+      - update
     subjects:
-      - kind: ServiceAccount
-        serviceAccount:
-          name: karpenter
-          namespace: "${KARPENTER_NAMESPACE}"
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
+
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-workload
@@ -39,24 +40,24 @@ spec:
   priorityLevelConfiguration:
     name: workload-high
   rules:
-    - nonResourceRules:
-        - nonResourceURLs:
-            - '*'
-          verbs:
-            - '*'
-      resourceRules:
-        - apiGroups:
-            - '*'
-          clusterScope: true
-          namespaces:
-            - '*'
-          resources:
-            - '*'
-          verbs:
-            - '*'
-      subjects:
-        - kind: ServiceAccount
-          serviceAccount:
-            name: karpenter
-            namespace: "${KARPENTER_NAMESPACE}"
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
 EOF

--- a/website/content/en/v0.37/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
+++ b/website/content/en/v0.37/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
@@ -1,6 +1,6 @@
 cat <<EOF | envsubst | kubectl apply -f -
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-leader-election
@@ -13,22 +13,23 @@ spec:
   rules:
   - resourceRules:
     - apiGroups:
-        - coordination.k8s.io
+      - coordination.k8s.io
       namespaces:
-        - '*'
+      - '*'
       resources:
-        - leases
+      - leases
       verbs:
-        - get
-        - create
-        - update
+      - get
+      - create
+      - update
     subjects:
-      - kind: ServiceAccount
-        serviceAccount:
-          name: karpenter
-          namespace: "${KARPENTER_NAMESPACE}"
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
+
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-workload
@@ -39,24 +40,24 @@ spec:
   priorityLevelConfiguration:
     name: workload-high
   rules:
-    - nonResourceRules:
-        - nonResourceURLs:
-            - '*'
-          verbs:
-            - '*'
-      resourceRules:
-        - apiGroups:
-            - '*'
-          clusterScope: true
-          namespaces:
-            - '*'
-          resources:
-            - '*'
-          verbs:
-            - '*'
-      subjects:
-        - kind: ServiceAccount
-          serviceAccount:
-            name: karpenter
-            namespace: "${KARPENTER_NAMESPACE}"
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
 EOF

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
@@ -1,6 +1,6 @@
 cat <<EOF | envsubst | kubectl apply -f -
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-leader-election
@@ -13,22 +13,23 @@ spec:
   rules:
   - resourceRules:
     - apiGroups:
-        - coordination.k8s.io
+      - coordination.k8s.io
       namespaces:
-        - '*'
+      - '*'
       resources:
-        - leases
+      - leases
       verbs:
-        - get
-        - create
-        - update
+      - get
+      - create
+      - update
     subjects:
-      - kind: ServiceAccount
-        serviceAccount:
-          name: karpenter
-          namespace: "${KARPENTER_NAMESPACE}"
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
+
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-workload
@@ -39,24 +40,24 @@ spec:
   priorityLevelConfiguration:
     name: workload-high
   rules:
-    - nonResourceRules:
-        - nonResourceURLs:
-            - '*'
-          verbs:
-            - '*'
-      resourceRules:
-        - apiGroups:
-            - '*'
-          clusterScope: true
-          namespaces:
-            - '*'
-          resources:
-            - '*'
-          verbs:
-            - '*'
-      subjects:
-        - kind: ServiceAccount
-          serviceAccount:
-            name: karpenter
-            namespace: "${KARPENTER_NAMESPACE}"
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
 EOF

--- a/website/content/en/v1.1/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
+++ b/website/content/en/v1.1/getting-started/getting-started-with-karpenter/scripts/step15-apply-flowschemas.sh
@@ -1,6 +1,6 @@
 cat <<EOF | envsubst | kubectl apply -f -
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-leader-election
@@ -13,22 +13,23 @@ spec:
   rules:
   - resourceRules:
     - apiGroups:
-        - coordination.k8s.io
+      - coordination.k8s.io
       namespaces:
-        - '*'
+      - '*'
       resources:
-        - leases
+      - leases
       verbs:
-        - get
-        - create
-        - update
+      - get
+      - create
+      - update
     subjects:
-      - kind: ServiceAccount
-        serviceAccount:
-          name: karpenter
-          namespace: "${KARPENTER_NAMESPACE}"
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
+
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: karpenter-workload
@@ -39,24 +40,24 @@ spec:
   priorityLevelConfiguration:
     name: workload-high
   rules:
-    - nonResourceRules:
-        - nonResourceURLs:
-            - '*'
-          verbs:
-            - '*'
-      resourceRules:
-        - apiGroups:
-            - '*'
-          clusterScope: true
-          namespaces:
-            - '*'
-          resources:
-            - '*'
-          verbs:
-            - '*'
-      subjects:
-        - kind: ServiceAccount
-          serviceAccount:
-            name: karpenter
-            namespace: "${KARPENTER_NAMESPACE}"
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: karpenter
+        namespace: "${KARPENTER_NAMESPACE}"
 EOF


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

FlowControl API moved to v1 since v1.29, and will be removed till v1.32. [reference](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-32)

To remediate the issue comes from upgrade insights report
```
Migrate manifests and API clients to use the flowcontrol.apiserver.k8s.io/v1 API version, available since v1.29
```

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.