### PR TITLE
fix: spurious logging from capacity reservation controller

### DIFF
--- a/pkg/controllers/nodeclaim/capacityreservation/controller.go
+++ b/pkg/controllers/nodeclaim/capacityreservation/controller.go
@@ -130,6 +130,7 @@ func (c *Controller) syncCapacityType(ctx context.Context, capacityType string, 
 	if err != nil {
 		return false, fmt.Errorf("listing nodes for nodeclaim %q, %w", nc.Name, err)
 	}
+	updated := false
 	for _, n := range nodes {
 		if !n.DeletionTimestamp.IsZero() {
 			continue
@@ -148,6 +149,7 @@ func (c *Controller) syncCapacityType(ctx context.Context, capacityType string, 
 		if err := c.kubeClient.Patch(ctx, n, client.MergeFrom(stored)); client.IgnoreNotFound(err) != nil {
 			return false, fmt.Errorf("patching node %q, %w", n.Name, err)
 		}
+		updated = true
 	}
-	return true, nil
+	return updated, nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7835 

**Description**
Doesn't return true unless a nodeclaim was demoted from Reserved to OnDemand.

**How was this change tested?**
In test cluster

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.