### PR TITLE
docs: Update the Managed AMIs task to reflect the v1 API

### DIFF
--- a/website/content/en/docs/tasks/managing-amis.md
+++ b/website/content/en/docs/tasks/managing-amis.md
@@ -6,6 +6,17 @@ description: >
   Task for managing AMIs in Karpenter
 ---
 
+{{% alert title="Important" color="warning" %}}
+Karpenter __heavily recommends against__ opting-in to use an `amiSelectorTerm` with `@latest` unless you are doing this in a pre-production environment or are willing to accept the risk that a faulty AMI may cause downtime in your production clusters. In general, if using a publicly released version of a well-known AMI type (like AL2, AL2023, or Bottlerocket), we recommend that you pin to a version of that AMI and deploy newer versions of that AMI type in a staged approach when newer patch versions are available.
+
+```yaml
+amiSelectorTerms:
+  - alias: al2023@v20240807
+```
+
+More details are described in [Controlling AMI Replacement]({{< relref "#controlling-ami-replacement" >}}) below.
+{{% /alert %}}
+
 Understanding how Karpenter assigns AMIs to nodes can help ensure that your workloads will run successfully on those nodes and continue to run if the nodes are upgraded to newer AMIs.
 Below we describe how Karpenter assigns AMIs to nodes when they are first deployed and how newer AMIs are assigned later when nodes are spun up to replace old ones.
 Later, it describes the options you have to assert control over how AMIs are used by Karpenter for your clusters.
@@ -17,137 +28,131 @@ See [How do I upgrade an EKS Cluster with Karpenter]({{< relref "../faq/#how-do-
 
 Here is how Karpenter assigns AMIs nodes:
 
-* When you create an `EC2NodeClass`, you are required to set the family of AMIs to use. For example, for the AL2 family, you would set `amiFamily: AL2`.
-* With that `amiFamily` set, any time Karpenter spins up a new node, it uses the latest [Amazon EKS optimized Amazon Linux 2 AMIs](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html) release.
-* Later, if an existing node needs to be replaced, Karpenter checks to see if a newer AMI in the AL2 family is available and automatically uses the new AMI instead to spin up the new node. In other words, you may automatically get an AMI that you have not tested with your workloads.
+* When you create an `EC2NodeClass`, you are required to specify [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}). [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) allow you to select on AMIs that can be spun-up by this EC2NodeClass based on tags, id, name, or an alias. Multiple AMIs may be specified, and Karpenter will choose the newest compatible AMI when spinning up new nodes.
+* Some `amiSelectorTerm` types are static and always resolve to the same AMI (e.g. `id`). However, some are dynamic and may resolve to different AMIs over time. Examples of dynamic types include `alias`, `tags`, and `name` (when using a wildcard). For example, if you specify an `amiSelectorTerm` with an `alias` set to `@latest` (e.g. `al2023@latest`, `al2@latest`, or `bottlerocket@latest`), Karpenter will use the _latest_ release for that AMI type when spinning up a new node.
+* When a node is replaced, Karpenter checks to see if a newer AMI is available based on your `amiSelectorTerms`. If a newer AMI is available, Karpenter will automatically use the new AMI to spin up the new node. __In particular, if you are using a dynamic `amiSelectorTerm` type, you may get a new AMI deployed to your environment without having properly tested it.__
 
-You can manually delete a node managed by Karpenter, which will cause the default behavior just described to take effect.
-However, there are situations that will cause node replacements with newer AMIs to happen automatically.
-These include: Expiration (if node expiry is set, the node is marked for deletion at a certain time after the node is created), [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}) (if a node is empty of workloads, or deemed to be inefficiently running workloads, nodes can be deleted and more appropriately featured nodes are brought up to consolidate workloads), [Drift]({{< relref "../concepts/disruption/#drift" >}}) (nodes are set for deletion when they drift from the desired state of the `NodeClaims` and new nodes are brought up to replace them), and [Interruption]({{< relref "../concepts/disruption/#interruption" >}}) (nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed).
+Whenever a node is replaced, the replacement node will be launched using the newest AMI based on your `amiSelectorTerms`. Nodes may be replaced due to manual deletion, or any of Karpenter's automated methods:
+- [**Expiration**]({{< relref "../concepts/disruption/#expiration" >}}): Automatically initiates replacement at a certain time after the node is created.
+-  [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}): If Karpenter detects that a cheaper node can be used to run the same workloads, Karpenter may replace the current node automatically.
+- [**Drift**]({{< relref "../concepts/disruption/#drift" >}}): If a node's state no longer matches the desired state dictated by the `NodePool` or `EC2NodeClass`, it will be replaced, including if the node's AMI no longer matches the latest AMI selected by the `amiSelectorTerms`.
+- [**Interruption**]({{< relref "../concepts/disruption/#interruption" >}}): Nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed.
 
 See [**Automated Methods**]({{< relref "../concepts/disruption/#automated-methods" >}}) for details on how Karpenter uses these automated actions to replace nodes.
 
-With these types of automated updates in place, there is some risk that the new AMI being used when replacing instances will introduce some regressions or bugs that cause your workloads to be degraded or fail altogether.
-The options described below tell you how to take more control over the ways in which Karpenter selects AMIs for your nodes.
+The most relevant automated disruption method is [**Drift**]({{< relref "../concepts/disruption/#drift" >}}), since it is initiated when a new AMI is selected-on by your `amiSelectorTerms`. This could be due to a manual update (e.g. a new `id` term was added), or due to a new AMI being resolved by a dynamic term.
+
+If you're using an `alias` with the `latest` pin (e.g. `al2023@latest`), Karpenter periodically checks for new AMI releases. Since AMI releases are outside your control, this could result in new AMIs being deployed before they have been properly tested in a lower environment. This is why we **strongly recommend** using version pins in production environments when using an alias (e.g. `al2023@v20240807`).
 
 {{% alert title="Important" color="warning" %}}
 If you are new to Karpenter, you should know that the behavior described here is different than you get with Managed Node Groups (MNG). MNG will always use the assigned AMI when it creates a new node and will never automatically upgrade to a new AMI when a new node is required. See [Updating a Managed Node Group](https://docs.aws.amazon.com/eks/latest/userguide/update-managed-node-group.html) to see how you would manually update MNG to use new AMIs.
 {{% /alert %}}
 
-## Choosing AMI options
-One of Karpenter's greatest assets is its ability to provide the right node at the right time, with little intervention from the person managing the cluster.
-Its default behavior of using a later AMI if one becomes available in the selected family means you automatically get the latest security fixes and features.
-However, with this comes the risk that the new AMI could break or degrade your workloads.
+## Controlling AMI Replacement
 
-As the Karpenter team looks for new ways to manage AMIs, the options below offer some means of reducing these risks, based on your own security and ease-of-use requirements.
-Here are the advantages and challenges of each of the options described below:
+Karpenter's automated node replacement functionality in tandem with the `EC2NodeClass` gives you a lot of flexibility to control the desired state of nodes on your cluster. For example, you can opt-in to AMI auto-upgrades using `alias` set to `@latest`; however, this has to be weighed heavily against the risk of newer versions of an AMI breaking existing applications on your cluster. Alternatively, you can choose to pin your AMIs in your production clusters to avoid the risk of breaking changes; however, this has to be weighed against the management cost of testing new AMIs in pre-production and keeping up with the latest AMI versions.
 
-* [Option 1]({{< relref "#option-1-manage-how-amis-are-tested-and-rolled-out" >}}) (Test AMIs): The safest way, and the one we recommend, for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. So combining this with other options, that do things like slow rollouts, can allow you to catch problems before they impact your whole cluster.
-* [Option 2]({{< relref "#option-2-lock-down-which-amis-are-selected" >}}) (Lock down AMIs): If workloads require a particluar AMI, this option can make sure that it is the only AMI used by Karpenter. This can be used in combination with Option 1, where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production. Keep in mind that this makes upgrades a manual process for you.
-* [Option 3]({{< relref "#option-3-control-the-pace-of-node-disruptions" >}}) ([Disruption budgets]({{< relref "../concepts/disruption/" >}})): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time respond to rollout issues.
+Karpenter offers you various controls to ensure you don't take on too much risk as you rollout new versions of AMIs to your production clusters. Below shows how you can use these controls:
 
-## Options
+* [Pinning AMIs]({{< relref "#pinning-amis" >}}): If workloads require a particluar AMI, this control ensures that it is the only AMI used by Karpenter. This can be used in combination with [Testing AMIs]({{< relref "#testing-amis" >}}) where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production.
+* [Testing AMIs]({{< relref "#testing-amis" >}}): The safest way for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. Combining this with other controls like [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}) can allow you to catch problems before they impact your whole cluster.
+* [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time to respond to rollout issues.
 
-The following lays out the options you have to impact Karpenter’s behavior as it relates to how nodes are created and AMIs are consumed.
+### Pinning AMIs
 
-### Option 1: Manage how AMIs are tested and rolled out
+When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you are required to configure which AMIs you want Karpenter to select on using the `amiSelectorTerms` field. When pinning to a specific `id`, `name`, `tags` or an `alias` that contains a fixed version, Karpenter will only select on a single AMI and won't automatically upgrade your nodes to a new version of an AMI. This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
+).
 
-Instead of just avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production.
-For example, you could have:
+{{% alert title="Note" color="primary" %}}
+Pinning an AMI to an `alias` type with a fixed version _will_ pin the AMI so long as your K8s control plane version doesn't change. Unlike `id` and `name` types, specifying a version `alias` in your `amiSelectorTerms` will cause Karpenter to consider the K8s control plane version of your cluster when choosing the AMI. If you upgrade your Kubernetes cluster while using this alias type, Karpenter _will_ automatically drift your nodes to a new AMI that still matches the AMI version but also matches your new K8s control plane version.
+{{% /alert %}}
 
-* **Test clusters**: On lower environment clusters, you can run the latest AMIs for your workloads in a safe environment. The `EC2NodeClass` for these clusters could be set with a chosen `amiFamily`, but no `amiSelectorTerms` set. For example, the `NodePool` and `EC2NodeClass` could begin with the following:
-
-  ```yaml
-  apiVersion: karpenter.sh/v1
-  kind: NodePool
-  metadata:
-    name: default
-  spec:
-    template:
-      spec:
-        nodeClassRef:
-          apiVersion: karpenter.k8s.aws/v1
-          kind: EC2NodeClass
-          name: default
-  ---
-  apiVersion: karpenter.k8s.aws/v1
-  kind: EC2NodeClass
-  metadata:
-    name: default
-  spec:
-    # The latest AMI in this family will be used
-    amiFamily: AL2
-  ```
-* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. One way to do that is to use `amiSelectorTerms` to set the tested AMI to be used in your production cluster. Refer to Option 2 for how to choose a particular AMI by `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in Option 3.
-
-### Option 2: Lock down which AMIs are selected
-
-Instead of letting Karpenter always run the latest AMI, you can change Karpenter’s default behavior.
-When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you can set a specific AMI that you want Karpenter to always choose, using the `amiSelectorTerms` field.
-This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
-
-With the `amiSelectorTerms` field in an `EC2NodeClass`, you can set a specific AMI for Karpenter to use, based on AMI name or id (only one is required).
-These examples show two different ways to identify the same AMI:
+These examples show three different ways to identify the same AMI:
 
 ```yaml
+# Using alias
+# Pinning to this fixed version alias will pull this version of the AMI,
+# matching the K8s control plane version of your cluster
 amiSelectorTerms:
-- tags:
-    karpenter.sh/discovery: "${CLUSTER_NAME}"
-    environment: prod
+- alias: al2023@v20240219
+```
+
+```yaml
+# Using name
+# This will only ever select the AMI that contains this exact name
+amiSelectorTerms:
 - name: al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64
 ```
 
-or
+```yaml
+# Using id
+# This will only ever select this specific AMI id
+amiSelectorTerms:
+- id: ami-052c9ea013e6e3567
+```
 
 ```yaml
+# Using tags
+# You can use a CI/CD system to test newer versions of an AMI
+# and automatically tag them as you validate that they are safe to upgrade to
 amiSelectorTerms:
 - tags:
     karpenter.sh/discovery: "${CLUSTER_NAME}"
     environment: prod
-- id: ami-052c9ea013e6e3567
 ```
 
-See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details. 
+See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details.
 Keep in mind, that this could prevent you from getting critical security patches when new AMIs are available, but it does give you control over exactly which AMI is running.
 
+### Testing AMIs
 
-### Option 3: Control the pace of node disruptions
+Instead of avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production. For example, you could have:
 
-To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter [**Disruption Budgets**]({{< relref "../concepts/disruption/#disruption-budgets " >}}).
-Disruption Budgets limit when and to what extent nodes can be disrupted.
-You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
-You can set Disruption Budgets in a `NodePool` spec.
-Here is an example:
+* **Test clusters**: On lower environment clusters, you can run the latest AMIs e.g. `al2023@latest`, `al2@latest`, `bottlerocket@latest`, for your workloads in a safe environment. This ensures that you get the latest patches for AMIs where downtime to applications isn't as critical and allows you to validate patches to AMIs before they are deployed to production.
+
+* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. Refer to [Pinning AMIs]({{< relref "#pinning-amis" >}}) for how to choose a particular AMI by `alias`, `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}).
+
+### Using Disruption Budgets
+
+To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter's [**Node Disruption Budgets**]({{< relref "#node-disruption-budgets " >}}) as well as ensure that you have [**Pod Disruption Budgets**]({{< relref "#pod-disruption-budgets " >}}) configured for applications on your cluster. Below provides more details on how to configure each.
+
+#### Node Disruption Budgets
+
+[Disruption Budgets]({{< relref "../concepts/disruption/#disruption-budgets " >}}) limit when and to what extent nodes can be disrupted. You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
+You can set Disruption Budgets in a `NodePool` spec. Here is an example:
 
 ```yaml
-template:
-  spec:
-    expireAfter: 1440h
 disruption:
-  consolidationPolicy: WhenEmpty
   budgets:
   - nodes: 15%
   - nodes: "3"
   - nodes: "0"
-    schedule: "0 7 * * sat-sun"
-    duration: 12h
+    schedule: "0 9 * * sat-sun"
+    duration: 24h
+  - nodes: "0"
+    schedule: "0 17 * * mon-fri"
+    duration: 16h
+    reasons:
+      - Drifted
 ```
-
-The `disruption` settings define a few fields that indicate the state of a node that should be disrupted.
-The `consolidationPolicy` field indicates that a node should be disrupted if the node is either empty or underutilized (`WhenEmptyOrUnderutilized`) or not running any pods (`WhenEmpty`).
-With `expireAfter` set to `1440` hours, the node expires after 60 days.
-Extending those values causes longer times without disruption.
 
 Settings for budgets in the above example include the following:
 
 * **Percentage of nodes**: From the first `nodes` setting, only `15%` of the NodePool’s nodes can be disrupted at a time.
 * **Number of nodes**: The second `nodes` setting limits the number of nodes that can be disrupted at a time to `3`.
-* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 7am on Saturday and Sunday and continues for 12 hours.
+* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 9am on Saturday and Sunday and continues for 24 (fully blocking disruptions all day).
 The format of the schedule follows the `crontab` format for identifying dates and times.
 See the [crontab](https://man7.org/linux/man-pages/man5/crontab.5.html) page for information on the supported values for these fields.
+* **Reasons**: The fourth `nodes` setting uses `reasons` which implies that this budget only applies to the `Drifted` disruption condition. This setting uses schedule to say that zero disruptions (`0`) are allowed starting at 5pm on Monday, Tuesday, Wednesday, Thursday, and Friday and continues for 16h (effectively blocking rolling nodes due to drift outside of working hours).
 
 As with all disruption settings, keep in mind that avoiding updated AMIs for your nodes can result in not getting fixes for known security risks and bugs.
 You need to balance that with your desire to not risk breaking the workloads on your cluster.
+
+#### Pod Disruption Budgets
+
+[Pod Disruption Budgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) allow you to describe how much disruption an application can tolerate before it begins to become unhealthy. This is critical to configure for Karpenter, since Karpenter uses this information to determine if it can continue to replace nodes. Specifically, if replacing a node would cause a Pod Disruption Budget to be breached (for graceful forms of disruption e.g. Drift or Consolidation), Karpenter will not replace the node.
+
+In a scenario where a faulty AMI is rolling out and begins causing downtime to your applications, configuring Pod Disruption Budgets is critical since this will tell Karpenter that it must stop replacing nodes until your applications become healthy again. This prevents Karpenter from deploying the faulty AMI throughout your cluster, reduces the imact the AMI has on your production applications, and gives you manually intervene in the cluster to remediate the issue.
 
 ## Follow-up
 

--- a/website/content/en/preview/tasks/managing-amis.md
+++ b/website/content/en/preview/tasks/managing-amis.md
@@ -6,6 +6,17 @@ description: >
   Task for managing AMIs in Karpenter
 ---
 
+{{% alert title="Important" color="warning" %}}
+Karpenter __heavily recommends against__ opting-in to use an `amiSelectorTerm` with `@latest` unless you are doing this in a pre-production environment or are willing to accept the risk that a faulty AMI may cause downtime in your production clusters. In general, if using a publicly released version of a well-known AMI type (like AL2, AL2023, or Bottlerocket), we recommend that you pin to a version of that AMI and deploy newer versions of that AMI type in a staged approach when newer patch versions are available.
+
+```yaml
+amiSelectorTerms:
+  - alias: al2023@v20240807
+```
+
+More details are described in [Controlling AMI Replacement]({{< relref "#controlling-ami-replacement" >}}) below.
+{{% /alert %}}
+
 Understanding how Karpenter assigns AMIs to nodes can help ensure that your workloads will run successfully on those nodes and continue to run if the nodes are upgraded to newer AMIs.
 Below we describe how Karpenter assigns AMIs to nodes when they are first deployed and how newer AMIs are assigned later when nodes are spun up to replace old ones.
 Later, it describes the options you have to assert control over how AMIs are used by Karpenter for your clusters.
@@ -17,137 +28,131 @@ See [How do I upgrade an EKS Cluster with Karpenter]({{< relref "../faq/#how-do-
 
 Here is how Karpenter assigns AMIs nodes:
 
-* When you create an `EC2NodeClass`, you are required to set the family of AMIs to use. For example, for the AL2 family, you would set `amiFamily: AL2`.
-* With that `amiFamily` set, any time Karpenter spins up a new node, it uses the latest [Amazon EKS optimized Amazon Linux 2 AMIs](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html) release.
-* Later, if an existing node needs to be replaced, Karpenter checks to see if a newer AMI in the AL2 family is available and automatically uses the new AMI instead to spin up the new node. In other words, you may automatically get an AMI that you have not tested with your workloads.
+* When you create an `EC2NodeClass`, you are required to specify [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}). [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) allow you to select on AMIs that can be spun-up by this EC2NodeClass based on tags, id, name, or an alias. Multiple AMIs may be specified, and Karpenter will choose the newest compatible AMI when spinning up new nodes.
+* Some `amiSelectorTerm` types are static and always resolve to the same AMI (e.g. `id`). However, some are dynamic and may resolve to different AMIs over time. Examples of dynamic types include `alias`, `tags`, and `name` (when using a wildcard). For example, if you specify an `amiSelectorTerm` with an `alias` set to `@latest` (e.g. `al2023@latest`, `al2@latest`, or `bottlerocket@latest`), Karpenter will use the _latest_ release for that AMI type when spinning up a new node.
+* When a node is replaced, Karpenter checks to see if a newer AMI is available based on your `amiSelectorTerms`. If a newer AMI is available, Karpenter will automatically use the new AMI to spin up the new node. __In particular, if you are using a dynamic `amiSelectorTerm` type, you may get a new AMI deployed to your environment without having properly tested it.__
 
-You can manually delete a node managed by Karpenter, which will cause the default behavior just described to take effect.
-However, there are situations that will cause node replacements with newer AMIs to happen automatically.
-These include: Expiration (if node expiry is set, the node is marked for deletion at a certain time after the node is created), [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}) (if a node is empty of workloads, or deemed to be inefficiently running workloads, nodes can be deleted and more appropriately featured nodes are brought up to consolidate workloads), [Drift]({{< relref "../concepts/disruption/#drift" >}}) (nodes are set for deletion when they drift from the desired state of the `NodeClaims` and new nodes are brought up to replace them), and [Interruption]({{< relref "../concepts/disruption/#interruption" >}}) (nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed).
+Whenever a node is replaced, the replacement node will be launched using the newest AMI based on your `amiSelectorTerms`. Nodes may be replaced due to manual deletion, or any of Karpenter's automated methods:
+- [**Expiration**]({{< relref "../concepts/disruption/#expiration" >}}): Automatically initiates replacement at a certain time after the node is created.
+-  [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}): If Karpenter detects that a cheaper node can be used to run the same workloads, Karpenter may replace the current node automatically.
+- [**Drift**]({{< relref "../concepts/disruption/#drift" >}}): If a node's state no longer matches the desired state dictated by the `NodePool` or `EC2NodeClass`, it will be replaced, including if the node's AMI no longer matches the latest AMI selected by the `amiSelectorTerms`.
+- [**Interruption**]({{< relref "../concepts/disruption/#interruption" >}}): Nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed.
 
 See [**Automated Methods**]({{< relref "../concepts/disruption/#automated-methods" >}}) for details on how Karpenter uses these automated actions to replace nodes.
 
-With these types of automated updates in place, there is some risk that the new AMI being used when replacing instances will introduce some regressions or bugs that cause your workloads to be degraded or fail altogether.
-The options described below tell you how to take more control over the ways in which Karpenter selects AMIs for your nodes.
+The most relevant automated disruption method is [**Drift**]({{< relref "../concepts/disruption/#drift" >}}), since it is initiated when a new AMI is selected-on by your `amiSelectorTerms`. This could be due to a manual update (e.g. a new `id` term was added), or due to a new AMI being resolved by a dynamic term.
+
+If you're using an `alias` with the `latest` pin (e.g. `al2023@latest`), Karpenter periodically checks for new AMI releases. Since AMI releases are outside your control, this could result in new AMIs being deployed before they have been properly tested in a lower environment. This is why we **strongly recommend** using version pins in production environments when using an alias (e.g. `al2023@v20240807`).
 
 {{% alert title="Important" color="warning" %}}
 If you are new to Karpenter, you should know that the behavior described here is different than you get with Managed Node Groups (MNG). MNG will always use the assigned AMI when it creates a new node and will never automatically upgrade to a new AMI when a new node is required. See [Updating a Managed Node Group](https://docs.aws.amazon.com/eks/latest/userguide/update-managed-node-group.html) to see how you would manually update MNG to use new AMIs.
 {{% /alert %}}
 
-## Choosing AMI options
-One of Karpenter's greatest assets is its ability to provide the right node at the right time, with little intervention from the person managing the cluster.
-Its default behavior of using a later AMI if one becomes available in the selected family means you automatically get the latest security fixes and features.
-However, with this comes the risk that the new AMI could break or degrade your workloads.
+## Controlling AMI Replacement
 
-As the Karpenter team looks for new ways to manage AMIs, the options below offer some means of reducing these risks, based on your own security and ease-of-use requirements.
-Here are the advantages and challenges of each of the options described below:
+Karpenter's automated node replacement functionality in tandem with the `EC2NodeClass` gives you a lot of flexibility to control the desired state of nodes on your cluster. For example, you can opt-in to AMI auto-upgrades using `alias` set to `@latest`; however, this has to be weighed heavily against the risk of newer versions of an AMI breaking existing applications on your cluster. Alternatively, you can choose to pin your AMIs in your production clusters to avoid the risk of breaking changes; however, this has to be weighed against the management cost of testing new AMIs in pre-production and keeping up with the latest AMI versions.
 
-* [Option 1]({{< relref "#option-1-manage-how-amis-are-tested-and-rolled-out" >}}) (Test AMIs): The safest way, and the one we recommend, for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. So combining this with other options, that do things like slow rollouts, can allow you to catch problems before they impact your whole cluster.
-* [Option 2]({{< relref "#option-2-lock-down-which-amis-are-selected" >}}) (Lock down AMIs): If workloads require a particluar AMI, this option can make sure that it is the only AMI used by Karpenter. This can be used in combination with Option 1, where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production. Keep in mind that this makes upgrades a manual process for you.
-* [Option 3]({{< relref "#option-3-control-the-pace-of-node-disruptions" >}}) ([Disruption budgets]({{< relref "../concepts/disruption/" >}})): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time respond to rollout issues.
+Karpenter offers you various controls to ensure you don't take on too much risk as you rollout new versions of AMIs to your production clusters. Below shows how you can use these controls:
 
-## Options
+* [Pinning AMIs]({{< relref "#pinning-amis" >}}): If workloads require a particluar AMI, this control ensures that it is the only AMI used by Karpenter. This can be used in combination with [Testing AMIs]({{< relref "#testing-amis" >}}) where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production.
+* [Testing AMIs]({{< relref "#testing-amis" >}}): The safest way for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. Combining this with other controls like [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}) can allow you to catch problems before they impact your whole cluster.
+* [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time to respond to rollout issues.
 
-The following lays out the options you have to impact Karpenter’s behavior as it relates to how nodes are created and AMIs are consumed.
+### Pinning AMIs
 
-### Option 1: Manage how AMIs are tested and rolled out
+When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you are required to configure which AMIs you want Karpenter to select on using the `amiSelectorTerms` field. When pinning to a specific `id`, `name`, `tags` or an `alias` that contains a fixed version, Karpenter will only select on a single AMI and won't automatically upgrade your nodes to a new version of an AMI. This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
+).
 
-Instead of just avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production.
-For example, you could have:
+{{% alert title="Note" color="primary" %}}
+Pinning an AMI to an `alias` type with a fixed version _will_ pin the AMI so long as your K8s control plane version doesn't change. Unlike `id` and `name` types, specifying a version `alias` in your `amiSelectorTerms` will cause Karpenter to consider the K8s control plane version of your cluster when choosing the AMI. If you upgrade your Kubernetes cluster while using this alias type, Karpenter _will_ automatically drift your nodes to a new AMI that still matches the AMI version but also matches your new K8s control plane version.
+{{% /alert %}}
 
-* **Test clusters**: On lower environment clusters, you can run the latest AMIs for your workloads in a safe environment. The `EC2NodeClass` for these clusters could be set with a chosen `amiFamily`, but no `amiSelectorTerms` set. For example, the `NodePool` and `EC2NodeClass` could begin with the following:
-
-  ```yaml
-  apiVersion: karpenter.sh/v1
-  kind: NodePool
-  metadata:
-    name: default
-  spec:
-    template:
-      spec:
-        nodeClassRef:
-          apiVersion: karpenter.k8s.aws/v1
-          kind: EC2NodeClass
-          name: default
-  ---
-  apiVersion: karpenter.k8s.aws/v1
-  kind: EC2NodeClass
-  metadata:
-    name: default
-  spec:
-    # The latest AMI in this family will be used
-    amiFamily: AL2
-  ```
-* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. One way to do that is to use `amiSelectorTerms` to set the tested AMI to be used in your production cluster. Refer to Option 2 for how to choose a particular AMI by `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in Option 3.
-
-### Option 2: Lock down which AMIs are selected
-
-Instead of letting Karpenter always run the latest AMI, you can change Karpenter’s default behavior.
-When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you can set a specific AMI that you want Karpenter to always choose, using the `amiSelectorTerms` field.
-This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
-
-With the `amiSelectorTerms` field in an `EC2NodeClass`, you can set a specific AMI for Karpenter to use, based on AMI name or id (only one is required).
-These examples show two different ways to identify the same AMI:
+These examples show three different ways to identify the same AMI:
 
 ```yaml
+# Using alias
+# Pinning to this fixed version alias will pull this version of the AMI,
+# matching the K8s control plane version of your cluster
 amiSelectorTerms:
-- tags:
-    karpenter.sh/discovery: "${CLUSTER_NAME}"
-    environment: prod
+- alias: al2023@v20240219
+```
+
+```yaml
+# Using name
+# This will only ever select the AMI that contains this exact name
+amiSelectorTerms:
 - name: al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64
 ```
 
-or
+```yaml
+# Using id
+# This will only ever select this specific AMI id
+amiSelectorTerms:
+- id: ami-052c9ea013e6e3567
+```
 
 ```yaml
+# Using tags
+# You can use a CI/CD system to test newer versions of an AMI
+# and automatically tag them as you validate that they are safe to upgrade to
 amiSelectorTerms:
 - tags:
     karpenter.sh/discovery: "${CLUSTER_NAME}"
     environment: prod
-- id: ami-052c9ea013e6e3567
 ```
 
-See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details. 
+See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details.
 Keep in mind, that this could prevent you from getting critical security patches when new AMIs are available, but it does give you control over exactly which AMI is running.
 
+### Testing AMIs
 
-### Option 3: Control the pace of node disruptions
+Instead of avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production. For example, you could have:
 
-To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter [**Disruption Budgets**]({{< relref "../concepts/disruption/#disruption-budgets " >}}).
-Disruption Budgets limit when and to what extent nodes can be disrupted.
-You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
-You can set Disruption Budgets in a `NodePool` spec.
-Here is an example:
+* **Test clusters**: On lower environment clusters, you can run the latest AMIs e.g. `al2023@latest`, `al2@latest`, `bottlerocket@latest`, for your workloads in a safe environment. This ensures that you get the latest patches for AMIs where downtime to applications isn't as critical and allows you to validate patches to AMIs before they are deployed to production.
+
+* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. Refer to [Pinning AMIs]({{< relref "#pinning-amis" >}}) for how to choose a particular AMI by `alias`, `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}).
+
+### Using Disruption Budgets
+
+To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter's [**Node Disruption Budgets**]({{< relref "#node-disruption-budgets " >}}) as well as ensure that you have [**Pod Disruption Budgets**]({{< relref "#pod-disruption-budgets " >}}) configured for applications on your cluster. Below provides more details on how to configure each.
+
+#### Node Disruption Budgets
+
+[Disruption Budgets]({{< relref "../concepts/disruption/#disruption-budgets " >}}) limit when and to what extent nodes can be disrupted. You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
+You can set Disruption Budgets in a `NodePool` spec. Here is an example:
 
 ```yaml
-template:
-  spec:
-    expireAfter: 1440h
 disruption:
-  consolidationPolicy: WhenEmpty
   budgets:
   - nodes: 15%
   - nodes: "3"
   - nodes: "0"
-    schedule: "0 7 * * sat-sun"
-    duration: 12h
+    schedule: "0 9 * * sat-sun"
+    duration: 24h
+  - nodes: "0"
+    schedule: "0 17 * * mon-fri"
+    duration: 16h
+    reasons:
+      - Drifted
 ```
-
-The `disruption` settings define a few fields that indicate the state of a node that should be disrupted.
-The `consolidationPolicy` field indicates that a node should be disrupted if the node is either empty or underutilized (`WhenEmptyOrUnderutilized`) or not running any pods (`WhenEmpty`).
-With `expireAfter` set to `1440` hours, the node expires after 60 days.
-Extending those values causes longer times without disruption.
 
 Settings for budgets in the above example include the following:
 
 * **Percentage of nodes**: From the first `nodes` setting, only `15%` of the NodePool’s nodes can be disrupted at a time.
 * **Number of nodes**: The second `nodes` setting limits the number of nodes that can be disrupted at a time to `3`.
-* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 7am on Saturday and Sunday and continues for 12 hours.
+* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 9am on Saturday and Sunday and continues for 24 (fully blocking disruptions all day).
 The format of the schedule follows the `crontab` format for identifying dates and times.
 See the [crontab](https://man7.org/linux/man-pages/man5/crontab.5.html) page for information on the supported values for these fields.
+* **Reasons**: The fourth `nodes` setting uses `reasons` which implies that this budget only applies to the `Drifted` disruption condition. This setting uses schedule to say that zero disruptions (`0`) are allowed starting at 5pm on Monday, Tuesday, Wednesday, Thursday, and Friday and continues for 16h (effectively blocking rolling nodes due to drift outside of working hours).
 
 As with all disruption settings, keep in mind that avoiding updated AMIs for your nodes can result in not getting fixes for known security risks and bugs.
 You need to balance that with your desire to not risk breaking the workloads on your cluster.
+
+#### Pod Disruption Budgets
+
+[Pod Disruption Budgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) allow you to describe how much disruption an application can tolerate before it begins to become unhealthy. This is critical to configure for Karpenter, since Karpenter uses this information to determine if it can continue to replace nodes. Specifically, if replacing a node would cause a Pod Disruption Budget to be breached (for graceful forms of disruption e.g. Drift or Consolidation), Karpenter will not replace the node.
+
+In a scenario where a faulty AMI is rolling out and begins causing downtime to your applications, configuring Pod Disruption Budgets is critical since this will tell Karpenter that it must stop replacing nodes until your applications become healthy again. This prevents Karpenter from deploying the faulty AMI throughout your cluster, reduces the imact the AMI has on your production applications, and gives you manually intervene in the cluster to remediate the issue.
 
 ## Follow-up
 

--- a/website/content/en/v1.0/tasks/managing-amis.md
+++ b/website/content/en/v1.0/tasks/managing-amis.md
@@ -6,6 +6,17 @@ description: >
   Task for managing AMIs in Karpenter
 ---
 
+{{% alert title="Important" color="warning" %}}
+Karpenter __heavily recommends against__ opting-in to use an `amiSelectorTerm` with `@latest` unless you are doing this in a pre-production environment or are willing to accept the risk that a faulty AMI may cause downtime in your production clusters. In general, if using a publicly released version of a well-known AMI type (like AL2, AL2023, or Bottlerocket), we recommend that you pin to a version of that AMI and deploy newer versions of that AMI type in a staged approach when newer patch versions are available.
+
+```yaml
+amiSelectorTerms:
+  - alias: al2023@v20240807
+```
+
+More details are described in [Controlling AMI Replacement]({{< relref "#controlling-ami-replacement" >}}) below.
+{{% /alert %}}
+
 Understanding how Karpenter assigns AMIs to nodes can help ensure that your workloads will run successfully on those nodes and continue to run if the nodes are upgraded to newer AMIs.
 Below we describe how Karpenter assigns AMIs to nodes when they are first deployed and how newer AMIs are assigned later when nodes are spun up to replace old ones.
 Later, it describes the options you have to assert control over how AMIs are used by Karpenter for your clusters.
@@ -17,137 +28,109 @@ See [How do I upgrade an EKS Cluster with Karpenter]({{< relref "../faq/#how-do-
 
 Here is how Karpenter assigns AMIs nodes:
 
-* When you create an `EC2NodeClass`, you are required to set the family of AMIs to use. For example, for the AL2 family, you would set `amiFamily: AL2`.
-* With that `amiFamily` set, any time Karpenter spins up a new node, it uses the latest [Amazon EKS optimized Amazon Linux 2 AMIs](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html) release.
-* Later, if an existing node needs to be replaced, Karpenter checks to see if a newer AMI in the AL2 family is available and automatically uses the new AMI instead to spin up the new node. In other words, you may automatically get an AMI that you have not tested with your workloads.
+* When you create an `EC2NodeClass`, you are required to specify [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}). [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) allow you to select on AMIs that can be spun-up by this EC2NodeClass based on tags, id, name, or an alias.
+* If you specify an `amiSelectorTerm` with an `alias` set to `@latest` e.g. `al2023@latest`, `al2@latest`, `bottlerocket@latest`, any time Karpenter spins up a new node, it uses the latest release for that AMI type.
+* When a node is replaced, Karpenter checks to see if a newer AMI is available based on your `amiSelectorTerms`. If a newer AMI is available, Karpenter will automatically use the new AMI to spin up the new node. In particular, if you are using an `alias` set to `@latest`, you may get a new AMI deployed to your environment without having properly tested it.
+  * Karpenter automatically marks nodes as `Drifted` (determining that the node needs to be replaced) when the latest AMI that matches your `amiSelectorTerms` does not match the AMI assigned to the node.
 
-You can manually delete a node managed by Karpenter, which will cause the default behavior just described to take effect.
-However, there are situations that will cause node replacements with newer AMIs to happen automatically.
-These include: Expiration (if node expiry is set, the node is marked for deletion at a certain time after the node is created), [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}) (if a node is empty of workloads, or deemed to be inefficiently running workloads, nodes can be deleted and more appropriately featured nodes are brought up to consolidate workloads), [Drift]({{< relref "../concepts/disruption/#drift" >}}) (nodes are set for deletion when they drift from the desired state of the `NodeClaims` and new nodes are brought up to replace them), and [Interruption]({{< relref "../concepts/disruption/#interruption" >}}) (nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed).
+You can manually delete a node managed by Karpenter, which will cause the replacement behavior mentioned above to take effect. Karpenter will also automatically replace your nodes when the node meets a certain replacement condition. These conditions include: [**Expiration**]({{< relref "../concepts/disruption/#expiration" >}}) (if node expiry is set, the node is marked for deletion at a certain time after the node is created), [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}) (if a node is empty of workloads, or deemed to be inefficiently running workloads, nodes can be deleted and more appropriately featured nodes are brought up to consolidate workloads), [**Drift**]({{< relref "../concepts/disruption/#drift" >}}) (nodes are set for deletion when they drift from the desired state of the `NodeClaims` and new nodes are brought up to replace them), and [**Interruption**]({{< relref "../concepts/disruption/#interruption" >}}) (nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed).
 
 See [**Automated Methods**]({{< relref "../concepts/disruption/#automated-methods" >}}) for details on how Karpenter uses these automated actions to replace nodes.
-
-With these types of automated updates in place, there is some risk that the new AMI being used when replacing instances will introduce some regressions or bugs that cause your workloads to be degraded or fail altogether.
-The options described below tell you how to take more control over the ways in which Karpenter selects AMIs for your nodes.
 
 {{% alert title="Important" color="warning" %}}
 If you are new to Karpenter, you should know that the behavior described here is different than you get with Managed Node Groups (MNG). MNG will always use the assigned AMI when it creates a new node and will never automatically upgrade to a new AMI when a new node is required. See [Updating a Managed Node Group](https://docs.aws.amazon.com/eks/latest/userguide/update-managed-node-group.html) to see how you would manually update MNG to use new AMIs.
 {{% /alert %}}
 
-## Choosing AMI options
-One of Karpenter's greatest assets is its ability to provide the right node at the right time, with little intervention from the person managing the cluster.
-Its default behavior of using a later AMI if one becomes available in the selected family means you automatically get the latest security fixes and features.
-However, with this comes the risk that the new AMI could break or degrade your workloads.
+## Controlling AMI Replacement
 
-As the Karpenter team looks for new ways to manage AMIs, the options below offer some means of reducing these risks, based on your own security and ease-of-use requirements.
-Here are the advantages and challenges of each of the options described below:
+Karpenter's automated node replacement functionality in tandem with the `EC2NodeClass` gives you a lot of flexibility to control the desired state of nodes on your cluster. For example, you can opt-in to AMI auto-upgrades using `alias` set to `@latest`; however, this has to be weighed heavily against the risk of newer versions of an AMI breaking existing applications on your cluster. Alternatively, you can choose to pin your AMIs in your production clusters to avoid the risk of breaking changes; however, this has to be weighed against the management cost of testing new AMIs in pre-production and keeping up with the latest AMI versions.
 
-* [Option 1]({{< relref "#option-1-manage-how-amis-are-tested-and-rolled-out" >}}) (Test AMIs): The safest way, and the one we recommend, for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. So combining this with other options, that do things like slow rollouts, can allow you to catch problems before they impact your whole cluster.
-* [Option 2]({{< relref "#option-2-lock-down-which-amis-are-selected" >}}) (Lock down AMIs): If workloads require a particluar AMI, this option can make sure that it is the only AMI used by Karpenter. This can be used in combination with Option 1, where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production. Keep in mind that this makes upgrades a manual process for you.
-* [Option 3]({{< relref "#option-3-control-the-pace-of-node-disruptions" >}}) ([Disruption budgets]({{< relref "../concepts/disruption/" >}})): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time respond to rollout issues.
+Karpenter offers you various controls to ensure you don't take on too much risk as you rollout new versions of AMIs to your production clusters. Below shows how you can use these controls:
 
-## Options
+* [Pinning AMIs]({{< relref "#pinning-amis" >}}): If workloads require a particluar AMI, this control ensures that it is the only AMI used by Karpenter. This can be used in combination with [Testing AMIs]({{< relref "#testing-amis" >}}) where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production.
+* [Testing AMIs]({{< relref "#testing-amis" >}}): The safest way for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. Combining this with other controls like [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}) can allow you to catch problems before they impact your whole cluster.
+* [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time to respond to rollout issues.
 
-The following lays out the options you have to impact Karpenter’s behavior as it relates to how nodes are created and AMIs are consumed.
+## Controls
 
-### Option 1: Manage how AMIs are tested and rolled out
+The following lays out the controls you have to impact Karpenter’s behavior as it relates to how nodes are created and AMIs are consumed.
 
-Instead of just avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production.
-For example, you could have:
+### Pinning AMIs
 
-* **Test clusters**: On lower environment clusters, you can run the latest AMIs for your workloads in a safe environment. The `EC2NodeClass` for these clusters could be set with a chosen `amiFamily`, but no `amiSelectorTerms` set. For example, the `NodePool` and `EC2NodeClass` could begin with the following:
-
-  ```yaml
-  apiVersion: karpenter.sh/v1
-  kind: NodePool
-  metadata:
-    name: default
-  spec:
-    template:
-      spec:
-        nodeClassRef:
-          apiVersion: karpenter.k8s.aws/v1
-          kind: EC2NodeClass
-          name: default
-  ---
-  apiVersion: karpenter.k8s.aws/v1
-  kind: EC2NodeClass
-  metadata:
-    name: default
-  spec:
-    # The latest AMI in this family will be used
-    amiFamily: AL2
-  ```
-* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. One way to do that is to use `amiSelectorTerms` to set the tested AMI to be used in your production cluster. Refer to Option 2 for how to choose a particular AMI by `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in Option 3.
-
-### Option 2: Lock down which AMIs are selected
-
-Instead of letting Karpenter always run the latest AMI, you can change Karpenter’s default behavior.
-When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you can set a specific AMI that you want Karpenter to always choose, using the `amiSelectorTerms` field.
-This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
-
-With the `amiSelectorTerms` field in an `EC2NodeClass`, you can set a specific AMI for Karpenter to use, based on AMI name or id (only one is required).
-These examples show two different ways to identify the same AMI:
+When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you are required to configure which AMIs you want Karpenter to select on using the `amiSelectorTerms` field. When pinning to a specific `id`, `name` or an `alias` that contains a fixed version, Karpenter will only select on a single AMI and won't automatically upgrade your nodes to a new version of an AMI. This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
+).
+These examples show three different ways to identify the same AMI:
 
 ```yaml
+# Using alias
 amiSelectorTerms:
-- tags:
-    karpenter.sh/discovery: "${CLUSTER_NAME}"
-    environment: prod
+- alias: al2023@v20240219
+```
+
+```yaml
+# Using name
+amiSelectorTerms:
 - name: al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64
 ```
 
-or
-
 ```yaml
+# Using id
 amiSelectorTerms:
-- tags:
-    karpenter.sh/discovery: "${CLUSTER_NAME}"
-    environment: prod
 - id: ami-052c9ea013e6e3567
 ```
 
-See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details. 
+See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details.
 Keep in mind, that this could prevent you from getting critical security patches when new AMIs are available, but it does give you control over exactly which AMI is running.
 
+### Testing AMIs
 
-### Option 3: Control the pace of node disruptions
+Instead of avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production. For example, you could have:
 
-To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter [**Disruption Budgets**]({{< relref "../concepts/disruption/#disruption-budgets " >}}).
-Disruption Budgets limit when and to what extent nodes can be disrupted.
-You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
-You can set Disruption Budgets in a `NodePool` spec.
-Here is an example:
+* **Test clusters**: On lower environment clusters, you can run the latest AMIs e.g. `al2023@latest`, `al2@latest`, `bottlerocket@latest`, for your workloads in a safe environment. This ensures that you get the latest patches for AMIs where downtime to applications isn't as critical and allows you to validate patches to AMIs before they are deployed to production.
+
+* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. Refer to [Pinning AMIs]({{< relref "#pinning-amis" >}}) for how to choose a particular AMI by `alias`, `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}).
+
+### Using Disruption Budgets
+
+To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter's [**Node Disruption Budgets**]({{< relref "#node-disruption-budgets " >}}) as well as ensure that you have [**Pod Disruption Budgets**]({{< relref "#pod-disruption-budgets " >}}) configured for applications on your cluster. Below provides more details on how to configure each.
+
+#### Node Disruption Budgets
+
+[Disruption Budgets]({{< relref "../concepts/disruption/#disruption-budgets " >}}) limit when and to what extent nodes can be disrupted. You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
+You can set Disruption Budgets in a `NodePool` spec. Here is an example:
 
 ```yaml
-template:
-  spec:
-    expireAfter: 1440h
 disruption:
-  consolidationPolicy: WhenEmpty
   budgets:
   - nodes: 15%
   - nodes: "3"
   - nodes: "0"
-    schedule: "0 7 * * sat-sun"
-    duration: 12h
+    schedule: "0 9 * * sat-sun"
+    duration: 24h
+  - nodes: "0"
+    schedule: "0 17 * * mon-fri"
+    duration: 16h
+    reasons:
+      - Drifted
 ```
-
-The `disruption` settings define a few fields that indicate the state of a node that should be disrupted.
-The `consolidationPolicy` field indicates that a node should be disrupted if the node is either empty or underutilized (`WhenEmptyOrUnderutilized`) or not running any pods (`WhenEmpty`).
-With `expireAfter` set to `1440` hours, the node expires after 60 days.
-Extending those values causes longer times without disruption.
 
 Settings for budgets in the above example include the following:
 
 * **Percentage of nodes**: From the first `nodes` setting, only `15%` of the NodePool’s nodes can be disrupted at a time.
 * **Number of nodes**: The second `nodes` setting limits the number of nodes that can be disrupted at a time to `3`.
-* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 7am on Saturday and Sunday and continues for 12 hours.
+* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 9am on Saturday and Sunday and continues for 24 (fully blocking disruptions all day).
 The format of the schedule follows the `crontab` format for identifying dates and times.
 See the [crontab](https://man7.org/linux/man-pages/man5/crontab.5.html) page for information on the supported values for these fields.
+* **Reasons**: The fourth `nodes` setting uses `reasons` which implies that this budget only applies to the `Drifted` disruption condition. This setting uses schedule to say that zero disruptions (`0`) are allowed starting at 5pm on Monday, Tuesday, Wednesday, Thursday, and Friday and continues for 16h (effectively blocking rolling nodes due to drift outside of working hours).
 
 As with all disruption settings, keep in mind that avoiding updated AMIs for your nodes can result in not getting fixes for known security risks and bugs.
 You need to balance that with your desire to not risk breaking the workloads on your cluster.
+
+#### Pod Disruption Budgets
+
+[Pod Disruption Budgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) allow you to describe how much disruption an application can tolerate before it begins to become unhealthy. This is critical to configure for Karpenter, since Karpenter uses this information to determine if it can continue to replace nodes. Specifically, if replacing a node would cause a Pod Disruption Budget to be breached (for graceful forms of disruption e.g. Drift or Consolidation), Karpenter will not replace the node.
+
+In a scenario where a faulty AMI is rolling out and begins causing downtime to your applications, configuring Pod Disruption Budgets is critical since this will tell Karpenter that it must stop replacing nodes until your applications become healthy again. This prevents Karpenter from deploying the faulty AMI throughout your cluster, reduces the imact the AMI has on your production applications, and gives you manually intervene in the cluster to remediate the issue.
 
 ## Follow-up
 

--- a/website/content/en/v1.1/tasks/managing-amis.md
+++ b/website/content/en/v1.1/tasks/managing-amis.md
@@ -6,6 +6,17 @@ description: >
   Task for managing AMIs in Karpenter
 ---
 
+{{% alert title="Important" color="warning" %}}
+Karpenter __heavily recommends against__ opting-in to use an `amiSelectorTerm` with `@latest` unless you are doing this in a pre-production environment or are willing to accept the risk that a faulty AMI may cause downtime in your production clusters. In general, if using a publicly released version of a well-known AMI type (like AL2, AL2023, or Bottlerocket), we recommend that you pin to a version of that AMI and deploy newer versions of that AMI type in a staged approach when newer patch versions are available.
+
+```yaml
+amiSelectorTerms:
+  - alias: al2023@v20240807
+```
+
+More details are described in [Controlling AMI Replacement]({{< relref "#controlling-ami-replacement" >}}) below.
+{{% /alert %}}
+
 Understanding how Karpenter assigns AMIs to nodes can help ensure that your workloads will run successfully on those nodes and continue to run if the nodes are upgraded to newer AMIs.
 Below we describe how Karpenter assigns AMIs to nodes when they are first deployed and how newer AMIs are assigned later when nodes are spun up to replace old ones.
 Later, it describes the options you have to assert control over how AMIs are used by Karpenter for your clusters.
@@ -17,137 +28,131 @@ See [How do I upgrade an EKS Cluster with Karpenter]({{< relref "../faq/#how-do-
 
 Here is how Karpenter assigns AMIs nodes:
 
-* When you create an `EC2NodeClass`, you are required to set the family of AMIs to use. For example, for the AL2 family, you would set `amiFamily: AL2`.
-* With that `amiFamily` set, any time Karpenter spins up a new node, it uses the latest [Amazon EKS optimized Amazon Linux 2 AMIs](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html) release.
-* Later, if an existing node needs to be replaced, Karpenter checks to see if a newer AMI in the AL2 family is available and automatically uses the new AMI instead to spin up the new node. In other words, you may automatically get an AMI that you have not tested with your workloads.
+* When you create an `EC2NodeClass`, you are required to specify [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}). [`amiSelectorTerms`]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) allow you to select on AMIs that can be spun-up by this EC2NodeClass based on tags, id, name, or an alias. Multiple AMIs may be specified, and Karpenter will choose the newest compatible AMI when spinning up new nodes.
+* Some `amiSelectorTerm` types are static and always resolve to the same AMI (e.g. `id`). However, some are dynamic and may resolve to different AMIs over time. Examples of dynamic types include `alias`, `tags`, and `name` (when using a wildcard). For example, if you specify an `amiSelectorTerm` with an `alias` set to `@latest` (e.g. `al2023@latest`, `al2@latest`, or `bottlerocket@latest`), Karpenter will use the _latest_ release for that AMI type when spinning up a new node.
+* When a node is replaced, Karpenter checks to see if a newer AMI is available based on your `amiSelectorTerms`. If a newer AMI is available, Karpenter will automatically use the new AMI to spin up the new node. __In particular, if you are using a dynamic `amiSelectorTerm` type, you may get a new AMI deployed to your environment without having properly tested it.__
 
-You can manually delete a node managed by Karpenter, which will cause the default behavior just described to take effect.
-However, there are situations that will cause node replacements with newer AMIs to happen automatically.
-These include: Expiration (if node expiry is set, the node is marked for deletion at a certain time after the node is created), [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}) (if a node is empty of workloads, or deemed to be inefficiently running workloads, nodes can be deleted and more appropriately featured nodes are brought up to consolidate workloads), [Drift]({{< relref "../concepts/disruption/#drift" >}}) (nodes are set for deletion when they drift from the desired state of the `NodeClaims` and new nodes are brought up to replace them), and [Interruption]({{< relref "../concepts/disruption/#interruption" >}}) (nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed).
+Whenever a node is replaced, the replacement node will be launched using the newest AMI based on your `amiSelectorTerms`. Nodes may be replaced due to manual deletion, or any of Karpenter's automated methods:
+- [**Expiration**]({{< relref "../concepts/disruption/#expiration" >}}): Automatically initiates replacement at a certain time after the node is created.
+-  [**Consolidation**]({{< relref "../concepts/disruption/#consolidation" >}}): If Karpenter detects that a cheaper node can be used to run the same workloads, Karpenter may replace the current node automatically.
+- [**Drift**]({{< relref "../concepts/disruption/#drift" >}}): If a node's state no longer matches the desired state dictated by the `NodePool` or `EC2NodeClass`, it will be replaced, including if the node's AMI no longer matches the latest AMI selected by the `amiSelectorTerms`.
+- [**Interruption**]({{< relref "../concepts/disruption/#interruption" >}}): Nodes are sometimes involuntarily disrupted by things like Spot interruption, health changes, and instance events, requiring new nodes to be deployed.
 
 See [**Automated Methods**]({{< relref "../concepts/disruption/#automated-methods" >}}) for details on how Karpenter uses these automated actions to replace nodes.
 
-With these types of automated updates in place, there is some risk that the new AMI being used when replacing instances will introduce some regressions or bugs that cause your workloads to be degraded or fail altogether.
-The options described below tell you how to take more control over the ways in which Karpenter selects AMIs for your nodes.
+The most relevant automated disruption method is [**Drift**]({{< relref "../concepts/disruption/#drift" >}}), since it is initiated when a new AMI is selected-on by your `amiSelectorTerms`. This could be due to a manual update (e.g. a new `id` term was added), or due to a new AMI being resolved by a dynamic term.
+
+If you're using an `alias` with the `latest` pin (e.g. `al2023@latest`), Karpenter periodically checks for new AMI releases. Since AMI releases are outside your control, this could result in new AMIs being deployed before they have been properly tested in a lower environment. This is why we **strongly recommend** using version pins in production environments when using an alias (e.g. `al2023@v20240807`).
 
 {{% alert title="Important" color="warning" %}}
 If you are new to Karpenter, you should know that the behavior described here is different than you get with Managed Node Groups (MNG). MNG will always use the assigned AMI when it creates a new node and will never automatically upgrade to a new AMI when a new node is required. See [Updating a Managed Node Group](https://docs.aws.amazon.com/eks/latest/userguide/update-managed-node-group.html) to see how you would manually update MNG to use new AMIs.
 {{% /alert %}}
 
-## Choosing AMI options
-One of Karpenter's greatest assets is its ability to provide the right node at the right time, with little intervention from the person managing the cluster.
-Its default behavior of using a later AMI if one becomes available in the selected family means you automatically get the latest security fixes and features.
-However, with this comes the risk that the new AMI could break or degrade your workloads.
+## Controlling AMI Replacement
 
-As the Karpenter team looks for new ways to manage AMIs, the options below offer some means of reducing these risks, based on your own security and ease-of-use requirements.
-Here are the advantages and challenges of each of the options described below:
+Karpenter's automated node replacement functionality in tandem with the `EC2NodeClass` gives you a lot of flexibility to control the desired state of nodes on your cluster. For example, you can opt-in to AMI auto-upgrades using `alias` set to `@latest`; however, this has to be weighed heavily against the risk of newer versions of an AMI breaking existing applications on your cluster. Alternatively, you can choose to pin your AMIs in your production clusters to avoid the risk of breaking changes; however, this has to be weighed against the management cost of testing new AMIs in pre-production and keeping up with the latest AMI versions.
 
-* [Option 1]({{< relref "#option-1-manage-how-amis-are-tested-and-rolled-out" >}}) (Test AMIs): The safest way, and the one we recommend, for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. So combining this with other options, that do things like slow rollouts, can allow you to catch problems before they impact your whole cluster.
-* [Option 2]({{< relref "#option-2-lock-down-which-amis-are-selected" >}}) (Lock down AMIs): If workloads require a particluar AMI, this option can make sure that it is the only AMI used by Karpenter. This can be used in combination with Option 1, where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production. Keep in mind that this makes upgrades a manual process for you.
-* [Option 3]({{< relref "#option-3-control-the-pace-of-node-disruptions" >}}) ([Disruption budgets]({{< relref "../concepts/disruption/" >}})): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time respond to rollout issues.
+Karpenter offers you various controls to ensure you don't take on too much risk as you rollout new versions of AMIs to your production clusters. Below shows how you can use these controls:
 
-## Options
+* [Pinning AMIs]({{< relref "#pinning-amis" >}}): If workloads require a particluar AMI, this control ensures that it is the only AMI used by Karpenter. This can be used in combination with [Testing AMIs]({{< relref "#testing-amis" >}}) where you lock down the AMI in production, but allow the newest AMIs in a test cluster while you test your workloads before upgrading production.
+* [Testing AMIs]({{< relref "#testing-amis" >}}): The safest way for ensuring that a new AMI doesn't break your workloads is to test it before putting it into production. This takes the most effort on your part, but most effectively models how your workloads will run in production, allowing you to catch issues ahead of time. Note that you can sometimes get different results from your test environment when you roll a new AMI into production, since issues like scale and other factors can elevate problems you might not see in test. Combining this with other controls like [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}) can allow you to catch problems before they impact your whole cluster.
+* [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}): This option can be used as a way of mitigating the scope of impact if a new AMI causes problems with your workloads. With Disruption budgets you can slow the pace of upgrades to nodes with new AMIs or make sure that upgrades only happen during selected dates and times (using `schedule`). This doesn't prevent a bad AMI from being deployed, but it allows you to control when nodes are upgraded, and gives you more time to respond to rollout issues.
 
-The following lays out the options you have to impact Karpenter’s behavior as it relates to how nodes are created and AMIs are consumed.
+### Pinning AMIs
 
-### Option 1: Manage how AMIs are tested and rolled out
+When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you are required to configure which AMIs you want Karpenter to select on using the `amiSelectorTerms` field. When pinning to a specific `id`, `name`, `tags` or an `alias` that contains a fixed version, Karpenter will only select on a single AMI and won't automatically upgrade your nodes to a new version of an AMI. This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
+).
 
-Instead of just avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production.
-For example, you could have:
+{{% alert title="Note" color="primary" %}}
+Pinning an AMI to an `alias` type with a fixed version _will_ pin the AMI so long as your K8s control plane version doesn't change. Unlike `id` and `name` types, specifying a version `alias` in your `amiSelectorTerms` will cause Karpenter to consider the K8s control plane version of your cluster when choosing the AMI. If you upgrade your Kubernetes cluster while using this alias type, Karpenter _will_ automatically drift your nodes to a new AMI that still matches the AMI version but also matches your new K8s control plane version.
+{{% /alert %}}
 
-* **Test clusters**: On lower environment clusters, you can run the latest AMIs for your workloads in a safe environment. The `EC2NodeClass` for these clusters could be set with a chosen `amiFamily`, but no `amiSelectorTerms` set. For example, the `NodePool` and `EC2NodeClass` could begin with the following:
-
-  ```yaml
-  apiVersion: karpenter.sh/v1
-  kind: NodePool
-  metadata:
-    name: default
-  spec:
-    template:
-      spec:
-        nodeClassRef:
-          apiVersion: karpenter.k8s.aws/v1
-          kind: EC2NodeClass
-          name: default
-  ---
-  apiVersion: karpenter.k8s.aws/v1
-  kind: EC2NodeClass
-  metadata:
-    name: default
-  spec:
-    # The latest AMI in this family will be used
-    amiFamily: AL2
-  ```
-* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. One way to do that is to use `amiSelectorTerms` to set the tested AMI to be used in your production cluster. Refer to Option 2 for how to choose a particular AMI by `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in Option 3.
-
-### Option 2: Lock down which AMIs are selected
-
-Instead of letting Karpenter always run the latest AMI, you can change Karpenter’s default behavior.
-When you configure the [**EC2NodeClass**]({{< relref "../concepts/nodeclasses" >}}), you can set a specific AMI that you want Karpenter to always choose, using the `amiSelectorTerms` field.
-This prevents a new and potentially untested AMI from replacing existing nodes when those nodes are terminated.
-
-With the `amiSelectorTerms` field in an `EC2NodeClass`, you can set a specific AMI for Karpenter to use, based on AMI name or id (only one is required).
-These examples show two different ways to identify the same AMI:
+These examples show three different ways to identify the same AMI:
 
 ```yaml
+# Using alias
+# Pinning to this fixed version alias will pull this version of the AMI,
+# matching the K8s control plane version of your cluster
 amiSelectorTerms:
-- tags:
-    karpenter.sh/discovery: "${CLUSTER_NAME}"
-    environment: prod
+- alias: al2023@v20240219
+```
+
+```yaml
+# Using name
+# This will only ever select the AMI that contains this exact name
+amiSelectorTerms:
 - name: al2023-ami-2023.3.20240219.0-kernel-6.1-x86_64
 ```
 
-or
+```yaml
+# Using id
+# This will only ever select this specific AMI id
+amiSelectorTerms:
+- id: ami-052c9ea013e6e3567
+```
 
 ```yaml
+# Using tags
+# You can use a CI/CD system to test newer versions of an AMI
+# and automatically tag them as you validate that they are safe to upgrade to
 amiSelectorTerms:
 - tags:
     karpenter.sh/discovery: "${CLUSTER_NAME}"
     environment: prod
-- id: ami-052c9ea013e6e3567
 ```
 
-See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details. 
+See the [**spec.amiSelectorTerms**]({{< relref "../concepts/nodeclasses/#specamiselectorterms" >}}) section of the NodeClasses page for details.
 Keep in mind, that this could prevent you from getting critical security patches when new AMIs are available, but it does give you control over exactly which AMI is running.
 
+### Testing AMIs
 
-### Option 3: Control the pace of node disruptions
+Instead of avoiding AMI upgrades, you can set up test clusters where you can try out new AMI releases before they are put into production. For example, you could have:
 
-To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter [**Disruption Budgets**]({{< relref "../concepts/disruption/#disruption-budgets " >}}).
-Disruption Budgets limit when and to what extent nodes can be disrupted.
-You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
-You can set Disruption Budgets in a `NodePool` spec.
-Here is an example:
+* **Test clusters**: On lower environment clusters, you can run the latest AMIs e.g. `al2023@latest`, `al2@latest`, `bottlerocket@latest`, for your workloads in a safe environment. This ensures that you get the latest patches for AMIs where downtime to applications isn't as critical and allows you to validate patches to AMIs before they are deployed to production.
+
+* **Production clusters**: After you've confirmed that the AMI works in your lower environments, you can pin the latest AMIs to be deployed in your production clusters to roll out the AMI. Refer to [Pinning AMIs]({{< relref "#pinning-amis" >}}) for how to choose a particular AMI by `alias`, `name` or `id`. Remember that it is still best practice to gradually roll new AMIs into your cluster, even if they have been tested. So consider implementing that for your production clusters as described in [Using Disruption Budgets]({{< relref "#using-disruption-budgets" >}}).
+
+### Using Disruption Budgets
+
+To reduce the risk of entire workloads being immediately degraded when a new AMI is deployed, you can enable Karpenter's [**Node Disruption Budgets**]({{< relref "#node-disruption-budgets " >}}) as well as ensure that you have [**Pod Disruption Budgets**]({{< relref "#pod-disruption-budgets " >}}) configured for applications on your cluster. Below provides more details on how to configure each.
+
+#### Node Disruption Budgets
+
+[Disruption Budgets]({{< relref "../concepts/disruption/#disruption-budgets " >}}) limit when and to what extent nodes can be disrupted. You can prevent disruption based on nodes (a percentage or number of nodes that can be disrupted at a time) and schedule (excluding certain times from disrupting nodes).
+You can set Disruption Budgets in a `NodePool` spec. Here is an example:
 
 ```yaml
-template:
-  spec:
-    expireAfter: 1440h
 disruption:
-  consolidationPolicy: WhenEmpty
   budgets:
   - nodes: 15%
   - nodes: "3"
   - nodes: "0"
-    schedule: "0 7 * * sat-sun"
-    duration: 12h
+    schedule: "0 9 * * sat-sun"
+    duration: 24h
+  - nodes: "0"
+    schedule: "0 17 * * mon-fri"
+    duration: 16h
+    reasons:
+      - Drifted
 ```
-
-The `disruption` settings define a few fields that indicate the state of a node that should be disrupted.
-The `consolidationPolicy` field indicates that a node should be disrupted if the node is either empty or underutilized (`WhenEmptyOrUnderutilized`) or not running any pods (`WhenEmpty`).
-With `expireAfter` set to `1440` hours, the node expires after 60 days.
-Extending those values causes longer times without disruption.
 
 Settings for budgets in the above example include the following:
 
 * **Percentage of nodes**: From the first `nodes` setting, only `15%` of the NodePool’s nodes can be disrupted at a time.
 * **Number of nodes**: The second `nodes` setting limits the number of nodes that can be disrupted at a time to `3`.
-* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 7am on Saturday and Sunday and continues for 12 hours.
+* **Schedule**: The third `nodes` setting uses schedule to say that zero disruptions (`0`) are allowed starting at 9am on Saturday and Sunday and continues for 24 (fully blocking disruptions all day).
 The format of the schedule follows the `crontab` format for identifying dates and times.
 See the [crontab](https://man7.org/linux/man-pages/man5/crontab.5.html) page for information on the supported values for these fields.
+* **Reasons**: The fourth `nodes` setting uses `reasons` which implies that this budget only applies to the `Drifted` disruption condition. This setting uses schedule to say that zero disruptions (`0`) are allowed starting at 5pm on Monday, Tuesday, Wednesday, Thursday, and Friday and continues for 16h (effectively blocking rolling nodes due to drift outside of working hours).
 
 As with all disruption settings, keep in mind that avoiding updated AMIs for your nodes can result in not getting fixes for known security risks and bugs.
 You need to balance that with your desire to not risk breaking the workloads on your cluster.
+
+#### Pod Disruption Budgets
+
+[Pod Disruption Budgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget) allow you to describe how much disruption an application can tolerate before it begins to become unhealthy. This is critical to configure for Karpenter, since Karpenter uses this information to determine if it can continue to replace nodes. Specifically, if replacing a node would cause a Pod Disruption Budget to be breached (for graceful forms of disruption e.g. Drift or Consolidation), Karpenter will not replace the node.
+
+In a scenario where a faulty AMI is rolling out and begins causing downtime to your applications, configuring Pod Disruption Budgets is critical since this will tell Karpenter that it must stop replacing nodes until your applications become healthy again. This prevents Karpenter from deploying the faulty AMI throughout your cluster, reduces the imact the AMI has on your production applications, and gives you manually intervene in the cluster to remediate the issue.
 
 ## Follow-up
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the `Managing AMIs` task to reflect the v1 API including:
- Providing a high-level recommendation at the top of the doc to pin to a specific version of an AMI using the `alias` field or to pin to `name` or `id` if no such `alias` exists
- Updating statements throughout the doc that `amiFamily` automatically opts you into the latest AMI and that the field is required (this was true before v1, but post-v1, the field is no longer required and you specifically have to use an `alias` with `@latest` to opt-in to get auto-upgraded onto the latest AMI)
- Adding a section on Pod Disruption Budgets when describing AMI upgrade controls (this is another critical measure that needs to be employed to ensure that Karpenter is aware of what "application health" means for applications on your cluster and that it does not casue applications to go unhealthy as you roll-out newer versions of the AMIs)
- Removes some extraneous details about disruption settings that aren't relevant to understanding how new versions of an AMI are rolled-out to clusters

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.