### PR TITLE
docs: Update docs to indicate do-not-disrupt does not block expiration

### DIFF
--- a/website/content/en/docs/concepts/disruption.md
+++ b/website/content/en/docs/concepts/disruption.md
@@ -295,7 +295,6 @@ This annotation will be ignored for [terminating pods](https://kubernetes.io/doc
 Examples of voluntary node removal that will be prevented by this annotation include:
 - [Consolidation]({{<ref "#consolidation" >}})
 - [Drift]({{<ref "#drift" >}})
-- Expiration
 
 {{% alert title="Note" color="primary" %}}
 Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`. Both of these are considered involuntary events, since node removal cannot be delayed.

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -295,7 +295,6 @@ This annotation will be ignored for [terminating pods](https://kubernetes.io/doc
 Examples of voluntary node removal that will be prevented by this annotation include:
 - [Consolidation]({{<ref "#consolidation" >}})
 - [Drift]({{<ref "#drift" >}})
-- Expiration
 
 {{% alert title="Note" color="primary" %}}
 Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`. Both of these are considered involuntary events, since node removal cannot be delayed.

--- a/website/content/en/v1.0/concepts/disruption.md
+++ b/website/content/en/v1.0/concepts/disruption.md
@@ -295,7 +295,6 @@ This annotation will be ignored for [terminating pods](https://kubernetes.io/doc
 Examples of voluntary node removal that will be prevented by this annotation include:
 - [Consolidation]({{<ref "#consolidation" >}})
 - [Drift]({{<ref "#drift" >}})
-- Expiration
 
 {{% alert title="Note" color="primary" %}}
 Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`. Both of these are considered involuntary events, since node removal cannot be delayed.

--- a/website/content/en/v1.1/concepts/disruption.md
+++ b/website/content/en/v1.1/concepts/disruption.md
@@ -295,7 +295,6 @@ This annotation will be ignored for [terminating pods](https://kubernetes.io/doc
 Examples of voluntary node removal that will be prevented by this annotation include:
 - [Consolidation]({{<ref "#consolidation" >}})
 - [Drift]({{<ref "#drift" >}})
-- Expiration
 
 {{% alert title="Note" color="primary" %}}
 Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`. Both of these are considered involuntary events, since node removal cannot be delayed.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Update docs to indicate do-not-disrupt does not block expiration

**How was this change tested?**
NA

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.