### PR TITLE
docs: Github should link to kubernetes sigs karpenter, instead of a provider (AWS)

### DIFF
--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -69,7 +69,7 @@ params:
   links:
     developer:
       - name: GitHub
-        url: "https://github.com/aws/karpenter-provider-aws"
+        url: "https://github.com/kubernetes-sigs/karpenter"
         icon: fab fa-github
         desc: Development takes place here!
       - name: Slack
@@ -89,7 +89,7 @@ menu:
   main:
     - name: GitHub
       weight: 99
-      url: "https://github.com/aws/karpenter-provider-aws"
+      url: "https://github.com/kubernetes-sigs/karpenter"
       pre: <i class='fab fa-github'></i>
     - name: Docs
       weight: 20


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The github link on karpenter.sh links to AWS' implementation provider. It should link to the main project. The main project currently contains links to the AWS provider, which is confusing for anyone using karpenter outside of AWS.

**How was this change tested?**

**Does this change impact docs?**
- [x ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.