### PR TITLE
chore: Only stale triage/needs-information and triage/solved issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,17 +12,39 @@ jobs:
     if: github.repository == 'aws/karpenter-provider-aws'
     name: Stale issue bot
     steps:
+      # PR stale-out
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue has been inactive for 14 days. StaleBot will close this stale issue after 14 more days of inactivity.'
-          exempt-issue-labels: 'bug,chore,feature,documentation,testing,operational-excellence,automation,roadmap'
-          stale-issue-label: 'lifecycle/stale'
-          close-issue-label: 'lifecycle/closed'
+          only-issue-labels: 'ignore' # Ignore this step for Issues
           stale-pr-message: 'This PR has been inactive for 14 days. StaleBot will close this stale PR after 14 more days of inactivity.'
           exempt-pr-labels: 'blocked,needs-review,needs-design'
           stale-pr-label: 'lifecycle/stale'
           close-pr-label: 'lifecycle/closed'
           days-before-stale: 14
           days-before-close: 14
+          operations-per-run: 300
+      # Issue stale-out for "triage/needs-information"
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been inactive for 14 days. StaleBot will close this stale issue after 14 more days of inactivity.'
+          only-issue-labels: 'triage/needs-information'
+          stale-issue-label: 'lifecycle/stale'
+          close-issue-label: 'lifecycle/closed'
+          only-pr-labels: 'ignore' # Ignore this step for PRs
+          days-before-stale: 14
+          days-before-close: 14
+          operations-per-run: 300
+      # Issue stale-out for "triage/solved"
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been inactive for 7 days and is marked as "triage/solved". StaleBot will close this stale issue after 7 more days of inactivity.'
+          only-issue-labels: 'triage/solved'
+          stale-issue-label: 'lifecycle/stale'
+          close-issue-label: 'lifecycle/closed'
+          only-pr-labels: 'ignore' # Ignore this step for PRs
+          days-before-stale: 7
+          days-before-close: 7
           operations-per-run: 300


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Our triage process needs to get solidified. One thing that we want to do is ensure that we signal that issues should be staled out either because the issue has not been responded to and needed information (`triage/needs-information`) or because the issue has been marked as solved (`triage/solved`).

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.