### PR TITLE
Bump sigs.k8s.io/karpenter to latest for release-v0.35.x

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	knative.dev/pkg v0.0.0-20240926013127-c4843b746d24
 	sigs.k8s.io/controller-runtime v0.18.4
-	sigs.k8s.io/karpenter v0.35.11
+	sigs.k8s.io/karpenter v0.35.12-0.20250115234433-0f837045f2af
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -749,8 +749,8 @@ sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHv
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/karpenter v0.35.11 h1:HlHEmwL/erGiKBlIc1RAHuvYq+ZHwZ0XOgX6glfeVj4=
-sigs.k8s.io/karpenter v0.35.11/go.mod h1:TrPdPiY6Oc/p8pgkkAlAMaCQDscbrbPsQpsGJUJNg0s=
+sigs.k8s.io/karpenter v0.35.12-0.20250115234433-0f837045f2af h1:GLp9m7HL4cYRgFeSbTaST7tfhLnvYLnaRhJdQN8a3wQ=
+sigs.k8s.io/karpenter v0.35.12-0.20250115234433-0f837045f2af/go.mod h1:TrPdPiY6Oc/p8pgkkAlAMaCQDscbrbPsQpsGJUJNg0s=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -16,7 +16,7 @@ tools() {
     go install github.com/mikefarah/yq/v4@latest
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.3
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
     go install github.com/sigstore/cosign/v2/cmd/cosign@latest
     go install -tags extended github.com/gohugoio/hugo@v0.110.0
     go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change is a cherry-pick of https://github.com/kubernetes-sigs/karpenter/pull/1914 to ensure that we don't crash on the application when the v1 version of the CRD has not been enabled yet to allow a user to upgrade their application before they upgrade their CRD.

**How was this change tested?**

Manually deployed this version to the cluster without upgrading the CRDs to contain the v1 version. Validated that the controller didn't crash and was able to continue to provision NodeClaims

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.