### PR TITLE
fix: spurious logging from the ssm invalidation controller

### DIFF
--- a/pkg/controllers/nodeclass/ami.go
+++ b/pkg/controllers/nodeclass/ami.go
@@ -22,9 +22,11 @@ import (
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
@@ -32,6 +34,14 @@ import (
 
 type AMI struct {
 	amiProvider amifamily.Provider
+	cm          *pretty.ChangeMonitor
+}
+
+func NewAMIReconciler(provider amifamily.Provider) *AMI {
+	return &AMI{
+		amiProvider: provider,
+		cm:          pretty.NewChangeMonitor(),
+	}
 }
 
 func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
@@ -46,6 +56,12 @@ func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconc
 		// Returning 'ok' in this case means that the nodeclass will remain in an unready state until the component is restarted.
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
 	}
+	if uniqueAMIs := lo.Uniq(lo.Map(amis, func(a amifamily.AMI, _ int) string {
+		return a.AmiID
+	})); a.cm.HasChanged(fmt.Sprintf("amis/%s", nodeClass.Name), uniqueAMIs) {
+		log.FromContext(ctx).WithValues("ids", uniqueAMIs).V(1).Info("discovered amis")
+	}
+
 	nodeClass.Status.AMIs = lo.Map(amis, func(ami amifamily.AMI, _ int) v1.AMI {
 		reqs := lo.Map(ami.Requirements.NodeSelectorRequirements(), func(item karpv1.NodeSelectorRequirementWithMinValues, _ int) corev1.NodeSelectorRequirement {
 			return item.NodeSelectorRequirement

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -75,7 +75,7 @@ func NewController(kubeClient client.Client, recorder events.Recorder, subnetPro
 		kubeClient:             kubeClient,
 		recorder:               recorder,
 		launchTemplateProvider: launchTemplateProvider,
-		ami:                    &AMI{amiProvider: amiProvider},
+		ami:                    NewAMIReconciler(amiProvider),
 		subnet:                 &Subnet{subnetProvider: subnetProvider},
 		securityGroup:          &SecurityGroup{securityGroupProvider: securityGroupProvider},
 		instanceProfile:        &InstanceProfile{instanceProfileProvider: instanceProfileProvider},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

The SSM invalidation controller uses the AMI provider to periodically check the AMIs provided by SSM parameters for deprecation. To do so, it creates dummy NodeClasses with the AMI IDs discovered from SSM parameters, and passes them to the provider. This causes spurious logging from the AMI providers change monitor, as it keeps discovering new AMIs for the EC2NodeClass with the name `""`:

https://github.com/aws/karpenter-provider-aws/blob/1b2fb34ece6b71b05cb5dc1a1850517d1627a61e/pkg/providers/amifamily/ami.go#L82-L85

Example Logs:
```
karpenter-7d45fc984d-x95n9 controller {"level":"DEBUG","time":"2025-02-05T16:11:25.875Z","logger":"controller","caller":"invalidation/controller.go:74","message":"discovered amis","commit":"12c5748-dirty","controller":"providers.ssm.invalidation","namespace":"","name":"","reconcileID":"d5b15907-2aa8-496d-a995-22ae61c7e6e3","ids":["ami-064765ed688898ddd"]}
karpenter-7d45fc984d-x95n9 controller {"level":"DEBUG","time":"2025-02-05T16:41:25.970Z","logger":"controller","caller":"invalidation/controller.go:74","message":"discovered amis","commit":"12c5748-dirty","controller":"providers.ssm.invalidation","namespace":"","name":"","reconcileID":"82bdcbdd-cc69-4b7e-a9b9-3964939310d6","ids":["ami-0e028c106b154cbaf"]}
karpenter-7d45fc984d-x95n9 controller {"level":"DEBUG","time":"2025-02-05T16:41:26.037Z","logger":"controller","caller":"invalidation/controller.go:74","message":"discovered amis","commit":"12c5748-dirty","controller":"providers.ssm.invalidation","namespace":"","name":"","reconcileID":"82bdcbdd-cc69-4b7e-a9b9-3964939310d6","ids":["ami-043ad4c51368cde81"]}
karpenter-7d45fc984d-x95n9 controller {"level":"DEBUG","time":"2025-02-05T16:41:26.105Z","logger":"controller","caller":"invalidation/controller.go:74","message":"discovered amis","commit":"12c5748-dirty","controller":"providers.ssm.invalidation","namespace":"","name":"","reconcileID":"82bdcbdd-cc69-4b7e-a9b9-3964939310d6","ids":["ami-086b44042794ec3a1"]}
karpenter-7d45fc984d-x95n9 controller {"level":"DEBUG","time":"2025-02-05T17:11:26.234Z","logger":"controller","caller":"invalidation/controller.go:74","message":"discovered amis","commit":"12c5748-dirty","controller":"providers.ssm.invalidation","namespace":"","name":"","reconcileID":"4088985e-2558-4855-aa45-b5181c90de85","ids":["ami-064765ed688898ddd"]}
karpenter-7d45fc984d-x95n9 controller {"level":"DEBUG","time":"2025-02-05T17:11:26.291Z","logger":"controller","caller":"invalidation/controller.go:74","message":"discovered amis","commit":"12c5748-dirty","controller":"providers.ssm.invalidation","namespace":"","name":"","reconcileID":"4088985e-2558-4855-aa45-b5181c90de85","ids":["ami-0e028c106b154cbaf"]}
karpenter-7d45fc984d-x95n9 controller {"level":"DEBUG","time":"2025-02-05T17:11:26.360Z","logger":"controller","caller":"invalidation/controller.go:74","message":"discovered amis","commit":"12c5748-dirty","controller":"providers.ssm.invalidation","namespace":"","name":"","reconcileID":"4088985e-2558-4855-aa45-b5181c90de85","ids":["ami-043ad4c51368cde81"]}
```

This PR moves that change monitor from the AMI provider to the NodeClass AMI reconciler. There are other ways to go about this (e.g. passing a no-op logger to the ami provider from the ssm invalidation controller), but IMO it makes more sense for the change monitor to be on the reconciler which is actually updating the resource anyway.

**How was this change tested?**
`make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.