### PR TITLE
Add metric labels to the metric reference docs

### DIFF
--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -1,0 +1,400 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/slices"
+
+	"github.com/samber/lo"
+
+	"sigs.k8s.io/karpenter/pkg/metrics"
+)
+
+type metricInfo struct {
+	namespace string
+	subsystem string
+	name      string
+	help      string
+	labels    []string
+}
+
+var (
+	stableMetrics = []string{"controller_runtime", "aws_sdk_go", "client_go", "leader_election", "interruption", "cluster_state", "workqueue", "karpenter_build_info", "karpenter_nodepool_usage", "karpenter_nodepool_limit",
+		"karpenter_nodeclaims_terminated_total", "karpenter_nodeclaims_created_total", "karpenter_nodes_terminated_total", "karpenter_nodes_created_total", "karpenter_pods_startup_duration_seconds",
+		"karpenter_scheduler_scheduling_duration_seconds", "karpenter_provisioner_scheduling_duration_seconds", "karpenter_nodepool_allowed_disruptions", "karpenter_voluntary_disruption_decisions_total"}
+	betaMetrics = []string{"status_condition", "cloudprovider", "cloudprovider_batcher", "karpenter_nodeclaims_termination_duration_seconds", "karpenter_nodeclaims_instance_termination_duration_seconds",
+		"karpenter_nodes_total_pod_requests", "karpenter_nodes_total_pod_limits", "karpenter_nodes_total_daemon_requests", "karpenter_nodes_total_daemon_limits", "karpenter_nodes_termination_duration_seconds",
+		"karpenter_nodes_system_overhead", "karpenter_nodes_allocatable", "karpenter_pods_state", "karpenter_scheduler_queue_depth", "karpenter_voluntary_disruption_queue_failures_total",
+		"karpenter_voluntary_disruption_decision_evaluation_duration_seconds", "karpenter_voluntary_disruption_eligible_nodes", "karpenter_voluntary_disruption_consolidation_timeouts_total"}
+)
+
+func (i metricInfo) qualifiedName() string {
+	return strings.Join(lo.Compact([]string{i.namespace, i.subsystem, i.name}), "_")
+}
+
+// metrics_gen_docs is used to parse the source code for Prometheus metrics and automatically generate markdown documentation
+// based on the naming and help provided in the source code.
+
+func main() {
+	flag.Parse()
+	if flag.NArg() < 2 {
+		log.Fatalf("Usage: %s path/to/metrics/controller path/to/metrics/controller2 path/to/markdown.md", os.Args[0])
+	}
+	var allMetrics []metricInfo
+	for i := 0; i < flag.NArg()-1; i++ {
+		packages := getPackages(flag.Arg(i))
+		allMetrics = append(allMetrics, getMetricsFromPackages(packages...)...)
+	}
+
+	// Dedupe metrics
+	allMetrics = lo.UniqBy(allMetrics, func(m metricInfo) string {
+		return fmt.Sprintf("%s/%s/%s", m.namespace, m.subsystem, m.name)
+	})
+
+	// Drop some metrics
+	for _, subsystem := range []string{"rest_client", "certwatcher_read", "controller_runtime_webhook"} {
+		allMetrics = lo.Reject(allMetrics, func(m metricInfo, _ int) bool {
+			return strings.HasPrefix(m.name, subsystem)
+		})
+	}
+
+	// Controller Runtime and AWS SDK Go for Prometheus naming is different in that they don't specify a namespace or subsystem
+	// Getting the metrics requires special parsing logic
+	for _, subsystem := range []string{"controller_runtime", "aws_sdk_go", "client_go", "leader_election"} {
+		for i := range allMetrics {
+			if allMetrics[i].subsystem == "" && strings.HasPrefix(allMetrics[i].name, fmt.Sprintf("%s_", subsystem)) {
+				allMetrics[i].subsystem = subsystem
+				allMetrics[i].name = strings.TrimPrefix(allMetrics[i].name, fmt.Sprintf("%s_", subsystem))
+			}
+		}
+	}
+	sort.Slice(allMetrics, bySubsystem(allMetrics))
+
+	outputFileName := flag.Arg(flag.NArg() - 1)
+	f, err := os.Create(outputFileName)
+	if err != nil {
+		log.Fatalf("error creating output file %s, %s", outputFileName, err)
+	}
+
+	log.Println("writing output to", outputFileName)
+	fmt.Fprintf(f, `---
+title: "Metrics"
+linkTitle: "Metrics"
+weight: 7
+
+description: >
+  Inspect Karpenter Metrics
+---
+`)
+	fmt.Fprintf(f, "<!-- this document is generated from hack/docs/metrics_gen_docs.go -->\n")
+	fmt.Fprintf(f, "Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. "+
+		"These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)\n")
+	previousSubsystem := ""
+
+	for _, metric := range allMetrics {
+		if metric.subsystem != previousSubsystem {
+			if metric.subsystem != "" {
+				subsystemTitle := strings.Join(lo.Map(strings.Split(metric.subsystem, "_"), func(s string, _ int) string {
+					if s == "sdk" || s == "aws" {
+						return strings.ToUpper(s)
+					} else {
+						return fmt.Sprintf("%s%s", strings.ToUpper(s[0:1]), s[1:])
+					}
+				}), " ")
+				fmt.Fprintf(f, "## %s Metrics\n", subsystemTitle)
+				fmt.Fprintln(f)
+			}
+			previousSubsystem = metric.subsystem
+		}
+		fmt.Fprintf(f, "### `%s`\n", metric.qualifiedName())
+		fmt.Fprintf(f, "%s\n", metric.help)
+		if len(metric.labels) > 0 {
+			fmt.Fprintf(f, "- Labels: %s\n", strings.Join(metric.labels, ", "))
+		}
+		switch {
+		case slices.Contains(stableMetrics, metric.subsystem) || slices.Contains(stableMetrics, metric.qualifiedName()):
+			fmt.Fprintf(f, "- Stability Level: %s\n", "STABLE")
+		case slices.Contains(betaMetrics, metric.subsystem) || slices.Contains(betaMetrics, metric.qualifiedName()):
+			fmt.Fprintf(f, "- Stability Level: %s\n", "BETA")
+		default:
+			fmt.Fprintf(f, "- Stability Level: %s\n", "ALPHA")
+		}
+		fmt.Fprintln(f)
+	}
+
+}
+
+func getPackages(root string) []*ast.Package {
+	var packages []*ast.Package
+	fset := token.NewFileSet()
+
+	// walk our metrics controller directory
+	log.Println("parsing code in", root)
+	filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if d == nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		// parse the packagers that we find
+		pkgs, err := parser.ParseDir(fset, path, func(info fs.FileInfo) bool {
+			return true
+		}, parser.AllErrors)
+		if err != nil {
+			log.Fatalf("error parsing, %s", err)
+		}
+		for _, pkg := range pkgs {
+			if strings.HasSuffix(pkg.Name, "_test") {
+				continue
+			}
+			packages = append(packages, pkg)
+		}
+		return nil
+	})
+	return packages
+}
+
+func getMetricsFromPackages(packages ...*ast.Package) []metricInfo {
+	// metrics are all package global variables
+	var allMetrics []metricInfo
+	for _, pkg := range packages {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				switch v := decl.(type) {
+				case *ast.FuncDecl:
+				// ignore
+				case *ast.GenDecl:
+					if v.Tok == token.VAR {
+						allMetrics = append(allMetrics, handleVariableDeclaration(v)...)
+					}
+				default:
+
+				}
+			}
+		}
+	}
+	return allMetrics
+}
+
+func bySubsystem(metrics []metricInfo) func(i int, j int) bool {
+	// Higher ordering comes first. If a value isn't designated here then the subsystem will be given a default of 0.
+	// Metrics without a subsystem come first since there is no designation for the bucket they fall under
+	subSystemSortOrder := map[string]int{
+		"":                 100,
+		"nodepool":         10,
+		"nodeclaims":       9,
+		"nodes":            8,
+		"pods":             7,
+		"status_condition": -1,
+		"workqueue":        -1,
+		"client_go":        -1,
+		"aws_sdk_go":       -1,
+		"leader_election":  -2,
+	}
+
+	return func(i, j int) bool {
+		lhs := metrics[i]
+		rhs := metrics[j]
+		if subSystemSortOrder[lhs.subsystem] != subSystemSortOrder[rhs.subsystem] {
+			return subSystemSortOrder[lhs.subsystem] > subSystemSortOrder[rhs.subsystem]
+		}
+		return lhs.qualifiedName() > rhs.qualifiedName()
+	}
+}
+
+func handleVariableDeclaration(v *ast.GenDecl) []metricInfo {
+	var promMetrics []metricInfo
+	for _, spec := range v.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for _, v := range vs.Values {
+			ce, ok := v.(*ast.CallExpr)
+			if !ok {
+				continue
+			}
+			funcPkg := getFuncPackage(ce.Fun)
+			if funcPkg != "prometheus" {
+				continue
+			}
+			if len(ce.Args) == 0 {
+				continue
+			}
+			arg := ce.Args[0].(*ast.CompositeLit)
+			keyValuePairs := map[string]string{}
+			var labels []string
+			for _, el := range arg.Elts {
+				kv := el.(*ast.KeyValueExpr)
+				key := fmt.Sprintf("%s", kv.Key)
+				switch key {
+				case "Namespace", "Subsystem", "Name", "Help":
+				case "ConstLabels":
+					labels = append(labels, getLabels(kv.Value)...)
+				default:
+					// skip any keys we don't care about
+					continue
+				}
+				value := ""
+				switch val := kv.Value.(type) {
+				case *ast.BasicLit:
+					value = val.Value
+				case *ast.SelectorExpr:
+					selector := fmt.Sprintf("%s.%s", val.X, val.Sel)
+					if v, err := getIdentMapping(selector); err != nil {
+						log.Fatalf("unsupported selector %s, %s", selector, err)
+					} else {
+						value = v
+					}
+				case *ast.Ident:
+					if v, err := getIdentMapping(val.String()); err != nil {
+						log.Fatal(err)
+					} else {
+						value = v
+					}
+				case *ast.BinaryExpr:
+					value = getBinaryExpr(val)
+				default:
+					log.Fatalf("unsupported value %T %v", kv.Value, kv.Value)
+				}
+				keyValuePairs[key] = strings.TrimFunc(value, func(r rune) bool {
+					return r == '"'
+				})
+			}
+			promMetrics = append(promMetrics, metricInfo{
+				namespace: keyValuePairs["Namespace"],
+				subsystem: keyValuePairs["Subsystem"],
+				name:      keyValuePairs["Name"],
+				help:      keyValuePairs["Help"],
+				labels:    labels,
+			})
+		}
+	}
+	return promMetrics
+}
+
+func getFuncPackage(fun ast.Expr) string {
+	if pexpr, ok := fun.(*ast.ParenExpr); ok {
+		return getFuncPackage(pexpr.X)
+	}
+	if sexpr, ok := fun.(*ast.StarExpr); ok {
+		return getFuncPackage(sexpr.X)
+	}
+	if sel, ok := fun.(*ast.SelectorExpr); ok {
+		return fmt.Sprintf("%s", sel.X)
+	}
+	if ident, ok := fun.(*ast.Ident); ok {
+		return ident.String()
+	}
+	if iexpr, ok := fun.(*ast.IndexExpr); ok {
+		return getFuncPackage(iexpr.X)
+	}
+	if _, ok := fun.(*ast.FuncLit); ok {
+		return ""
+	}
+	log.Fatalf("unsupported func expression %T, %v", fun, fun)
+	return ""
+}
+
+func getBinaryExpr(b *ast.BinaryExpr) string {
+	var x, y string
+	switch val := b.X.(type) {
+	case *ast.BasicLit:
+		x = strings.Trim(val.Value, `"`)
+	case *ast.BinaryExpr:
+		x = getBinaryExpr(val)
+	default:
+		log.Fatalf("unsupported value %T %v", val, val)
+	}
+	switch val := b.Y.(type) {
+	case *ast.BasicLit:
+		y = strings.Trim(val.Value, `"`)
+	case *ast.BinaryExpr:
+		y = getBinaryExpr(val)
+	default:
+		log.Fatalf("unsupported value %T %v", val, val)
+	}
+	return x + y
+}
+
+func getLabels(expr ast.Expr) []string {
+	var labels []string
+	switch v := expr.(type) {
+	case *ast.CompositeLit:
+		for _, elt := range v.Elts {
+			labels = append(labels, fmt.Sprintf("%s", elt))
+		}
+	case *ast.Ident:
+		labels = append(labels, v.Name)
+	default:
+		log.Fatalf("unsupported label expression %T %v", expr, expr)
+	}
+	return labels
+}
+
+// we cannot get the value of an Identifier directly so we map it manually instead
+func getIdentMapping(identName string) (string, error) {
+	identMapping := map[string]string{
+		"metrics.Namespace": metrics.Namespace,
+		"Namespace":         metrics.Namespace,
+
+		"MetricNamespace":            "operator",
+		"MetricSubsystem":            "status_condition",
+		"TerminationSubsystem":       "termination",
+		"WorkQueueSubsystem":         "workqueue",
+		"DepthKey":                   "depth",
+		"AddsKey":                    "adds_total",
+		"QueueLatencyKey":            "queue_duration_seconds",
+		"WorkDurationKey":            "work_duration_seconds",
+		"UnfinishedWorkKey":          "unfinished_work_seconds",
+		"LongestRunningProcessorKey": "longest_running_processor_seconds",
+		"RetriesKey":                 "retries_total",
+
+		"metrics.PodSubsystem":       "pods",
+		"NodeSubsystem":              "nodes",
+		"metrics.NodeSubsystem":      "nodes",
+		"machineSubsystem":           "machines",
+		"NodeClaimSubsystem":         "nodeclaims",
+		"metrics.NodeClaimSubsystem": "nodeclaims",
+		// TODO @joinnis: We should eventually change this subsystem to be
+		// plural so that it aligns with the other subsystems
+		"nodePoolSubsystem":            "nodepools",
+		"metrics.NodePoolSubsystem":    "nodepools",
+		"interruptionSubsystem":        "interruption",
+		"deprovisioningSubsystem":      "deprovisioning",
+		"voluntaryDisruptionSubsystem": "voluntary_disruption",
+		"batcherSubsystem":             "cloudprovider_batcher",
+		"cloudProviderSubsystem":       "cloudprovider",
+		"stateSubsystem":               "cluster_state",
+		"schedulerSubsystem":           "scheduler",
+	}
+	if v, ok := identMapping[identName]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("no identifier mapping exists for %s", identName)
+}

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -20,433 +20,531 @@ A metric with a constant '1' value labeled by version from which karpenter was b
 
 ### `karpenter_nodeclaims_termination_duration_seconds`
 Duration of NodeClaim termination in seconds.
+- Labels: nodeclaim
 - Stability Level: BETA
 
 ### `karpenter_nodeclaims_terminated_total`
 Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Labels: nodepool
 - Stability Level: STABLE
 
 ### `karpenter_nodeclaims_instance_termination_duration_seconds`
 Duration of CloudProvider Instance termination in seconds.
+- Labels: nodeclaim
 - Stability Level: BETA
 
 ### `karpenter_nodeclaims_disrupted_total`
 Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Labels: reason, nodepool
 - Stability Level: ALPHA
 
 ### `karpenter_nodeclaims_created_total`
 Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created and the owning nodepool.
+- Labels: reason, nodepool
 - Stability Level: STABLE
 
 ### `operator_nodeclaim_status_condition_transitions_total`
 The count of transitions of a nodeclaim, type and status. Labeled by the type, reason, and status.
+- Labels: type, reason, status
 - Stability Level: BETA
 
 ### `operator_nodeclaim_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodeclaim_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodeclaim_status_condition_count`
 The number of a condition for a nodeclaim, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodeclaim_termination_current_time_seconds`
 The current amount of time in seconds that a nodeclaim has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodeclaim_termination_duration_seconds`
 The amount of time taken by a nodeclaim to terminate completely.
+- Labels: nodeclaim
 - Stability Level: BETA
 
 ## Nodes Metrics
 
 ### `karpenter_nodes_total_pod_requests`
 Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_total_pod_limits`
 Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_total_daemon_requests`
 Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_total_daemon_limits`
 Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_termination_duration_seconds`
 The time taken between a node's deletion request and the removal of its finalizer
+- Labels: node
 - Stability Level: BETA
 
 ### `karpenter_nodes_terminated_total`
 Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Labels: nodepool
 - Stability Level: STABLE
 
 ### `karpenter_nodes_system_overhead`
 Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_lifetime_duration_seconds`
 The lifetime duration of the nodes since creation.
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_eviction_requests_total`
 The total number of eviction requests made by Karpenter
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_drained_total`
 The total number of nodes drained by Karpenter
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_current_lifetime_seconds`
 Node age in seconds
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_created_total`
 Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Labels: nodepool
 - Stability Level: STABLE
 
 ### `karpenter_nodes_allocatable`
 Node allocatable are the resources allocatable by nodes.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `operator_node_status_condition_transitions_total`
 The count of transitions of a node, type and status.
+- Labels: type, status
 - Stability Level: BETA
 
 ### `operator_node_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_node_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_node_status_condition_count`
 The number of a condition for a node, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_node_termination_current_time_seconds`
 The current amount of time in seconds that a node has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_node_termination_duration_seconds`
 The amount of time taken by a node to terminate completely.
+- Labels: node
 - Stability Level: BETA
 
 ### `operator_node_event_count`
 The number of a events for a node.
+- Labels: node
 - Stability Level: BETA
 
 ## Pods Metrics
 
 ### `karpenter_pods_state`
 Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type and pod phase.
+- Labels: name, namespace, owner, node, nodepool, zone, architecture, capacity_type, instance_type, phase
 - Stability Level: BETA
 
 ### `karpenter_pods_startup_duration_seconds`
 The time from pod creation until the pod is running.
+- Labels: pod
 - Stability Level: STABLE
 
 ## Termination Metrics
 
 ### `operator_termination_duration_seconds`
 The amount of time taken by an object to terminate completely.
+- Labels: object
 - Stability Level: DEPRECATED
 
 ### `operator_termination_current_time_seconds`
 The current amount of time in seconds that an object has been in terminating state.
+- Labels: object
 - Stability Level: DEPRECATED
 
 ## Voluntary Disruption Metrics
 
 ### `karpenter_voluntary_disruption_queue_failures_total`
 The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Labels: method
 - Stability Level: BETA
 
 ### `karpenter_voluntary_disruption_eligible_nodes`
 Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Labels: reason
 - Stability Level: BETA
 
 ### `karpenter_voluntary_disruption_decisions_total`
 Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Labels: decision, reason, consolidation_type
 - Stability Level: STABLE
 
 ### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
 Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Labels: method, consolidation_type
 - Stability Level: BETA
 
 ### `karpenter_voluntary_disruption_consolidation_timeouts_total`
 Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Labels: consolidation_type
 - Stability Level: BETA
 
 ## Scheduler Metrics
 
 ### `karpenter_scheduler_scheduling_duration_seconds`
 Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Labels: simulation
 - Stability Level: STABLE
 
 ### `karpenter_scheduler_queue_depth`
 The number of pods currently waiting to be scheduled.
+- Labels: queue
 - Stability Level: BETA
 
 ## Nodepools Metrics
 
 ### `karpenter_nodepools_usage`
 The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Labels: nodepool, resource
 - Stability Level: ALPHA
 
 ### `karpenter_nodepools_limit`
 Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Labels: nodepool, resource
 - Stability Level: ALPHA
 
 ### `karpenter_nodepools_allowed_disruptions`
 The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Labels: nodepool
 - Stability Level: ALPHA
 
 ### `operator_nodepool_status_condition_transitions_total`
 The count of transitions of a nodepool, type and status. Labeled by the type, reason, and status.
+- Labels: type, reason, status
 - Stability Level: BETA
 
 ### `operator_nodepool_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodepool_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodepool_status_condition_count`
 The number of an condition for a nodepool, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodepool_termination_current_time_seconds`
 The current amount of time in seconds that a nodepool has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodepool_termination_duration_seconds`
 Duration of NodePool termination in seconds.
+- Labels: nodepool
 - Stability Level: BETA
 
 ## EC2NodeClass Metrics
 
 ### `operator_ec2nodeclass_status_condition_transitions_total`
 The count of transitions of a ec2nodeclass, type and status. Labeled by the type, reason, and status.
+- Labels: type, reason, status
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_status_condition_count`
 The number of an condition for an ec2nodeclass, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_termination_current_time_seconds`
 The current amount of time in seconds that an ec2nodeclass has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_termination_duration_seconds`
 Duration of ec2nodeclass termination in seconds.
+- Labels: ec2nodeclass
 - Stability Level: BETA
 
 ## Interruption Metrics
 
 ### `karpenter_interruption_received_messages_total`
 Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Labels: message_type, actionable
 - Stability Level: STABLE
 
 ### `karpenter_interruption_message_queue_duration_seconds`
 Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Labels: message_type
 - Stability Level: STABLE
 
 ### `karpenter_interruption_deleted_messages_total`
 Count of messages deleted from the SQS queue.
+- Labels: message_type
 - Stability Level: STABLE
 
 ## Cluster Metrics
 
 ### `karpenter_cluster_utilization_percent`
 Utilization of allocatable resources by pod requests
+- Labels: resource
 - Stability Level: ALPHA
 
 ## Cluster State Metrics
 
 ### `karpenter_cluster_state_unsynced_time_seconds`
 The time for which cluster state is not synced
+- Labels: state
 - Stability Level: ALPHA
 
 ### `karpenter_cluster_state_synced`
 Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Labels: state
 - Stability Level: STABLE
 
 ### `karpenter_cluster_state_node_count`
 Current count of nodes in cluster state
+- Labels: state
 - Stability Level: STABLE
 
 ## Cloudprovider Metrics
 
 ### `karpenter_cloudprovider_instance_type_offering_price_estimate`
 Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Labels: instance_type, capacity_type, zone
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_instance_type_offering_available`
 Instance type offering availability, based on instance type, capacity type, and zone
+- Labels: instance_type, capacity_type, zone
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_instance_type_memory_bytes`
 Memory, in bytes, for a given instance type.
+- Labels: instance_type
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_instance_type_cpu_cores`
 VCPUs cores for a given instance type.
+- Labels: instance_type
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_errors_total`
 Total number of errors returned from CloudProvider calls.
+- Labels: method, provider
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_duration_seconds`
 Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Labels: controller, method, provider
 - Stability Level: BETA
 
 ## Cloudprovider Batcher Metrics
 
 ### `karpenter_cloudprovider_batcher_batch_time_seconds`
 Duration of the batching window per batcher
+- Labels: batcher
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_batcher_batch_size`
 Size of the request batch per batcher
+- Labels: batcher
 - Stability Level: BETA
 
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
 Total number of terminal reconciliation errors per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_total`
 Total number of reconciliations per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_time_seconds`
 Length of time per reconciliation per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_panics_total`
 Total number of reconciliation panics per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_errors_total`
 Total number of reconciliation errors per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_max_concurrent_reconciles`
 Maximum number of concurrent reconciles per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_active_workers`
 Number of currently used workers per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ## Workqueue Metrics
 
 ### `workqueue_work_duration_seconds`
 How long in seconds processing an item from workqueue takes.
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_unfinished_work_seconds`
 How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_retries_total`
 Total number of retries handled by workqueue
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_queue_duration_seconds`
 How long in seconds an item stays in workqueue before being requested
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_longest_running_processor_seconds`
 How many seconds has the longest running processor for workqueue been running.
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_depth`
 Current depth of workqueue
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_adds_total`
 Total number of adds handled by workqueue
+- Labels: queue
 - Stability Level: STABLE
 
 ## Status Condition Metrics
 
 ### `operator_status_condition_transitions_total`
 The count of transitions of a given object, type and status.
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ### `operator_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ### `operator_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ### `operator_status_condition_count`
 The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ## Client Go Metrics
 
 ### `client_go_request_total`
 Number of HTTP requests, partitioned by status code and method.
+- Labels: code, method
 - Stability Level: STABLE
 
 ### `client_go_request_duration_seconds`
 Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
+- Labels: verb, group, version, kind, subresource
 - Stability Level: STABLE
 
 ## AWS SDK Go Metrics
 
 ### `aws_sdk_go_request_total`
 The total number of AWS SDK Go requests
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_retry_count`
 The total number of AWS SDK Go retry attempts per request
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_duration_seconds`
 Latency of AWS SDK Go requests
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_attempt_total`
 The total number of AWS SDK Go request attempts
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_attempt_duration_seconds`
 Latency of AWS SDK Go request attempts
+- Labels: service, operation
 - Stability Level: STABLE
 
 ## Leader Election Metrics
 
 ### `leader_election_slowpath_total`
 Total number of slow path exercised in renewing leader leases. 'name' is the string used to identify the lease. Please make sure to group by name.
+- Labels: name
 - Stability Level: STABLE
 
 ### `leader_election_master_status`
 Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.
+- Labels: name
 - Stability Level: STABLE
-

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -20,433 +20,531 @@ A metric with a constant '1' value labeled by version from which karpenter was b
 
 ### `karpenter_nodeclaims_termination_duration_seconds`
 Duration of NodeClaim termination in seconds.
+- Labels: nodeclaim
 - Stability Level: BETA
 
 ### `karpenter_nodeclaims_terminated_total`
 Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Labels: nodepool
 - Stability Level: STABLE
 
 ### `karpenter_nodeclaims_instance_termination_duration_seconds`
 Duration of CloudProvider Instance termination in seconds.
+- Labels: nodeclaim
 - Stability Level: BETA
 
 ### `karpenter_nodeclaims_disrupted_total`
 Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Labels: reason, nodepool
 - Stability Level: ALPHA
 
 ### `karpenter_nodeclaims_created_total`
 Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created and the owning nodepool.
+- Labels: reason, nodepool
 - Stability Level: STABLE
 
 ### `operator_nodeclaim_status_condition_transitions_total`
 The count of transitions of a nodeclaim, type and status. Labeled by the type, reason, and status.
+- Labels: type, reason, status
 - Stability Level: BETA
 
 ### `operator_nodeclaim_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodeclaim_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodeclaim_status_condition_count`
 The number of a condition for a nodeclaim, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodeclaim_termination_current_time_seconds`
 The current amount of time in seconds that a nodeclaim has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodeclaim_termination_duration_seconds`
 The amount of time taken by a nodeclaim to terminate completely.
+- Labels: nodeclaim
 - Stability Level: BETA
 
 ## Nodes Metrics
 
 ### `karpenter_nodes_total_pod_requests`
 Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_total_pod_limits`
 Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_total_daemon_requests`
 Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_total_daemon_limits`
 Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_termination_duration_seconds`
 The time taken between a node's deletion request and the removal of its finalizer
+- Labels: node
 - Stability Level: BETA
 
 ### `karpenter_nodes_terminated_total`
 Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Labels: nodepool
 - Stability Level: STABLE
 
 ### `karpenter_nodes_system_overhead`
 Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `karpenter_nodes_lifetime_duration_seconds`
 The lifetime duration of the nodes since creation.
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_eviction_requests_total`
 The total number of eviction requests made by Karpenter
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_drained_total`
 The total number of nodes drained by Karpenter
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_current_lifetime_seconds`
 Node age in seconds
+- Labels: node
 - Stability Level: ALPHA
 
 ### `karpenter_nodes_created_total`
 Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Labels: nodepool
 - Stability Level: STABLE
 
 ### `karpenter_nodes_allocatable`
 Node allocatable are the resources allocatable by nodes.
+- Labels: node, resource
 - Stability Level: BETA
 
 ### `operator_node_status_condition_transitions_total`
 The count of transitions of a node, type and status.
+- Labels: type, status
 - Stability Level: BETA
 
 ### `operator_node_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_node_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_node_status_condition_count`
 The number of a condition for a node, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_node_termination_current_time_seconds`
 The current amount of time in seconds that a node has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_node_termination_duration_seconds`
 The amount of time taken by a node to terminate completely.
+- Labels: node
 - Stability Level: BETA
 
 ### `operator_node_event_count`
 The number of a events for a node.
+- Labels: node
 - Stability Level: BETA
 
 ## Pods Metrics
 
 ### `karpenter_pods_state`
 Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type and pod phase.
+- Labels: name, namespace, owner, node, nodepool, zone, architecture, capacity_type, instance_type, phase
 - Stability Level: BETA
 
 ### `karpenter_pods_startup_duration_seconds`
 The time from pod creation until the pod is running.
+- Labels: pod
 - Stability Level: STABLE
 
 ## Termination Metrics
 
 ### `operator_termination_duration_seconds`
 The amount of time taken by an object to terminate completely.
+- Labels: object
 - Stability Level: DEPRECATED
 
 ### `operator_termination_current_time_seconds`
 The current amount of time in seconds that an object has been in terminating state.
+- Labels: object
 - Stability Level: DEPRECATED
 
 ## Voluntary Disruption Metrics
 
 ### `karpenter_voluntary_disruption_queue_failures_total`
 The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Labels: method
 - Stability Level: BETA
 
 ### `karpenter_voluntary_disruption_eligible_nodes`
 Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Labels: reason
 - Stability Level: BETA
 
 ### `karpenter_voluntary_disruption_decisions_total`
 Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Labels: decision, reason, consolidation_type
 - Stability Level: STABLE
 
 ### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
 Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Labels: method, consolidation_type
 - Stability Level: BETA
 
 ### `karpenter_voluntary_disruption_consolidation_timeouts_total`
 Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Labels: consolidation_type
 - Stability Level: BETA
 
 ## Scheduler Metrics
 
 ### `karpenter_scheduler_scheduling_duration_seconds`
 Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Labels: simulation
 - Stability Level: STABLE
 
 ### `karpenter_scheduler_queue_depth`
 The number of pods currently waiting to be scheduled.
+- Labels: queue
 - Stability Level: BETA
 
 ## Nodepools Metrics
 
 ### `karpenter_nodepools_usage`
 The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Labels: nodepool, resource
 - Stability Level: ALPHA
 
 ### `karpenter_nodepools_limit`
 Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Labels: nodepool, resource
 - Stability Level: ALPHA
 
 ### `karpenter_nodepools_allowed_disruptions`
 The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Labels: nodepool
 - Stability Level: ALPHA
 
 ### `operator_nodepool_status_condition_transitions_total`
 The count of transitions of a nodepool, type and status. Labeled by the type, reason, and status.
+- Labels: type, reason, status
 - Stability Level: BETA
 
 ### `operator_nodepool_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodepool_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodepool_status_condition_count`
 The number of an condition for a nodepool, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_nodepool_termination_current_time_seconds`
 The current amount of time in seconds that a nodepool has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_nodepool_termination_duration_seconds`
 Duration of NodePool termination in seconds.
+- Labels: nodepool
 - Stability Level: BETA
 
 ## EC2NodeClass Metrics
 
 ### `operator_ec2nodeclass_status_condition_transitions_total`
 The count of transitions of a ec2nodeclass, type and status. Labeled by the type, reason, and status.
+- Labels: type, reason, status
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_status_condition_count`
 The number of an condition for an ec2nodeclass, type and status. Labeled by the name, namespace, type, status, and reason.
+- Labels: name, namespace, type, status, reason
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_termination_current_time_seconds`
 The current amount of time in seconds that an ec2nodeclass has been in terminating state. Labeled by name, and namespace.
+- Labels: name, namespace
 - Stability Level: BETA
 
 ### `operator_ec2nodeclass_termination_duration_seconds`
 Duration of ec2nodeclass termination in seconds.
+- Labels: ec2nodeclass
 - Stability Level: BETA
 
 ## Interruption Metrics
 
 ### `karpenter_interruption_received_messages_total`
 Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Labels: message_type, actionable
 - Stability Level: STABLE
 
 ### `karpenter_interruption_message_queue_duration_seconds`
 Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Labels: message_type
 - Stability Level: STABLE
 
 ### `karpenter_interruption_deleted_messages_total`
 Count of messages deleted from the SQS queue.
+- Labels: message_type
 - Stability Level: STABLE
 
 ## Cluster Metrics
 
 ### `karpenter_cluster_utilization_percent`
 Utilization of allocatable resources by pod requests
+- Labels: resource
 - Stability Level: ALPHA
 
 ## Cluster State Metrics
 
 ### `karpenter_cluster_state_unsynced_time_seconds`
 The time for which cluster state is not synced
+- Labels: state
 - Stability Level: ALPHA
 
 ### `karpenter_cluster_state_synced`
 Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Labels: state
 - Stability Level: STABLE
 
 ### `karpenter_cluster_state_node_count`
 Current count of nodes in cluster state
+- Labels: state
 - Stability Level: STABLE
 
 ## Cloudprovider Metrics
 
 ### `karpenter_cloudprovider_instance_type_offering_price_estimate`
 Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Labels: instance_type, capacity_type, zone
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_instance_type_offering_available`
 Instance type offering availability, based on instance type, capacity type, and zone
+- Labels: instance_type, capacity_type, zone
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_instance_type_memory_bytes`
 Memory, in bytes, for a given instance type.
+- Labels: instance_type
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_instance_type_cpu_cores`
 VCPUs cores for a given instance type.
+- Labels: instance_type
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_errors_total`
 Total number of errors returned from CloudProvider calls.
+- Labels: method, provider
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_duration_seconds`
 Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Labels: controller, method, provider
 - Stability Level: BETA
 
 ## Cloudprovider Batcher Metrics
 
 ### `karpenter_cloudprovider_batcher_batch_time_seconds`
 Duration of the batching window per batcher
+- Labels: batcher
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_batcher_batch_size`
 Size of the request batch per batcher
+- Labels: batcher
 - Stability Level: BETA
 
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
 Total number of terminal reconciliation errors per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_total`
 Total number of reconciliations per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_time_seconds`
 Length of time per reconciliation per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_panics_total`
 Total number of reconciliation panics per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_reconcile_errors_total`
 Total number of reconciliation errors per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_max_concurrent_reconciles`
 Maximum number of concurrent reconciles per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ### `controller_runtime_active_workers`
 Number of currently used workers per controller
+- Labels: controller
 - Stability Level: STABLE
 
 ## Workqueue Metrics
 
 ### `workqueue_work_duration_seconds`
 How long in seconds processing an item from workqueue takes.
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_unfinished_work_seconds`
 How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_retries_total`
 Total number of retries handled by workqueue
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_queue_duration_seconds`
 How long in seconds an item stays in workqueue before being requested
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_longest_running_processor_seconds`
 How many seconds has the longest running processor for workqueue been running.
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_depth`
 Current depth of workqueue
+- Labels: queue
 - Stability Level: STABLE
 
 ### `workqueue_adds_total`
 Total number of adds handled by workqueue
+- Labels: queue
 - Stability Level: STABLE
 
 ## Status Condition Metrics
 
 ### `operator_status_condition_transitions_total`
 The count of transitions of a given object, type and status.
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ### `operator_status_condition_transition_seconds`
 The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ### `operator_status_condition_current_status_seconds`
 The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ### `operator_status_condition_count`
 The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Labels: type, status
 - Stability Level: DEPRECATED
 
 ## Client Go Metrics
 
 ### `client_go_request_total`
 Number of HTTP requests, partitioned by status code and method.
+- Labels: code, method
 - Stability Level: STABLE
 
 ### `client_go_request_duration_seconds`
 Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
+- Labels: verb, group, version, kind, subresource
 - Stability Level: STABLE
 
 ## AWS SDK Go Metrics
 
 ### `aws_sdk_go_request_total`
 The total number of AWS SDK Go requests
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_retry_count`
 The total number of AWS SDK Go retry attempts per request
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_duration_seconds`
 Latency of AWS SDK Go requests
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_attempt_total`
 The total number of AWS SDK Go request attempts
+- Labels: service, operation
 - Stability Level: STABLE
 
 ### `aws_sdk_go_request_attempt_duration_seconds`
 Latency of AWS SDK Go request attempts
+- Labels: service, operation
 - Stability Level: STABLE
 
 ## Leader Election Metrics
 
 ### `leader_election_slowpath_total`
 Total number of slow path exercised in renewing leader leases. 'name' is the string used to identify the lease. Please make sure to group by name.
+- Labels: name
 - Stability Level: STABLE
 
 ### `leader_election_master_status`
 Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.
+- Labels: name
 - Stability Level: STABLE
-


### PR DESCRIPTION
Related to #5276

Add metric labels to the metric reference documentation.

* **hack/docs/metrics_gen_docs.go**: Add a new field `labels` to the `metricInfo` struct. Modify functions to extract and handle labels from metric definitions. Update markdown generation logic to include labels for each metric.
* **website/content/en/docs/reference/metrics.md**: Regenerate the metrics documentation to include labels for each metric.
* **pkg/batcher/metrics.go**: Add labels to the `BatchWindowDuration` and `BatchSize` metrics.
* **pkg/providers/instancetype/metrics.go**: Add labels to the `InstanceTypeVCPU`, `InstanceTypeMemory`, `InstanceTypeOfferingAvailable`, and `InstanceTypeOfferingPriceEstimate` metrics.

