### PR TITLE
docs: webhook configurations for upgrade to v1

### DIFF
--- a/website/content/en/v1.0/upgrading/v1-migration.md
+++ b/website/content/en/v1.0/upgrading/v1-migration.md
@@ -299,6 +299,18 @@ You should still review the upgrade procedure; the sequence of operations remain
 Karpenter has deprecated and moved a number of Helm values as part of the v1 release. Ensure that you upgrade to the newer version of these helm values during your migration to v1. You can find detail for all the settings that were moved in the [v1 Upgrade Reference]({{<ref "#helm-values" >}}).
     {{% /alert %}}
 
+    {{% alert title="Note" color="primary" %}}
+<!-- Note: don't indent this line to match the indenting of the alert box. Hugo will create a code block. -->
+Karpenter versions 0.32.x through 0.37.x have  a number of mutating webhooks and validating webhooks that are not present
+in 1.0.x; if you are only using `helm` to generate manifests and are not using it to deploy them, you must clean up
+these webhook configurations by hand: specifically, you will need to remove the following resources:
+
+* `defaulting.webhook.karpenter.k8s.aws`
+* `validation.webhook.karpenter.sh`
+* `validation.webhook.config.karpenter.sh`
+* `validation.webhook.karpenter.k8s.aws`
+    {{% /alert %}}
+
 11. Upgrade your cloudformation stack and remove the temporary `v1` controller policy.
 
     ```bash


### PR DESCRIPTION
**Description**

Adding a note to the upgrade docs for people not using `helm` to upgrade that some manual cleanup of the webhook configuraitons may be necessary.  There are a number of closed issues (e.g. #7134, #6982, #6879) where it seems like people are running into this so seems like maybe a helpful note to have.

**How was this change tested?**
Built the docs locally:

![image](https://github.com/user-attachments/assets/3b66404d-ac2b-4462-8cf4-773e8b04285b)

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.