### PR TITLE
feat: make `instanceTypeFlexibilityThreshold` configurable

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -34,14 +34,15 @@ func init() {
 type optionsKey struct{}
 
 type Options struct {
-	ClusterCABundle         string
-	ClusterName             string
-	ClusterEndpoint         string
-	IsolatedVPC             bool
-	EKSControlPlane         bool
-	VMMemoryOverheadPercent float64
-	InterruptionQueue       string
-	ReservedENIs            int
+	ClusterCABundle                  string
+	ClusterName                      string
+	ClusterEndpoint                  string
+	IsolatedVPC                      bool
+	EKSControlPlane                  bool
+	VMMemoryOverheadPercent          float64
+	InterruptionQueue                string
+	ReservedENIs                     int
+	InstanceTypeFlexibilityThreshold int
 }
 
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
@@ -53,6 +54,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent", utils.WithDefaultFloat64("VM_MEMORY_OVERHEAD_PERCENT", 0.075), "The VM memory overhead as a percent that will be subtracted from the total memory for all instance types when cached information is unavailable.")
 	fs.StringVar(&o.InterruptionQueue, "interruption-queue", env.WithDefaultString("INTERRUPTION_QUEUE", ""), "Interruption queue is the name of the SQS queue used for processing interruption events from EC2. Interruption handling is disabled if not specified. Enabling interruption handling may require additional permissions on the controller service account. Additional permissions are outlined in the docs.")
 	fs.IntVar(&o.ReservedENIs, "reserved-enis", env.WithDefaultInt("RESERVED_ENIS", 0), "Reserved ENIs are not included in the calculations for max-pods or kube-reserved. This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.")
+	fs.IntVar(&o.InstanceTypeFlexibilityThreshold, "instance-type-flexibility-threshold", env.WithDefaultInt("INSTANCE_TYPE_FLEXIBILITY_THRESHOLD", 5), "The minimum number of instance types to limit the instance selector values to when using instance type flexibility.")
 }
 
 func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -27,6 +27,7 @@ func (o Options) Validate() error {
 		o.validateVMMemoryOverheadPercent(),
 		o.validateReservedENIs(),
 		o.validateRequiredFields(),
+		o.validateInstanceTypeFlexibilityThreshold(),
 	)
 }
 
@@ -60,6 +61,13 @@ func (o Options) validateReservedENIs() error {
 func (o Options) validateRequiredFields() error {
 	if o.ClusterName == "" {
 		return fmt.Errorf("missing field, cluster-name")
+	}
+	return nil
+}
+
+func (o Options) validateInstanceTypeFlexibilityThreshold() error {
+	if o.InstanceTypeFlexibilityThreshold < 1 {
+		return fmt.Errorf("instance-type-flexibility-threshold must be greater than 0")
 	}
 	return nil
 }

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -62,16 +62,18 @@ var _ = Describe("Options", func() {
 			"--isolated-vpc",
 			"--vm-memory-overhead-percent", "0.1",
 			"--interruption-queue", "env-cluster",
-			"--reserved-enis", "10")
+			"--reserved-enis", "10",
+			"--instance-type-flexibility-threshold", "2")
 		Expect(err).ToNot(HaveOccurred())
 		expectOptionsEqual(opts, test.Options(test.OptionsFields{
-			ClusterCABundle:         lo.ToPtr("env-bundle"),
-			ClusterName:             lo.ToPtr("env-cluster"),
-			ClusterEndpoint:         lo.ToPtr("https://env-cluster"),
-			IsolatedVPC:             lo.ToPtr(true),
-			VMMemoryOverheadPercent: lo.ToPtr[float64](0.1),
-			InterruptionQueue:       lo.ToPtr("env-cluster"),
-			ReservedENIs:            lo.ToPtr(10),
+			ClusterCABundle:                  lo.ToPtr("env-bundle"),
+			ClusterName:                      lo.ToPtr("env-cluster"),
+			ClusterEndpoint:                  lo.ToPtr("https://env-cluster"),
+			IsolatedVPC:                      lo.ToPtr(true),
+			VMMemoryOverheadPercent:          lo.ToPtr[float64](0.1),
+			InterruptionQueue:                lo.ToPtr("env-cluster"),
+			ReservedENIs:                     lo.ToPtr(10),
+			InstanceTypeFlexibilityThreshold: lo.ToPtr(2),
 		}))
 	})
 	It("should correctly fallback to env vars when CLI flags aren't set", func() {
@@ -82,6 +84,7 @@ var _ = Describe("Options", func() {
 		os.Setenv("VM_MEMORY_OVERHEAD_PERCENT", "0.1")
 		os.Setenv("INTERRUPTION_QUEUE", "env-cluster")
 		os.Setenv("RESERVED_ENIS", "10")
+		os.Setenv("INSTANCE_TYPE_FLEXIBILITY_THRESHOLD", "2")
 
 		// Add flags after we set the environment variables so that the parsing logic correctly refers
 		// to the new environment variable values
@@ -89,13 +92,14 @@ var _ = Describe("Options", func() {
 		err := opts.Parse(fs)
 		Expect(err).ToNot(HaveOccurred())
 		expectOptionsEqual(opts, test.Options(test.OptionsFields{
-			ClusterCABundle:         lo.ToPtr("env-bundle"),
-			ClusterName:             lo.ToPtr("env-cluster"),
-			ClusterEndpoint:         lo.ToPtr("https://env-cluster"),
-			IsolatedVPC:             lo.ToPtr(true),
-			VMMemoryOverheadPercent: lo.ToPtr[float64](0.1),
-			InterruptionQueue:       lo.ToPtr("env-cluster"),
-			ReservedENIs:            lo.ToPtr(10),
+			ClusterCABundle:                  lo.ToPtr("env-bundle"),
+			ClusterName:                      lo.ToPtr("env-cluster"),
+			ClusterEndpoint:                  lo.ToPtr("https://env-cluster"),
+			IsolatedVPC:                      lo.ToPtr(true),
+			VMMemoryOverheadPercent:          lo.ToPtr[float64](0.1),
+			InterruptionQueue:                lo.ToPtr("env-cluster"),
+			ReservedENIs:                     lo.ToPtr(10),
+			InstanceTypeFlexibilityThreshold: lo.ToPtr(2),
 		}))
 	})
 
@@ -119,6 +123,10 @@ var _ = Describe("Options", func() {
 			err := opts.Parse(fs, "--cluster-name", "test-cluster", "--reserved-enis", "-1")
 			Expect(err).To(HaveOccurred())
 		})
+		It("should fail when instanceTypeFlexibilityThreshold is negative", func() {
+			err := opts.Parse(fs, "--cluster-name", "test-cluster", "--instance-type-flexibility-threshold", "-1")
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })
 
@@ -131,4 +139,5 @@ func expectOptionsEqual(optsA *options.Options, optsB *options.Options) {
 	Expect(optsA.VMMemoryOverheadPercent).To(Equal(optsB.VMMemoryOverheadPercent))
 	Expect(optsA.InterruptionQueue).To(Equal(optsB.InterruptionQueue))
 	Expect(optsA.ReservedENIs).To(Equal(optsB.ReservedENIs))
+	Expect(optsA.InstanceTypeFlexibilityThreshold).To(Equal(optsB.InstanceTypeFlexibilityThreshold))
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -24,14 +24,15 @@ import (
 )
 
 type OptionsFields struct {
-	ClusterCABundle         *string
-	ClusterName             *string
-	ClusterEndpoint         *string
-	IsolatedVPC             *bool
-	EKSControlPlane         *bool
-	VMMemoryOverheadPercent *float64
-	InterruptionQueue       *string
-	ReservedENIs            *int
+	ClusterCABundle                  *string
+	ClusterName                      *string
+	ClusterEndpoint                  *string
+	IsolatedVPC                      *bool
+	EKSControlPlane                  *bool
+	VMMemoryOverheadPercent          *float64
+	InterruptionQueue                *string
+	ReservedENIs                     *int
+	InstanceTypeFlexibilityThreshold *int
 }
 
 func Options(overrides ...OptionsFields) *options.Options {
@@ -42,13 +43,14 @@ func Options(overrides ...OptionsFields) *options.Options {
 		}
 	}
 	return &options.Options{
-		ClusterCABundle:         lo.FromPtrOr(opts.ClusterCABundle, ""),
-		ClusterName:             lo.FromPtrOr(opts.ClusterName, "test-cluster"),
-		ClusterEndpoint:         lo.FromPtrOr(opts.ClusterEndpoint, "https://test-cluster"),
-		IsolatedVPC:             lo.FromPtrOr(opts.IsolatedVPC, false),
-		EKSControlPlane:         lo.FromPtrOr(opts.EKSControlPlane, false),
-		VMMemoryOverheadPercent: lo.FromPtrOr(opts.VMMemoryOverheadPercent, 0.075),
-		InterruptionQueue:       lo.FromPtrOr(opts.InterruptionQueue, ""),
-		ReservedENIs:            lo.FromPtrOr(opts.ReservedENIs, 0),
+		ClusterCABundle:                  lo.FromPtrOr(opts.ClusterCABundle, ""),
+		ClusterName:                      lo.FromPtrOr(opts.ClusterName, "test-cluster"),
+		ClusterEndpoint:                  lo.FromPtrOr(opts.ClusterEndpoint, "https://test-cluster"),
+		IsolatedVPC:                      lo.FromPtrOr(opts.IsolatedVPC, false),
+		EKSControlPlane:                  lo.FromPtrOr(opts.EKSControlPlane, false),
+		VMMemoryOverheadPercent:          lo.FromPtrOr(opts.VMMemoryOverheadPercent, 0.075),
+		InterruptionQueue:                lo.FromPtrOr(opts.InterruptionQueue, ""),
+		ReservedENIs:                     lo.FromPtrOr(opts.ReservedENIs, 0),
+		InstanceTypeFlexibilityThreshold: lo.FromPtrOr(opts.InstanceTypeFlexibilityThreshold, 1),
 	}
 }

--- a/website/content/en/docs/reference/settings.md
+++ b/website/content/en/docs/reference/settings.md
@@ -22,6 +22,7 @@ Karpenter surfaces environment variables and CLI parameters to allow you to conf
 | ENABLE_PROFILING | \-\-enable-profiling | Enable the profiling on the metric endpoint|
 | FEATURE_GATES | \-\-feature-gates | Optional features can be enabled / disabled using feature gates. Current options are: SpotToSpotConsolidation (default = NodeRepair=false,SpotToSpotConsolidation=false)|
 | HEALTH_PROBE_PORT | \-\-health-probe-port | The port the health probe endpoint binds to for reporting controller health (default = 8081)|
+| INSTANCE_TYPE_FLEXIBILITY_THRESHOLD | \-\-instance-type-flexibility-threshold | The minimum number of instance types below which to fallback to on-demand. (default = 5)|
 | INTERRUPTION_QUEUE | \-\-interruption-queue | Interruption queue is the name of the SQS queue used for processing interruption events from EC2. Interruption handling is disabled if not specified. Enabling interruption handling may require additional permissions on the controller service account. Additional permissions are outlined in the docs.|
 | ISOLATED_VPC | \-\-isolated-vpc | If true, then assume we can't reach AWS services which don't have a VPC endpoint. This also has the effect of disabling look-ups to the AWS on-demand pricing endpoint.|
 | KARPENTER_SERVICE | \-\-karpenter-service | The Karpenter Service name for the dynamic webhook certificate|


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

**Description**

Adds `--instance-type-flexibility-threshold` / `INSTANCE_TYPE_FLEXIBILITY_THRESHOLD` with same default value of 5.

**How was this change tested?**

only basic functionality testing done

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, Issue: 
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.