### PR TITLE
ci: Fix flaking in the terminationGracePeriod E2Es

### DIFF
--- a/test/suites/termination/termination_grace_period_test.go
+++ b/test/suites/termination/termination_grace_period_test.go
@@ -32,12 +32,12 @@ import (
 
 var _ = Describe("TerminationGracePeriod", func() {
 	BeforeEach(func() {
-		nodePool.Spec.Template.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 30}
+		nodePool.Spec.Template.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 60}
 	})
 	It("should delete pod with do-not-disrupt when it reaches its terminationGracePeriodSeconds", func() {
 		pod := coretest.UnschedulablePod(coretest.PodOptions{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 			karpv1.DoNotDisruptAnnotationKey: "true",
-		}}, TerminationGracePeriodSeconds: lo.ToPtr(int64(15))})
+		}}, TerminationGracePeriodSeconds: lo.ToPtr(int64(30))})
 		env.ExpectCreated(nodeClass, nodePool, pod)
 
 		nodeClaim := env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
@@ -59,15 +59,17 @@ var _ = Describe("TerminationGracePeriod", func() {
 		}).WithTimeout(3 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
 
 		// Check that pod remains healthy until termination grace period
-		// subtract the polling time of the eventually above to reduce any races.
-		env.ConsistentlyExpectHealthyPods(time.Second*15-100*time.Millisecond, pod)
+		// subtracting 5s is close enough to say that we waited for the entire terminationGracePeriod
+		// and to stop us flaking from tricky timing bugs
+		env.ConsistentlyExpectHealthyPods(time.Duration(lo.FromPtr(pod.Spec.TerminationGracePeriodSeconds)-5)*time.Second, pod)
+
 		// Both nodeClaim and node should be gone once terminationGracePeriod is reached
 		env.EventuallyExpectNotFound(nodeClaim, node, pod)
 	})
 	It("should delete pod that has a pre-stop hook after termination grace period seconds", func() {
 		pod := coretest.UnschedulablePod(coretest.PodOptions{
 			PreStopSleep:                  lo.ToPtr(int64(300)),
-			TerminationGracePeriodSeconds: lo.ToPtr(int64(15)),
+			TerminationGracePeriodSeconds: lo.ToPtr(int64(30)),
 			Image:                         "alpine:3.20.2",
 			Command:                       []string{"/bin/sh", "-c", "sleep 30"}})
 		env.ExpectCreated(nodeClass, nodePool, pod)
@@ -91,8 +93,9 @@ var _ = Describe("TerminationGracePeriod", func() {
 		env.EventuallyExpectTerminating(pod)
 
 		// Check that pod remains healthy until termination grace period
-		// subtract the polling time of the eventually above to reduce any races.
-		env.ConsistentlyExpectTerminatingPods(time.Second*15-100*time.Millisecond, pod)
+		// subtracting 5s is close enough to say that we waited for the entire terminationGracePeriod
+		// and to stop us flaking from tricky timing bugs
+		env.ConsistentlyExpectHealthyPods(time.Duration(lo.FromPtr(pod.Spec.TerminationGracePeriodSeconds)-5)*time.Second, pod)
 
 		// Both nodeClaim and node should be gone once terminationGracePeriod is reached
 		env.EventuallyExpectNotFound(nodeClaim, node, pod)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change ensures that we don't try to be "so perfect" with our terminationGracePeriod testing where we try to get exactly up to our terminationGracePeriod on the pod. This gives us a 5s buffer so that we won't flake as frequently when it comes to timing

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.