### PR TITLE
test: Add Support for Upstream E2E tests with default AWS Provider EC2NodeClass 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ KARPENTER_CORE_DIR = $(shell go list -m -f '{{ .Dir }}' sigs.k8s.io/karpenter)
 
 # TEST_SUITE enables you to select a specific test suite directory to run "make e2etests" against
 TEST_SUITE ?= "..."
+TMPFILE = $(shell mktemp) 
 
 # Filename when building the binary controller only
 GOARCH ?= $(shell go env GOARCH)
@@ -87,6 +88,20 @@ e2etests: ## Run the e2e suite against your local cluster
 		--ginkgo.timeout=3h \
 		--ginkgo.grace-period=3m \
 		--ginkgo.vv
+
+upstream-e2etests: 
+	CLUSTER_NAME=${CLUSTER_NAME} envsubst < $(shell pwd)/test/pkg/environment/aws/default_ec2nodeclass.yaml > ${TMPFILE}
+	go test \
+		-count 1 \
+		-timeout 1h \
+		-v \
+		$(KARPENTER_CORE_DIR)/test/suites/$(shell echo $(TEST_SUITE) | tr A-Z a-z)/... \
+		--ginkgo.focus="${FOCUS}" \
+		--ginkgo.timeout=1h \
+		--ginkgo.grace-period=5m \
+		--ginkgo.vv \
+		--default-nodeclass="$(TMPFILE)"\
+		--default-nodepool="$(shell pwd)/test/pkg/environment/aws/default_nodepool.yaml"
 
 e2etests-deflake: ## Run the e2e suite against your local cluster
 	cd test && CLUSTER_NAME=${CLUSTER_NAME} ginkgo \

--- a/test/pkg/environment/aws/default_ec2nodeclass.yaml
+++ b/test/pkg/environment/aws/default_ec2nodeclass.yaml
@@ -1,0 +1,15 @@
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2023
+  subnetSelectorTerms:
+    - tags: 
+        karpenter.sh/discovery: $CLUSTER_NAME
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: $CLUSTER_NAME
+  role: KarpenterNodeRole-$CLUSTER_NAME
+  amiSelectorTerms:
+    - alias: al2023@latest

--- a/test/pkg/environment/aws/default_nodepool.yaml
+++ b/test/pkg/environment/aws/default_nodepool.yaml
@@ -1,0 +1,36 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+ name: default
+spec:
+ disruption:
+   consolidationPolicy: WhenEmptyOrUnderutilized
+   consolidateAfter: Never
+   budgets:
+     - nodes: 100%
+ limits:
+   cpu: 1000
+   memory: 1000Gi
+ template:
+   spec:
+     expireAfter: Never
+     requirements:
+       - key: kubernetes.io/os
+         operator: In
+         values: ["linux"]
+       - key: karpenter.sh/capacity-type
+         operator: In
+         values: ["on-demand"]
+       - key: karpenter.k8s.aws/instance-category
+         operator: In
+         values: ["c", "m", "r"]
+       - key: karpenter.k8s.aws/instance-generation
+         operator: In
+         values: ["2"]
+       - key: karpenter.k8s.aws/instance-family
+         operator: NotIn
+         values: ["a1"]
+     nodeClassRef:
+      group: karpenter.k8s.aws
+      kind: EKSNodeClass
+      name: default


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Adding support for running `kubernetes-sigs/karpenter` tests: https://github.com/kubernetes-sigs/karpenter/pull/1963

**How was this change tested?**
- Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.