### PR TITLE
docs: Fix website version dropdown

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -203,7 +203,7 @@ editWebsiteVersionsMenu() {
   local versions version
 
   # shellcheck disable=SC2207
-  versions=($(find website/content/en/* -maxdepth 0 -type d -name "*" -print0 | xargs -0 -r -n 1 basename | grep -v "docs\|preview"))
+  versions=($(find website/content/en/* -maxdepth 0 -type d -name "*" -print0 | xargs -0 -r -n 1 basename | grep -v "docs\|preview" | sort -r))
   versions+=('preview')
 
   yq -i '.params.versions = []' website/hugo.yaml

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -79,11 +79,11 @@ params:
   latest_release_version: "1.3.0"
   latest_k8s_version: "1.32"
   versions:
-    - v0.32
-    - v1.0
-    - v1.1
-    - v1.2
     - v1.3
+    - v1.2
+    - v1.1
+    - v1.0
+    - v0.32
     - preview
 menu:
   main:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Version dropdown ordering was reversed and was causing `latest` to be marked as `v0.32`

**How was this change tested?**

`prepareWebsite`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.