### PR TITLE
chore: Remove Nirvana Money from ADOPTERS.md, as they have shut down

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -37,7 +37,6 @@ If you are open to others contacting you about your use of Karpenter on Slack, a
 | Kaltura | Using karpenter to deliver video to millions of end users | `@Ido Ziv` | [Homepage](https://corp.kaltura.com/) |
 | Livspace | Replacement for cluster autoscaler on production and staging EKS clusters | `@praveen-livspace` | [Homepage](https://www.livspace.com) |
 | Nexxiot | Easier, Safer, Cleaner Global Transportation - Using Karpenter to manage EKS nodes | `@Alex Berger` | [Homepage](https://nexxiot.com/) |
-| Nirvana Money | Building healthy, happy financial lives - Using Karpenter to manage all-Spot clusters | `@DWSR` | [Homepage](https://www.nirvana.money/) |
 | OccMundial | Using karpenter to manage our production workloads, using the dynamic scaling according to workload that needs to scale.  | `@parraletz` | [Homepage](https://www.occ.com.mx) |
 | Omaze | Intelligently using Karpenter's autoscaling to power our platforms | `@devopsidiot` | [Homepage](https://www.omaze.com/) |
 | PITS Global Data Recovery Services | Used to manage continuous integration and continuous delivery/deployment workflows. | N/A | [PITS Global Data Recovery Services](https://www.pitsdatarecovery.net/) |


### PR DESCRIPTION
Fixes #N/A 

**Description**
Remove Nirvana Money from ADOPTERS.md. They are not in business any longer. 
See https://www.fintechfutures.com/2022/11/us-fintech-start-up-nirvana-money-is-shutting-down-just-weeks-after-launch/

**How was this change tested?**

Only Readme change. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No (unsure whether this counts as docs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.