### PR TITLE
Add support for Bottlerocket on Neuron instance types

### DIFF
--- a/pkg/controllers/nodeclass/ami_test.go
+++ b/pkg/controllers/nodeclass/ami_test.go
@@ -311,7 +311,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 
-			Expect(len(nodeClass.Status.AMIs)).To(Equal(4))
+			Expect(len(nodeClass.Status.AMIs)).To(Equal(5))
 			Expect(nodeClass.Status.AMIs).To(ContainElements([]v1.AMI{
 				{
 					Name: "amd64-standard",
@@ -348,6 +348,22 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 						{
 							Key:      v1.LabelInstanceAcceleratorCount,
 							Operator: corev1.NodeSelectorOpDoesNotExist,
+						},
+					},
+				},
+				// Note: Bottlerocket uses the same AMI for standard and neuron
+				{
+					Name: "amd64-standard",
+					ID:   "ami-amd64-standard",
+					Requirements: []corev1.NodeSelectorRequirement{
+						{
+							Key:      corev1.LabelArchStable,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{karpv1.ArchitectureAmd64},
+						},
+						{
+							Key:      v1.LabelInstanceAcceleratorCount,
+							Operator: corev1.NodeSelectorOpExists,
 						},
 					},
 				},
@@ -468,7 +484,7 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 
-		Expect(len(nodeClass.Status.AMIs)).To(Equal(2))
+		Expect(len(nodeClass.Status.AMIs)).To(Equal(3))
 		Expect(nodeClass.Status.AMIs).To(ContainElements([]v1.AMI{
 			{
 				Name: "arm64-standard",

--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -79,6 +79,7 @@ type BottlerocketKubernetes struct {
 	ClusterDomain                      *string                                   `toml:"cluster-domain,omitempty"`
 	SeccompDefault                     *bool                                     `toml:"seccomp-default,omitempty"`
 	PodPidsLimit                       *int                                      `toml:"pod-pids-limit,omitempty"`
+	DeviceOwnershipFromSecurityContext *bool                                     `toml:"device-ownership-from-security-context,omitempty"`
 }
 
 type BottlerocketStaticPod struct {

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -44,7 +44,7 @@ func (b Bottlerocket) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Pr
 	trimmedAMIVersion := strings.TrimLeft(amiVersion, "v")
 	ids := map[string][]Variant{}
 	for path, variants := range map[string][]Variant{
-		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/%s/image_id", k8sVersion, trimmedAMIVersion):        {VariantStandard},
+		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/%s/image_id", k8sVersion, trimmedAMIVersion):        {VariantStandard, VariantNeuron},
 		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/%s/image_id", k8sVersion, trimmedAMIVersion):         {VariantStandard},
 		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/%s/image_id", k8sVersion, trimmedAMIVersion): {VariantNvidia},
 		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/arm64/%s/image_id", k8sVersion, trimmedAMIVersion):  {VariantNvidia},

--- a/pkg/providers/amifamily/suite_test.go
+++ b/pkg/providers/amifamily/suite_test.go
@@ -169,7 +169,7 @@ var _ = Describe("AMIProvider", func() {
 		}
 		amis, err := awsEnv.AMIProvider.List(ctx, nodeClass)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(amis).To(HaveLen(4))
+		Expect(amis).To(HaveLen(5))
 	})
 	It("should succeed to resolve AMIs (Windows2019)", func() {
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "windows2019@latest"}}
@@ -304,7 +304,7 @@ var _ = Describe("AMIProvider", func() {
 			// Only 4 of the requirements sets for the SSM aliases will resolve
 			amis, err := awsEnv.AMIProvider.List(ctx, nodeClass)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(amis).To(HaveLen(3))
+			Expect(amis).To(HaveLen(4))
 		})
 	})
 	Context("AMI Tag Requirements", func() {

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -1353,6 +1353,20 @@ cluster-name = 'cluster'
 'memory.available' = '12%%'
 ```
 
+#### Device ownership in Bottlerocket
+
+Bottlerocket `v1.30.0+` supports device ownership using the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) provided in the Kubernetes specfile. To enable this, you will need the following user-data configurations:
+
+```toml
+[settings]
+[settings.kubernetes]
+device-ownership-from-security-context = true
+```
+
+This allows the container to take ownership of devices allocated to the pod via device-plugins based on the `runAsUser` and `runAsGroup` values provided in the spec. For more details on this, see the [Kubernetes documentation](https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/)
+
+This setting helps you enable Neuron workloads on Bottlerocket instances. See [Accelerators/GPU Resources]({{< ref "./scheduling#acceleratorsgpu-resources" >}}) for more details.
+
 ### Windows2019/Windows2022
 
 * Your UserData must be specified as PowerShell commands.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7596 <!-- issue number -->

**Description**
This changes allows karpenter to launch Neuron instances (`inf`, `trn` instance types) using the Bottlerocket AMI.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.