### PR TITLE
perf: Remove calling List on NodeClaims and Nodes in interruption controller

### DIFF
--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -38,16 +38,14 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
-	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+
+	"sigs.k8s.io/karpenter/pkg/events"
 
 	"github.com/aws/karpenter-provider-aws/pkg/cache"
 	interruptionevents "github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/events"
 	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/sqs"
-	"github.com/aws/karpenter-provider-aws/pkg/utils"
-
-	"sigs.k8s.io/karpenter/pkg/events"
 )
 
 type Action string
@@ -104,14 +102,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	if len(sqsMessages) == 0 {
 		return reconcile.Result{RequeueAfter: singleton.RequeueImmediately}, nil
 	}
-	nodeClaimInstanceIDMap, err := c.makeNodeClaimInstanceIDMap(ctx)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("making nodeclaim instance id map, %w", err)
-	}
-	nodeInstanceIDMap, err := c.makeNodeInstanceIDMap(ctx)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("making node instance id map, %w", err)
-	}
+
 	errs := make([]error, len(sqsMessages))
 	workqueue.ParallelizeUntil(ctx, 10, len(sqsMessages), func(i int) {
 		msg, e := c.parseMessage(sqsMessages[i])
@@ -121,7 +112,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconcile.Result, error) {
 			errs[i] = c.deleteMessage(ctx, sqsMessages[i])
 			return
 		}
-		if e = c.handleMessage(ctx, nodeClaimInstanceIDMap, nodeInstanceIDMap, msg); e != nil {
+		if e = c.handleMessage(ctx, msg); e != nil {
 			errs[i] = fmt.Errorf("handling message, %w", e)
 			return
 		}
@@ -154,9 +145,7 @@ func (c *Controller) parseMessage(raw *sqstypes.Message) (messages.Message, erro
 }
 
 // handleMessage takes an action against every node involved in the message that is owned by a NodePool
-func (c *Controller) handleMessage(ctx context.Context, nodeClaimInstanceIDMap map[string]*karpv1.NodeClaim,
-	nodeInstanceIDMap map[string]*corev1.Node, msg messages.Message) (err error) {
-
+func (c *Controller) handleMessage(ctx context.Context, msg messages.Message) (err error) {
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("messageKind", msg.Kind()))
 	ReceivedMessages.Inc(map[string]string{messageTypeLabel: string(msg.Kind())})
 
@@ -164,13 +153,27 @@ func (c *Controller) handleMessage(ctx context.Context, nodeClaimInstanceIDMap m
 		return nil
 	}
 	for _, instanceID := range msg.EC2InstanceIDs() {
-		nodeClaim, ok := nodeClaimInstanceIDMap[instanceID]
-		if !ok {
+		nodeClaimList := &karpv1.NodeClaimList{}
+		if e := c.kubeClient.List(ctx, nodeClaimList, client.MatchingFields{"status.instanceID": instanceID}); e != nil {
+			err = multierr.Append(err, e)
 			continue
 		}
-		node := nodeInstanceIDMap[instanceID]
-		if e := c.handleNodeClaim(ctx, msg, nodeClaim, node); e != nil {
-			err = multierr.Append(err, e)
+		if len(nodeClaimList.Items) == 0 {
+			continue
+		}
+		for _, nodeClaim := range nodeClaimList.Items {
+			nodeList := &corev1.NodeList{}
+			if e := c.kubeClient.List(ctx, nodeList, client.MatchingFields{"spec.instanceID": instanceID}); e != nil {
+				err = multierr.Append(err, e)
+				continue
+			}
+			var node *corev1.Node
+			if len(nodeList.Items) > 0 {
+				node = &nodeList.Items[0]
+			}
+			if e := c.handleNodeClaim(ctx, msg, &nodeClaim, node); e != nil {
+				err = multierr.Append(err, e)
+			}
 		}
 	}
 	MessageLatency.Observe(time.Since(msg.StartTime()).Seconds(), nil)
@@ -252,48 +255,6 @@ func (c *Controller) notifyForMessage(msg messages.Message, nodeClaim *karpv1.No
 
 	default:
 	}
-}
-
-// makeNodeClaimInstanceIDMap builds a map between the instance id that is stored in the
-// NodeClaim .status.providerID and the NodeClaim
-func (c *Controller) makeNodeClaimInstanceIDMap(ctx context.Context) (map[string]*karpv1.NodeClaim, error) {
-	m := map[string]*karpv1.NodeClaim{}
-	nodeClaims, err := nodeclaimutils.ListManaged(ctx, c.kubeClient, c.cloudProvider)
-	if err != nil {
-		return nil, err
-	}
-	for _, nc := range nodeClaims {
-		if nc.Status.ProviderID == "" {
-			continue
-		}
-		id, err := utils.ParseInstanceID(nc.Status.ProviderID)
-		if err != nil || id == "" {
-			continue
-		}
-		m[id] = nc
-	}
-	return m, nil
-}
-
-// makeNodeInstanceIDMap builds a map between the instance id that is stored in the
-// node .spec.providerID and the node
-func (c *Controller) makeNodeInstanceIDMap(ctx context.Context) (map[string]*corev1.Node, error) {
-	m := map[string]*corev1.Node{}
-	nodeList := &corev1.NodeList{}
-	if err := c.kubeClient.List(ctx, nodeList); err != nil {
-		return nil, fmt.Errorf("listing nodes, %w", err)
-	}
-	for i := range nodeList.Items {
-		if nodeList.Items[i].Spec.ProviderID == "" {
-			continue
-		}
-		id, err := utils.ParseInstanceID(nodeList.Items[i].Spec.ProviderID)
-		if err != nil || id == "" {
-			continue
-		}
-		m[id] = &nodeList.Items[i]
-	}
-	return m, nil
 }
 
 func actionForMessage(msg messages.Message) Action {

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -84,7 +84,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
-	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
+	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...), coretest.WithFieldIndexers(test.NodeInstanceIDFieldIndexer(ctx), test.NodeClaimInstanceIDFieldIndexer(ctx)))
 	awsEnv = test.NewEnvironment(ctx, env)
 	fakeClock = &clock.FakeClock{}
 	unavailableOfferingsCache = awscache.NewUnavailableOfferings()

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,12 +26,13 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
-	config "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/aws/smithy-go"
 	"github.com/patrickmn/go-cache"
@@ -66,6 +67,7 @@ import (
 	ssmp "github.com/aws/karpenter-provider-aws/pkg/providers/ssm"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/subnet"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
+	"github.com/aws/karpenter-provider-aws/pkg/utils"
 )
 
 func init() {
@@ -185,6 +187,10 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		launchTemplateProvider,
 	)
 
+	// Setup field indexers on instanceID -- specifically for the interruption controller
+	if options.FromContext(ctx).InterruptionQueue != "" {
+		SetupIndexers(ctx, operator.Manager)
+	}
 	return ctx, &Operator{
 		Operator:                  operator,
 		Config:                    cfg,
@@ -272,4 +278,27 @@ func KubeDNSIP(ctx context.Context, kubernetesInterface kubernetes.Interface) (n
 		return nil, fmt.Errorf("parsing cluster IP")
 	}
 	return kubeDNSIP, nil
+}
+
+func SetupIndexers(ctx context.Context, mgr manager.Manager) {
+	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &karpv1.NodeClaim{}, "status.instanceID", func(o client.Object) []string {
+		if o.(*karpv1.NodeClaim).Status.ProviderID == "" {
+			return nil
+		}
+		id, e := utils.ParseInstanceID(o.(*karpv1.NodeClaim).Status.ProviderID)
+		if e != nil || id == "" {
+			return nil
+		}
+		return []string{id}
+	}), "failed to setup nodeclaim instanceID indexer")
+	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &corev1.Node{}, "spec.instanceID", func(o client.Object) []string {
+		if o.(*corev1.Node).Spec.ProviderID == "" {
+			return nil
+		}
+		id, e := utils.ParseInstanceID(o.(*corev1.Node).Spec.ProviderID)
+		if e != nil || id == "" {
+			return nil
+		}
+		return []string{id}
+	}), "failed to setup node instanceID indexer")
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change removes the construction of the NodeClaim instanceID map and the Node instanceID map -- this was expensive to construct and was re-constructed on every requeue of the interruption controller. Rather than constructing the mapping this way, we can use a field indexer on instanceID and look-up the NodeClaim and Nodes add-hoc by performing a matchField list query against the internal read cache

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.