### PR TITLE
fix: cache ec2nodeclass validation state

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -66,6 +66,7 @@ func main() {
 			op.EventRecorder,
 			op.UnavailableOfferingsCache,
 			op.SSMCache,
+			op.ValidationCache,
 			cloudProvider,
 			op.SubnetProvider,
 			op.SecurityGroupProvider,

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -1186,7 +1186,7 @@ var _ = Describe("CloudProvider", func() {
 				{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(100),
 					Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}}},
 			}})
-			controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API)
+			controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache)
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 			pod := coretest.UnschedulablePod(coretest.PodOptions{NodeSelector: map[string]string{corev1.LabelTopologyZone: "test-zone-1a"}})
@@ -1203,7 +1203,7 @@ var _ = Describe("CloudProvider", func() {
 				{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(11),
 					Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}}},
 			}})
-			controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API)
+			controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache)
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				MaxPods: aws.Int32(1),
 			}
@@ -1244,7 +1244,7 @@ var _ = Describe("CloudProvider", func() {
 			}})
 			nodeClass.Spec.SubnetSelectorTerms = []v1.SubnetSelectorTerm{{Tags: map[string]string{"Name": "test-subnet-1"}}}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-			controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API)
+			controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache)
 			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 			podSubnet1 := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, podSubnet1)

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -71,6 +71,7 @@ func NewControllers(
 	recorder events.Recorder,
 	unavailableOfferings *awscache.UnavailableOfferings,
 	ssmCache *cache.Cache,
+	validationCache *cache.Cache,
 	cloudProvider cloudprovider.CloudProvider,
 	subnetProvider subnet.Provider,
 	securityGroupProvider securitygroup.Provider,
@@ -85,7 +86,7 @@ func NewControllers(
 ) []controller.Controller {
 	controllers := []controller.Controller{
 		nodeclasshash.NewController(kubeClient),
-		nodeclass.NewController(ctx, clk, kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, launchTemplateProvider, capacityReservationProvider, ec2api),
+		nodeclass.NewController(ctx, clk, kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, launchTemplateProvider, capacityReservationProvider, ec2api, validationCache),
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider),
 		nodeclaimtagging.NewController(kubeClient, cloudProvider, instanceProvider),
 		controllerspricing.NewController(pricingProvider),

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -29,6 +29,12 @@ type InstanceProfile struct {
 	instanceProfileProvider instanceprofile.Provider
 }
 
+func NewInstanceProfileReconciler(instanceProfileProvider instanceprofile.Provider) *InstanceProfile {
+	return &InstanceProfile{
+		instanceProfileProvider: instanceProfileProvider,
+	}
+}
+
 func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	if nodeClass.Spec.Role != "" {
 		name, err := ip.instanceProfileProvider.Create(ctx, nodeClass)

--- a/pkg/controllers/nodeclass/readiness.go
+++ b/pkg/controllers/nodeclass/readiness.go
@@ -31,6 +31,12 @@ type Readiness struct {
 	launchTemplateProvider launchtemplate.Provider
 }
 
+func NewReadinessReconciler(launchTemplateProvider launchtemplate.Provider) *Readiness {
+	return &Readiness{
+		launchTemplateProvider: launchTemplateProvider,
+	}
+}
+
 func (n Readiness) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	// A NodeClass that uses AL2023 requires the cluster CIDR for launching nodes.
 	// To allow Karpenter to be used for Non-EKS clusters, resolving the Cluster CIDR

--- a/pkg/controllers/nodeclass/securitygroup.go
+++ b/pkg/controllers/nodeclass/securitygroup.go
@@ -32,6 +32,12 @@ type SecurityGroup struct {
 	securityGroupProvider securitygroup.Provider
 }
 
+func NewSecurityGroupReconciler(securityGroupProvider securitygroup.Provider) *SecurityGroup {
+	return &SecurityGroup{
+		securityGroupProvider: securityGroupProvider,
+	}
+}
+
 func (sg *SecurityGroup) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	securityGroups, err := sg.securityGroupProvider.List(ctx, nodeClass)
 	if err != nil {

--- a/pkg/controllers/nodeclass/subnet.go
+++ b/pkg/controllers/nodeclass/subnet.go
@@ -32,6 +32,12 @@ type Subnet struct {
 	subnetProvider subnet.Provider
 }
 
+func NewSubnetReconciler(subnetProvider subnet.Provider) *Subnet {
+	return &Subnet{
+		subnetProvider: subnetProvider,
+	}
+}
+
 func (s *Subnet) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	subnets, err := s.subnetProvider.List(ctx, nodeClass)
 	if err != nil {

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -82,6 +82,7 @@ var _ = BeforeSuite(func() {
 		awsEnv.LaunchTemplateProvider,
 		awsEnv.CapacityReservationProvider,
 		awsEnv.EC2API,
+		awsEnv.ValidationCache,
 	)
 })
 

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/smithy-go"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/nodeclass"
 	"github.com/aws/karpenter-provider-aws/pkg/fake"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
 
@@ -30,6 +31,48 @@ import (
 )
 
 var _ = Describe("NodeClass Validation Status Controller", func() {
+	Context("Preconditions", func() {
+		var reconciler *nodeclass.Validation
+		BeforeEach(func() {
+			reconciler = nodeclass.NewValidationReconciler(awsEnv.EC2API, awsEnv.AMIProvider, awsEnv.ValidationCache)
+			for _, cond := range []string{
+				v1.ConditionTypeAMIsReady,
+				v1.ConditionTypeInstanceProfileReady,
+				v1.ConditionTypeSecurityGroupsReady,
+				v1.ConditionTypeSubnetsReady,
+			} {
+				nodeClass.StatusConditions().SetTrue(cond)
+			}
+		})
+		DescribeTable(
+			"should set validated status condition to false when any required condition is false",
+			func(cond string) {
+				nodeClass.StatusConditions().SetFalse(cond, "test", "test")
+				_, err := reconciler.Reconcile(ctx, nodeClass)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(nodeclass.ConditionReasonDependenciesNotReady))
+			},
+			Entry(v1.ConditionTypeAMIsReady, v1.ConditionTypeAMIsReady),
+			Entry(v1.ConditionTypeInstanceProfileReady, v1.ConditionTypeInstanceProfileReady),
+			Entry(v1.ConditionTypeSecurityGroupsReady, v1.ConditionTypeSecurityGroupsReady),
+			Entry(v1.ConditionTypeSubnetsReady, v1.ConditionTypeSubnetsReady),
+		)
+		DescribeTable(
+			"should set validated status condition to unknown when no required condition is false and any are unknown",
+			func(cond string) {
+				nodeClass.StatusConditions().SetUnknown(cond)
+				_, err := reconciler.Reconcile(ctx, nodeClass)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsUnknown()).To(BeTrue())
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(nodeclass.ConditionReasonDependenciesNotReady))
+			},
+			Entry(v1.ConditionTypeAMIsReady, v1.ConditionTypeAMIsReady),
+			Entry(v1.ConditionTypeInstanceProfileReady, v1.ConditionTypeInstanceProfileReady),
+			Entry(v1.ConditionTypeSecurityGroupsReady, v1.ConditionTypeSecurityGroupsReady),
+			Entry(v1.ConditionTypeSubnetsReady, v1.ConditionTypeSubnetsReady),
+		)
+	})
 	Context("Tag Validation", func() {
 		BeforeEach(func() {
 			nodeClass = test.EC2NodeClass(v1.EC2NodeClass{
@@ -63,6 +106,7 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 			Expect(err).To(HaveOccurred())
 			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal("TagValidationFailed"))
 			Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsFalse()).To(BeTrue())
 			Expect(nodeClass.StatusConditions().Get(status.ConditionReady).Message).To(Equal("ValidationSucceeded=False"))
 		},
@@ -83,39 +127,44 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 		})
 	})
 	Context("Authorization Validation", func() {
-		DescribeTable("NodeClass validation failure conditions",
-			func(setupFn func()) {
+		DescribeTable(
+			"NodeClass validation failure conditions",
+			func(setupFn func(), reason string) {
 				ExpectApplied(ctx, env.Client, nodeClass)
 				setupFn()
 				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 				nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
-			},
-			Entry("should update status condition as NotReady when CreateFleet unauthorized",
-				func() {
-					awsEnv.EC2API.CreateFleetBehavior.Error.Set(&smithy.GenericAPIError{
-						Code: "UnauthorizedOperation",
-					}, fake.MaxCalls(1))
-				}),
-			Entry("should update status condition as NotReady when RunInstances unauthorized",
-				func() {
-					awsEnv.EC2API.RunInstancesBehavior.Error.Set(&smithy.GenericAPIError{
-						Code: "UnauthorizedOperation",
-					}, fake.MaxCalls(1))
-				}),
-			Entry("should update status condition as NotReady when CreateLaunchTemplate unauthorized",
-				func() {
-					awsEnv.EC2API.CreateLaunchTemplateBehavior.Error.Set(&smithy.GenericAPIError{
-						Code: "UnauthorizedOperation",
-					}, fake.MaxCalls(1))
-				}),
-		)
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(reason))
+				Expect(awsEnv.ValidationCache.Items()).To(HaveLen(1))
 
-		It("should update status condition as Ready when authorized", func() {
-			ExpectApplied(ctx, env.Client, nodeClass)
-			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
-			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
-			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsTrue()).To(BeTrue())
-		})
+				// Even though we would succeed on the subsequent call, we should fail here because we hit the cache
+				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+				nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(reason))
+
+				// After flushing the cache, we should succeed
+				awsEnv.ValidationCache.Flush()
+				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+				nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsTrue()).To(BeTrue())
+			},
+			Entry("should update status condition as NotReady when CreateFleet unauthorized", func() {
+				awsEnv.EC2API.CreateFleetBehavior.Error.Set(&smithy.GenericAPIError{
+					Code: "UnauthorizedOperation",
+				}, fake.MaxCalls(1))
+			}, nodeclass.ConditionReasonCreateFleetAuthFailed),
+			Entry("should update status condition as NotReady when RunInstances unauthorized", func() {
+				awsEnv.EC2API.RunInstancesBehavior.Error.Set(&smithy.GenericAPIError{
+					Code: "UnauthorizedOperation",
+				}, fake.MaxCalls(1))
+			}, nodeclass.ConditionReasonRunInstancesAuthFailed),
+			Entry("should update status condition as NotReady when CreateLaunchTemplate unauthorized", func() {
+				awsEnv.EC2API.CreateLaunchTemplateBehavior.Error.Set(&smithy.GenericAPIError{
+					Code: "UnauthorizedOperation",
+				}, fake.MaxCalls(1))
+			}, nodeclass.ConditionReasonCreateLaunchTemplateAuthFailed),
+		)
 	})
 })

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -81,6 +81,7 @@ type Operator struct {
 	Config                      aws.Config
 	UnavailableOfferingsCache   *awscache.UnavailableOfferings
 	SSMCache                    *cache.Cache
+	ValidationCache             *cache.Cache
 	SubnetProvider              subnet.Provider
 	SecurityGroupProvider       securitygroup.Provider
 	InstanceProfileProvider     instanceprofile.Provider
@@ -143,6 +144,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	}
 	unavailableOfferingsCache := awscache.NewUnavailableOfferings()
 	ssmCache := cache.New(awscache.SSMCacheTTL, awscache.DefaultCleanupInterval)
+	validationCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 
 	subnetProvider := subnet.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval), cache.New(awscache.AvailableIPAddressTTL, awscache.DefaultCleanupInterval), cache.New(awscache.AssociatePublicIPAddressTTL, awscache.DefaultCleanupInterval))
 	securityGroupProvider := securitygroup.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
@@ -210,6 +212,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		Config:                      cfg,
 		UnavailableOfferingsCache:   unavailableOfferingsCache,
 		SSMCache:                    ssmCache,
+		ValidationCache:             validationCache,
 		SubnetProvider:              subnetProvider,
 		SecurityGroupProvider:       securityGroupProvider,
 		InstanceProfileProvider:     instanceProfileProvider,

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2042,7 +2042,7 @@ essential = true
 				nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyCustom)
 				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Tags: map[string]string{"*": "*"}}}
 				ExpectApplied(ctx, env.Client, nodeClass)
-				controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API)
+				controller := nodeclass.NewController(ctx, awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache)
 				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
 					{

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -80,6 +80,7 @@ type Environment struct {
 	DiscoveredCapacityCache              *cache.Cache
 	CapacityReservationCache             *cache.Cache
 	CapacityReservationAvailabilityCache *cache.Cache
+	ValidationCache                      *cache.Cache
 
 	// Providers
 	CapacityReservationProvider *capacityreservation.DefaultProvider
@@ -121,6 +122,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	ssmCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	capacityReservationCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	capacityReservationAvailabilityCache := cache.New(24*time.Hour, awscache.DefaultCleanupInterval)
+	validationCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	fakePricingAPI := &fake.PricingAPI{}
 
 	// Providers
@@ -186,6 +188,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		DiscoveredCapacityCache:              discoveredCapacityCache,
 		CapacityReservationCache:             capacityReservationCache,
 		CapacityReservationAvailabilityCache: capacityReservationAvailabilityCache,
+		ValidationCache:                      validationCache,
 
 		CapacityReservationProvider: capacityReservationProvider,
 		InstanceTypesResolver:       instanceTypesResolver,
@@ -224,6 +227,7 @@ func (env *Environment) Reset() {
 	env.SSMCache.Flush()
 	env.DiscoveredCapacityCache.Flush()
 	env.CapacityReservationCache.Flush()
+	env.ValidationCache.Flush()
 	mfs, err := crmetrics.Registry.Gather()
 	if err != nil {
 		for _, mf := range mfs {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Implements caching for EC2NodeClass validation. Currently, Karpenter will perform the dry-run API calls for each reconciliation of the nodeclass controller. The issue is that this controller has a watch on NodeClaims in addition to NodeClasses, leading to an extremely high call volume. With this change we will cache the result for a minute, reducing call volume. The cache key is based on the nodeclass name and resource version, ensuring we invalidate the cache entry when there's an update to the nodeclass itself.

To reduce the risk of cache related errors (e.g. entering slightly different types into the cache, or the use of different cache key formats), I've split the main reconcile function by auth failure type. These are all called by the main reconcile function and we now only have a single place data is added to the cache.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.