### PR TITLE
fix: only select available AMIs

### DIFF
--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -639,6 +639,7 @@ var _ = Describe("CloudProvider", func() {
 								Value: aws.String("ami-value-1"),
 							},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 					{
 						Name:         aws.String(coretest.RandomName()),
@@ -651,6 +652,7 @@ var _ = Describe("CloudProvider", func() {
 								Value: aws.String("ami-value-2"),
 							},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 				},
 			})

--- a/pkg/controllers/nodeclass/ami_test.go
+++ b/pkg/controllers/nodeclass/ami_test.go
@@ -68,6 +68,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 						{Key: aws.String("Name"), Value: aws.String("amd64-standard")},
 						{Key: aws.String("foo"), Value: aws.String("bar")},
 					},
+					State: ec2types.ImageStateAvailable,
 				},
 				{
 					Name:         aws.String("amd64-standard-new"),
@@ -78,6 +79,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 						{Key: aws.String("Name"), Value: aws.String("amd64-standard")},
 						{Key: aws.String("foo"), Value: aws.String("bar")},
 					},
+					State: ec2types.ImageStateAvailable,
 				},
 				{
 					Name:         aws.String("amd64-nvidia"),
@@ -88,6 +90,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 						{Key: aws.String("Name"), Value: aws.String("amd64-nvidia")},
 						{Key: aws.String("foo"), Value: aws.String("bar")},
 					},
+					State: ec2types.ImageStateAvailable,
 				},
 				{
 					Name:         aws.String("amd64-neuron"),
@@ -98,6 +101,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 						{Key: aws.String("Name"), Value: aws.String("amd64-neuron")},
 						{Key: aws.String("foo"), Value: aws.String("bar")},
 					},
+					State: ec2types.ImageStateAvailable,
 				},
 				{
 					Name:         aws.String("arm64-standard"),
@@ -108,6 +112,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 						{Key: aws.String("Name"), Value: aws.String("arm64-standard")},
 						{Key: aws.String("foo"), Value: aws.String("bar")},
 					},
+					State: ec2types.ImageStateAvailable,
 				},
 				{
 					Name:         aws.String("arm64-nvidia"),
@@ -118,6 +123,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 						{Key: aws.String("Name"), Value: aws.String("arm64-nvidia")},
 						{Key: aws.String("foo"), Value: aws.String("bar")},
 					},
+					State: ec2types.ImageStateAvailable,
 				},
 			},
 		})
@@ -555,6 +561,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 							{Key: aws.String("Name"), Value: aws.String("test-ami-3")},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 					{
 						Name:         aws.String("test-ami-2"),
@@ -565,6 +572,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 							{Key: aws.String("Name"), Value: aws.String("test-ami-2")},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 				},
 			})
@@ -659,8 +667,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 							Key:      corev1.LabelArchStable,
 							Operator: corev1.NodeSelectorOpIn,
 							Values:   []string{karpv1.ArchitectureArm64},
-						},
-						},
+						}},
 					},
 					{
 						Name: "test-ami-3",
@@ -671,8 +678,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 							Key:      corev1.LabelArchStable,
 							Operator: corev1.NodeSelectorOpIn,
 							Values:   []string{karpv1.ArchitectureAmd64},
-						},
-						},
+						}},
 					},
 				},
 			))
@@ -692,6 +698,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 							{Key: aws.String("Name"), Value: aws.String("test-ami-4")},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 					{
 						Name:         aws.String("test-ami-2"),
@@ -702,6 +709,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 							{Key: aws.String("Name"), Value: aws.String("test-ami-2")},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 				},
 			})

--- a/pkg/controllers/providers/ssm/invalidation/suite_test.go
+++ b/pkg/controllers/providers/ssm/invalidation/suite_test.go
@@ -158,6 +158,7 @@ func deprecateAMIs(amiIDs ...string) {
 				CreationDate:    lo.ToPtr(awsEnv.Clock.Now().Add(-24 * time.Hour).Format(time.RFC3339)),
 				Architecture:    "x86_64",
 				DeprecationTime: lo.ToPtr(awsEnv.Clock.Now().Add(-12 * time.Hour).Format(time.RFC3339)),
+				State:           ec2types.ImageStateAvailable,
 			}
 		}),
 	})

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -338,6 +338,7 @@ func (e *EC2API) DescribeImages(_ context.Context, input *ec2.DescribeImagesInpu
 				ImageId:      aws.String(test.RandomName()),
 				CreationDate: aws.String(time.Now().Format(time.UnixDate)),
 				Architecture: "x86_64",
+				State:        ec2types.ImageStateAvailable,
 			},
 		},
 	}, nil

--- a/pkg/providers/amifamily/suite_test.go
+++ b/pkg/providers/amifamily/suite_test.go
@@ -85,6 +85,7 @@ var _ = BeforeEach(func() {
 					{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
+				State: ec2types.ImageStateAvailable,
 			},
 			{
 				Name:         aws.String(arm64AMI),
@@ -95,6 +96,7 @@ var _ = BeforeEach(func() {
 					{Key: aws.String("Name"), Value: aws.String(arm64AMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
+				State: ec2types.ImageStateAvailable,
 			},
 			{
 				Name:         aws.String(amd64NvidiaAMI),
@@ -105,6 +107,7 @@ var _ = BeforeEach(func() {
 					{Key: aws.String("Name"), Value: aws.String(amd64NvidiaAMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
+				State: ec2types.ImageStateAvailable,
 			},
 			{
 				Name:         aws.String(arm64NvidiaAMI),
@@ -115,6 +118,7 @@ var _ = BeforeEach(func() {
 					{Key: aws.String("Name"), Value: aws.String(arm64NvidiaAMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
+				State: ec2types.ImageStateAvailable,
 			},
 		},
 	})
@@ -228,6 +232,45 @@ var _ = Describe("AMIProvider", func() {
 		}
 		wg.Wait()
 	})
+	DescribeTable(
+		"should ignore images when image.state != available",
+		func(state ec2types.ImageState) {
+			awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []ec2types.Image{
+				{
+					Name:         aws.String(coretest.RandomName()),
+					ImageId:      aws.String("ami-123"),
+					Architecture: "x86_64",
+					Tags:         []ec2types.Tag{{Key: lo.ToPtr("test"), Value: lo.ToPtr("test")}},
+					CreationDate: aws.String("2022-08-15T12:00:00Z"),
+					State:        ec2types.ImageStateAvailable,
+				},
+				{
+					Name:         aws.String(coretest.RandomName()),
+					ImageId:      aws.String("ami-456"),
+					Architecture: "arm64",
+					Tags:         []ec2types.Tag{{Key: lo.ToPtr("test"), Value: lo.ToPtr("test")}},
+					CreationDate: aws.String("2022-08-15T12:00:00Z"),
+					State:        state,
+				},
+			}})
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{
+				Tags: map[string]string{
+					"test": "test",
+				},
+			}}
+			amis, err := awsEnv.AMIProvider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(amis).To(HaveLen(1))
+			Expect(amis[0].AmiID).To(Equal("ami-123"))
+		},
+		lo.FilterMap(ec2types.ImageState("").Values(), func(state ec2types.ImageState, _ int) (TableEntry, bool) {
+			if state == ec2types.ImageStateAvailable {
+				return TableEntry{}, false
+			}
+			return Entry(string(state), state), true
+		}),
+	)
+
 	Context("SSM Alias Missing", func() {
 		It("should succeed to partially resolve AMIs if all SSM aliases don't exist (Al2)", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
@@ -278,6 +321,7 @@ var _ = Describe("AMIProvider", func() {
 					{Key: aws.String(corev1.LabelInstanceTypeStable), Value: aws.String("m5.large")},
 					{Key: aws.String(corev1.LabelTopologyZone), Value: aws.String("test-zone-1a")},
 				},
+				State: ec2types.ImageStateAvailable,
 			}
 			awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{
 				Images: []ec2types.Image{
@@ -329,6 +373,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 					{
 						Name:         aws.String(amd64AMI),
@@ -339,6 +384,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 				},
 			})
@@ -369,6 +415,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 					{
 						Name:            aws.String(amd64AMI),
@@ -380,6 +427,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 				},
 			})
@@ -411,6 +459,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String("test-ami-2")},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 					{
 						Name:            aws.String("test-ami-1"),
@@ -422,6 +471,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String("test-ami-1")},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 				},
 			})
@@ -452,6 +502,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 					{
 						Name:            aws.String(amd64AMI),
@@ -463,6 +514,7 @@ var _ = Describe("AMIProvider", func() {
 							{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 							{Key: aws.String("foo"), Value: aws.String("bar")},
 						},
+						State: ec2types.ImageStateAvailable,
 					},
 				},
 			})
@@ -498,7 +550,7 @@ var _ = Describe("AMIProvider", func() {
 				{
 					Filters: []ec2types.Filter{
 						{
-							Name:   aws.String("tag:Name"),
+							Name:   lo.ToPtr("tag:Name"),
 							Values: []string{"my-ami"},
 						},
 					},
@@ -519,7 +571,7 @@ var _ = Describe("AMIProvider", func() {
 				{
 					Filters: []ec2types.Filter{
 						{
-							Name:   aws.String("name"),
+							Name:   lo.ToPtr("name"),
 							Values: []string{"my-ami"},
 						},
 					},
@@ -548,7 +600,7 @@ var _ = Describe("AMIProvider", func() {
 				{
 					Filters: []ec2types.Filter{
 						{
-							Name:   aws.String("image-id"),
+							Name:   lo.ToPtr("image-id"),
 							Values: []string{"ami-abcd1234", "ami-cafeaced"},
 						},
 					},
@@ -599,7 +651,7 @@ var _ = Describe("AMIProvider", func() {
 					Owners: []string{"0123456789"},
 					Filters: []ec2types.Filter{
 						{
-							Name:   aws.String("name"),
+							Name:   lo.ToPtr("name"),
 							Values: []string{"my-name"},
 						},
 					},
@@ -608,7 +660,7 @@ var _ = Describe("AMIProvider", func() {
 					Owners: []string{"self"},
 					Filters: []ec2types.Filter{
 						{
-							Name:   aws.String("name"),
+							Name:   lo.ToPtr("name"),
 							Values: []string{"my-name"},
 						},
 					},

--- a/pkg/providers/amifamily/types.go
+++ b/pkg/providers/amifamily/types.go
@@ -108,8 +108,10 @@ type DescribeImageQuery struct {
 
 func (q DescribeImageQuery) DescribeImagesInput() *ec2.DescribeImagesInput {
 	return &ec2.DescribeImagesInput{
-		// Don't include filters in the Describe Images call as EC2 API doesn't allow empty filters.
-		Filters:           lo.Ternary(len(q.Filters) > 0, q.Filters, nil),
+		Filters: append(q.Filters, ec2types.Filter{
+			Name:   lo.ToPtr("state"),
+			Values: []string{string(ec2types.ImageStateAvailable)},
+		}),
 		Owners:            lo.Ternary(len(q.Owners) > 0, q.Owners, nil),
 		IncludeDeprecated: aws.Bool(true),
 		MaxResults:        aws.Int32(1000),

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1948,6 +1948,7 @@ essential = true
 						Architecture: "x86_64",
 						Tags:         []ec2types.Tag{{Key: aws.String(corev1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
+						State:        ec2types.ImageStateAvailable,
 					},
 					{
 						Name:         aws.String(coretest.RandomName()),
@@ -1955,6 +1956,7 @@ essential = true
 						Architecture: "x86_64",
 						Tags:         []ec2types.Tag{{Key: aws.String(corev1.LabelInstanceTypeStable), Value: aws.String("m5.xlarge")}},
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
+						State:        ec2types.ImageStateAvailable,
 					},
 				}})
 				ExpectApplied(ctx, env.Client, nodeClass, nodePool)
@@ -1969,6 +1971,10 @@ essential = true
 					{
 						Name:   aws.String("image-id"),
 						Values: []string{"ami-123", "ami-456"},
+					},
+					{
+						Name:   aws.String("state"),
+						Values: []string{string(ec2types.ImageStateAvailable)},
 					},
 				}
 				Expect(actualFilter).To(Equal(expectedFilter))
@@ -2009,12 +2015,14 @@ essential = true
 						ImageId:      aws.String("ami-123"),
 						Architecture: "x86_64",
 						CreationDate: aws.String("2020-01-01T12:00:00Z"),
+						State:        ec2types.ImageStateAvailable,
 					},
 					{
 						Name:         aws.String(coretest.RandomName()),
 						ImageId:      aws.String("ami-456"),
 						Architecture: "x86_64",
 						CreationDate: aws.String("2021-01-01T12:00:00Z"),
+						State:        ec2types.ImageStateAvailable,
 					},
 					{
 						// Incompatible because required ARM64
@@ -2022,6 +2030,7 @@ essential = true
 						ImageId:      aws.String("ami-789"),
 						Architecture: "arm64",
 						CreationDate: aws.String("2022-01-01T12:00:00Z"),
+						State:        ec2types.ImageStateAvailable,
 					},
 				}})
 				nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyCustom)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7652 <!-- issue number -->

**Description**
Updates the AMI provider to only list AMIs in state `available`.

**How was this change tested?**
`make test` and `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.