### PR TITLE
docs: Update INTERRUPTION QUEUE naming to match ARN for it to work properly

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -18,7 +18,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
   --version 1.1.1 \
   --set "serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN}" \
   --set settings.clusterName=${CLUSTER_NAME} \
-  --set settings.interruptionQueue=${CLUSTER_NAME} \
+  --set settings.interruptionQueue=arn:${AWS_PARTITION}:sqs:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:${CLUSTER_NAME} \
   --wait
 ```
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:

docs:            <-- Documentation changes that do not impact code

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Karpenter setup on an existing EKS cluster was not running and pods were going into a crash loop, upon investigating I noticed that SQS QUEUE NAME was not sufficient for the controller pods to run, we have to provide the entire ARN

**How was this change tested?**
This was tested by implementing the change in karpenter.yaml and also while doing the helm upgrade --install of the chart with with setting of the values.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.