### PR TITLE
feat: add option for extra hourly cost per host

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -147,6 +147,10 @@ spec:
             - name: RESERVED_ENIS
               value: "{{ . }}"
           {{- end }}
+          {{- with .Values.settings.extraHourlyCostPerHost }}
+            - name: EXTRA_HOURLY_COST_PER_HOST
+              value: "{{ . }}"
+          {{- end }}
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -181,6 +181,8 @@ settings:
   # -- Reserved ENIs are not included in the calculations for max-pods or kube-reserved
   # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
   reservedENIs: "0"
+  # -- The additional hourly cost per host, added to the total instance cost, is useful for accounting for extra expenses such as Datadog Infrastructure or APM per-host charges.
+  extraHourlyCostPerHost: 0.0
   # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
   # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
   featureGates:

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -42,6 +42,7 @@ type Options struct {
 	VMMemoryOverheadPercent float64
 	InterruptionQueue       string
 	ReservedENIs            int
+	ExtraHourlyCostPerHost  float64
 }
 
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
@@ -53,6 +54,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent", utils.WithDefaultFloat64("VM_MEMORY_OVERHEAD_PERCENT", 0.075), "The VM memory overhead as a percent that will be subtracted from the total memory for all instance types when cached information is unavailable.")
 	fs.StringVar(&o.InterruptionQueue, "interruption-queue", env.WithDefaultString("INTERRUPTION_QUEUE", ""), "Interruption queue is the name of the SQS queue used for processing interruption events from EC2. Interruption handling is disabled if not specified. Enabling interruption handling may require additional permissions on the controller service account. Additional permissions are outlined in the docs.")
 	fs.IntVar(&o.ReservedENIs, "reserved-enis", env.WithDefaultInt("RESERVED_ENIS", 0), "Reserved ENIs are not included in the calculations for max-pods or kube-reserved. This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.")
+	fs.Float64Var(&o.ExtraHourlyCostPerHost, "extra-hourly-cost-per-host", utils.WithDefaultFloat64("EXTRA_HOURLY_COST_PER_HOST", 0.0), "The additional hourly cost per host, added to the total instance cost, is useful for accounting for extra expenses such as Datadog Infrastructure or APM per-host charges.")
 }
 
 func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -62,7 +62,8 @@ var _ = Describe("Options", func() {
 			"--isolated-vpc",
 			"--vm-memory-overhead-percent", "0.1",
 			"--interruption-queue", "env-cluster",
-			"--reserved-enis", "10")
+			"--reserved-enis", "10",
+			"--extra-hourly-cost-per-host", "0.66")
 		Expect(err).ToNot(HaveOccurred())
 		expectOptionsEqual(opts, test.Options(test.OptionsFields{
 			ClusterCABundle:         lo.ToPtr("env-bundle"),
@@ -72,6 +73,7 @@ var _ = Describe("Options", func() {
 			VMMemoryOverheadPercent: lo.ToPtr[float64](0.1),
 			InterruptionQueue:       lo.ToPtr("env-cluster"),
 			ReservedENIs:            lo.ToPtr(10),
+			ExtraHourlyCostPerHost:  lo.ToPtr[float64](0.66),
 		}))
 	})
 	It("should correctly fallback to env vars when CLI flags aren't set", func() {
@@ -82,6 +84,7 @@ var _ = Describe("Options", func() {
 		os.Setenv("VM_MEMORY_OVERHEAD_PERCENT", "0.1")
 		os.Setenv("INTERRUPTION_QUEUE", "env-cluster")
 		os.Setenv("RESERVED_ENIS", "10")
+		os.Setenv("EXTRA_HOURLY_COST_PER_HOST", "0.88")
 
 		// Add flags after we set the environment variables so that the parsing logic correctly refers
 		// to the new environment variable values
@@ -96,6 +99,7 @@ var _ = Describe("Options", func() {
 			VMMemoryOverheadPercent: lo.ToPtr[float64](0.1),
 			InterruptionQueue:       lo.ToPtr("env-cluster"),
 			ReservedENIs:            lo.ToPtr(10),
+			ExtraHourlyCostPerHost:  lo.ToPtr[float64](0.88),
 		}))
 	})
 
@@ -131,4 +135,5 @@ func expectOptionsEqual(optsA *options.Options, optsB *options.Options) {
 	Expect(optsA.VMMemoryOverheadPercent).To(Equal(optsB.VMMemoryOverheadPercent))
 	Expect(optsA.InterruptionQueue).To(Equal(optsB.InterruptionQueue))
 	Expect(optsA.ReservedENIs).To(Equal(optsB.ReservedENIs))
+	Expect(optsA.ExtraHourlyCostPerHost).To(Equal(optsB.ExtraHourlyCostPerHost))
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -32,6 +32,7 @@ type OptionsFields struct {
 	VMMemoryOverheadPercent *float64
 	InterruptionQueue       *string
 	ReservedENIs            *int
+	ExtraHourlyCostPerHost  *float64
 }
 
 func Options(overrides ...OptionsFields) *options.Options {

--- a/website/content/en/preview/reference/settings.md
+++ b/website/content/en/preview/reference/settings.md
@@ -35,6 +35,7 @@ Karpenter surfaces environment variables and CLI parameters to allow you to conf
 | MEMORY_LIMIT | \-\-memory-limit | Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value. (default = -1)|
 | METRICS_PORT | \-\-metrics-port | The port the metric endpoint binds to for operating metrics about the controller itself (default = 8080)|
 | RESERVED_ENIS | \-\-reserved-enis | Reserved ENIs are not included in the calculations for max-pods or kube-reserved. This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html. (default = 0)|
+| EXTRA_HOURLY_COST_PER_HOST | \-\-extra-hourly-cost-per-host | The additional hourly cost per host, added to the total instance cost, is useful for accounting for extra expenses such as Datadog Infrastructure or APM per-host charges. |
 | VM_MEMORY_OVERHEAD_PERCENT | \-\-vm-memory-overhead-percent | The VM memory overhead as a percent that will be subtracted from the total memory for all instance types when cached information is unavailable. (default = 0.075)|
 
 [comment]: <> (end docs generated content from hack/docs/configuration_gen_docs.go)


### PR DESCRIPTION
Fixes https://github.com/aws/karpenter-provider-aws/issues/5163

**Description**

This feature allows specifying an extra hourly cost per host for thing like Datadog APM agent, etc.

**How was this change tested?**

1. Create a nodepool with only xlarge and 2xlarge instance sizes.
2. Created a test Deployment with 1 pod with 1 cpu/2GB memory requests with 100 replicas.
3. Modify the nodepool and add all instance sizes.
4. Modify the karpenter-aws-provider deployment and set `EXTRA_HOURLY_COST_PER_HOST` to `"1.0"`

**Does this change impact docs?**

- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Other Info**

I considered adding the extra hourly cost per host to the static pricing for environments without access to the pricing API. However, this would require passing `context` into `Reset()` based on the current implementation, which introduces significant ripple effects across the entire test stack. I’m curious if anyone has alternative ideas or solutions to address this challenge.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.