### PR TITLE
chore: Drop deprecated AMI status condition 

### DIFF
--- a/pkg/apis/v1/ec2nodeclass_status.go
+++ b/pkg/apis/v1/ec2nodeclass_status.go
@@ -23,7 +23,6 @@ const (
 	ConditionTypeSubnetsReady         = "SubnetsReady"
 	ConditionTypeSecurityGroupsReady  = "SecurityGroupsReady"
 	ConditionTypeAMIsReady            = "AMIsReady"
-	ConditionTypeAMIsDeprecated       = "AMIsDeprecated"
 	ConditionTypeInstanceProfileReady = "InstanceProfileReady"
 )
 

--- a/pkg/controllers/nodeclass/status/ami.go
+++ b/pkg/controllers/nodeclass/status/ami.go
@@ -65,17 +65,6 @@ func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconc
 		}
 	})
 
-	// If deprecated AMIs are discovered set the AMIsDeprecated status condition
-	// If no deprecated AMIs are present, and previous status condition for AMIsDeprecated exists, remove the condition
-	hasDeprecatedAMIs := lo.Filter(nodeClass.Status.AMIs, func(ami v1.AMI, _ int) bool {
-		return ami.Deprecated
-	})
-	hasDeprecatedCondition := nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsDeprecated) != nil
-	if len(hasDeprecatedAMIs) > 0 {
-		nodeClass.StatusConditions().SetTrue(v1.ConditionTypeAMIsDeprecated)
-	} else if hasDeprecatedCondition {
-		_ = nodeClass.StatusConditions().Clear(v1.ConditionTypeAMIsDeprecated)
-	}
 	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeAMIsReady)
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }

--- a/pkg/controllers/nodeclass/status/ami_test.go
+++ b/pkg/controllers/nodeclass/status/ami_test.go
@@ -638,7 +638,6 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 					},
 				},
 			))
-			Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeAMIsDeprecated)).To(BeTrue())
 			Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeAMIsReady)).To(BeTrue())
 		})
 		It("should remove AMIDeprecated status condition when non deprecated AMIs are discovered", func() {
@@ -678,7 +677,6 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 				},
 			))
 			// Checks if both AMIsReady and AMIsDeprecated status conditions are set
-			Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeAMIsDeprecated)).To(BeTrue())
 			Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeAMIsReady)).To(BeTrue())
 
 			// rediscover AMIs again and reconcile
@@ -740,7 +738,6 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 				},
 			))
 			// Since all AMIs discovered are non deprecated, the status conditions should remove AMIsDeprecated and only set AMIsReady
-			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsDeprecated)).To(BeNil())
 			Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeAMIsReady)).To(BeTrue())
 		})
 	})

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -178,7 +178,6 @@ var _ = Describe("AMI", func() {
 		Expect(len(nc.Status.AMIs)).To(BeNumerically("==", 1))
 		Expect(nc.Status.AMIs[0].Deprecated).To(BeTrue())
 		ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsReady, Status: metav1.ConditionTrue})
-		ExpectStatusConditions(env, env.Client, 1*time.Minute, nodeClass, status.Condition{Type: v1.ConditionTypeAMIsDeprecated, Status: metav1.ConditionTrue})
 	})
 	It("should prioritize launch with non-deprecated AMIs", func() {
 		nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -377,7 +377,8 @@ var _ = Describe("Drift", func() {
 
 		By("validating the deprecated status condition has propagated")
 		Eventually(func(g Gomega) {
-			g.Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsDeprecated).IsTrue()).To(BeTrue())
+			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeClass), nodeClass)).Should(Succeed())
+			g.Expect(nodeClass.Status.AMIs[0].Deprecated).To(BeTrue())
 			g.Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady).IsTrue()).To(BeTrue())
 		}).Should(Succeed())
 
@@ -397,10 +398,8 @@ var _ = Describe("Drift", func() {
 		pod = env.EventuallyExpectHealthyPodCount(selector, numPods)[0]
 		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("ImageId", HaveValue(Equal(amdAMI))))
 
-		By("validating the deprecated status condition has been removed")
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeClass), nodeClass)).Should(Succeed())
-			g.Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsDeprecated)).To(BeNil())
 			g.Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady).IsTrue()).To(BeTrue())
 		}).Should(Succeed())
 	})

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -1566,8 +1566,7 @@ NodeClasses have the following status conditions:
 | SubnetsReady         | Subnets are discovered.                                                                                                                                                                                                           |
 | SecurityGroupsReady  | Security Groups are discovered.                                                                                                                                                                                                   |
 | InstanceProfileReady | Instance Profile is discovered.                                                                                                                                                                                                   |
-| AMIsReady            | AMIs are discovered.                                                                                                                                                                                                            |
-| AMIsDeprecated       | AMIs are discovered, but they are deprecated. Individual deprecated AMIs can be identified by reviewing the `status.amis`.                                                                                                                                                                                                                 |
+| AMIsReady            | AMIs are discovered.                                                |
 | Ready                | Top level condition that indicates if the nodeClass is ready. If any of the underlying conditions is `False` then this condition is set to `False` and `Message` on the condition indicates the dependency that was not resolved. |
 
 If a NodeClass is not ready, NodePools that reference it through their `nodeClassRef` will not be considered for scheduling.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Dropping the deprecated AMI status condition. We are in the process considering mechanisms to communicate nodeclass that are in a "Degraded" state, but are still able to provision capacity. The would like a general status condition that is able to describe multiple modes of degradation similar to deprecated AMIs 

**How was this change tested?**
- `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.