### PR TITLE
fix(helm):  MEMORY_LIMIT env for custom controller container name 

### DIFF
--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -75,6 +75,12 @@ Karpenter image to use
 {{- end }}
 {{- end }}
 
+{{/*
+Karpenter controller container name
+*/}}
+{{- define "karpenter.controller.containerName" -}}
+{{- .Values.controller.containerName | default "controller" -}}
+{{- end -}}
 
 {{/* Get PodDisruptionBudget API Version */}}
 {{- define "karpenter.pdb.apiVersion" -}}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       schedulerName: {{ . | quote }}
       {{- end }}
       containers:
-        - name: {{ .Values.controller.containerName | default "controller" }}
+        - name: {{ include "karpenter.controller.containerName" . }}
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
@@ -102,7 +102,7 @@ spec:
             - name: MEMORY_LIMIT
               valueFrom:
                 resourceFieldRef:
-                  containerName: {{ .Values.controller.containerName | default "controller" }}
+                  containerName: {{ include "karpenter.controller.containerName" . }}
                   divisor: "0"
                   resource: limits.memory
             - name: FEATURE_GATES

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             - name: MEMORY_LIMIT
               valueFrom:
                 resourceFieldRef:
-                  containerName: controller
+                  containerName: {{ .Values.controller.containerName | default "controller" }}
                   divisor: "0"
                   resource: limits.memory
             - name: FEATURE_GATES


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7650

**Description**

the value `controller.containerName` is supported #7384, but not for relevant env set by downward api.

1. fix the env MEMORY_LIMIT to refer `controller.containerName` if set
2. pull up both container name and env to the helper function

**How was this change tested?**

```sh
❯ helm template charts/karpenter --set controller.containerName="custom-name" 2>/dev/null | yq '...comments="" | select(.kind=="Deployment").spec.template.spec.containers[0].env[] | select(.name=="MEMORY_LIMIT")' 
name: MEMORY_LIMIT
valueFrom:
  resourceFieldRef:
    containerName: custom-name
    divisor: "0"
    resource: limits.memory

❯ helm template charts/karpenter --set controller.containerName="custom-name" 2>/dev/null | yq '...comments="" | select(.kind=="Deployment").spec.template.spec.containers[0].name' 
custom-name
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.