### PR TITLE
fix: don't drift when launched into open ODCR

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -385,7 +385,10 @@ func (c *CloudProvider) instanceToNodeClaim(i *instance.Instance, instanceType *
 
 	if instanceType != nil {
 		for key, req := range instanceType.Requirements {
-			if req.Len() == 1 {
+			// Only add the label if there is a single possible value. Counter examples include zone and reservation id. We need
+			// an explicit check for reservation id because even if there is a single value, if we launched into spot or OD it
+			// won't be used.
+			if req.Len() == 1 && req.Key != cloudprovider.ReservationIDLabel {
 				labels[key] = req.Values()[0]
 			}
 		}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -385,9 +385,11 @@ func (c *CloudProvider) instanceToNodeClaim(i *instance.Instance, instanceType *
 
 	if instanceType != nil {
 		for key, req := range instanceType.Requirements {
-			// Only add the label if there is a single possible value. Counter examples include zone and reservation id. We need
-			// an explicit check for reservation id because even if there is a single value, if we launched into spot or OD it
-			// won't be used.
+			// We only want to add a label based on the instance type requirements if there is a single value for that
+			// requirement. For example, we can't add a label for zone based on this if the requirement is compatible with
+			// three. Capacity reservation IDs are a special case since we don't have a way to represent that the label may or
+			// may not exist. Since this requirement will be present regardless of the capacity type, we can't insert it here.
+			// Otherwise, you may end up with spot and on-demand NodeClaims with a reservation ID label.
 			if req.Len() == 1 && req.Key != cloudprovider.ReservationIDLabel {
 				labels[key] = req.Values()[0]
 			}

--- a/pkg/controllers/nodeclaim/capacityreservation/suite_test.go
+++ b/pkg/controllers/nodeclaim/capacityreservation/suite_test.go
@@ -42,6 +42,8 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 var ctx context.Context
@@ -59,6 +61,7 @@ func TestAWS(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...), coretest.WithFieldIndexers(coretest.NodeProviderIDFieldIndexer(ctx)))
 	ctx = options.ToContext(ctx, test.Options())
+	ctx = coreoptions.ToContext(ctx, coretest.Options(coretest.OptionsFields{FeatureGates: coretest.FeatureGates{ReservedCapacity: lo.ToPtr(true)}}))
 	ctx, stop = context.WithCancel(ctx)
 	awsEnv = test.NewEnvironment(ctx, env)
 

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -46,6 +46,8 @@ import (
 	. "github.com/onsi/gomega"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 var ctx context.Context
@@ -63,6 +65,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
+	ctx = coreoptions.ToContext(ctx, coretest.Options(coretest.OptionsFields{FeatureGates: coretest.FeatureGates{ReservedCapacity: lo.ToPtr(true)}}))
 	awsEnv = test.NewEnvironment(ctx, env)
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
 		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider)

--- a/pkg/controllers/nodeclaim/tagging/suite_test.go
+++ b/pkg/controllers/nodeclaim/tagging/suite_test.go
@@ -219,7 +219,7 @@ var _ = Describe("TaggingController", func() {
 				v1.EKSClusterNameTagKey: options.FromContext(ctx).ClusterName,
 			}
 			ec2Instance := lo.Must(awsEnv.EC2API.Instances.Load(*ec2Instance.InstanceId)).(ec2types.Instance)
-			instanceTags := instance.NewInstance(ec2Instance).Tags
+			instanceTags := instance.NewInstance(ctx, ec2Instance).Tags
 
 			for tag, value := range expectedTags {
 				if lo.Contains(customTags, tag) {

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -15,12 +15,14 @@ limitations under the License.
 package instance
 
 import (
+	"context"
 	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/samber/lo"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 // Instance is an internal data representation of either an ec2.Instance or an ec2.FleetInstance
@@ -40,7 +42,7 @@ type Instance struct {
 	EFAEnabled            bool
 }
 
-func NewInstance(out ec2types.Instance) *Instance {
+func NewInstance(ctx context.Context, out ec2types.Instance) *Instance {
 	return &Instance{
 		LaunchTime: lo.FromPtr(out.LaunchTime),
 		State:      out.State.Name,
@@ -49,9 +51,13 @@ func NewInstance(out ec2types.Instance) *Instance {
 		Type:       out.InstanceType,
 		Zone:       lo.FromPtr(out.Placement.AvailabilityZone),
 		CapacityType: lo.If(out.SpotInstanceRequestId != nil, karpv1.CapacityTypeSpot).
-			ElseIf(out.CapacityReservationId != nil, karpv1.CapacityTypeReserved).
+			ElseIf(out.CapacityReservationId != nil && options.FromContext(ctx).FeatureGates.ReservedCapacity, karpv1.CapacityTypeReserved).
 			Else(karpv1.CapacityTypeOnDemand),
-		CapacityReservationID: lo.FromPtr(out.CapacityReservationId),
+		CapacityReservationID: lo.Ternary(
+			options.FromContext(ctx).FeatureGates.ReservedCapacity,
+			lo.FromPtr(out.CapacityReservationId),
+			"",
+		),
 		SecurityGroupIDs: lo.Map(out.SecurityGroups, func(securitygroup ec2types.GroupIdentifier, _ int) string {
 			return lo.FromPtr(securitygroup.GroupId)
 		}),

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -50,6 +50,9 @@ func NewInstance(ctx context.Context, out ec2types.Instance) *Instance {
 		ImageID:    lo.FromPtr(out.ImageId),
 		Type:       out.InstanceType,
 		Zone:       lo.FromPtr(out.Placement.AvailabilityZone),
+		// NOTE: Only set the capacity type to reserved and assign a reservation ID if the feature gate is enabled. It's
+		// possible for these to be set if the instance launched into an open ODCR, but treating it as reserved would induce
+		// drift.
 		CapacityType: lo.If(out.SpotInstanceRequestId != nil, karpv1.CapacityTypeSpot).
 			ElseIf(out.CapacityReservationId != nil && options.FromContext(ctx).FeatureGates.ReservedCapacity, karpv1.CapacityTypeReserved).
 			Else(karpv1.CapacityTypeOnDemand),

--- a/test/suites/integration/tags_test.go
+++ b/test/suites/integration/tags_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -110,7 +111,8 @@ var _ = Describe("Tags", func() {
 				g.Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1.AnnotationClusterNameTaggedCompatability, "true"))
 			}, time.Minute).Should(Succeed())
 
-			nodeInstance := instance.NewInstance(env.GetInstance(node.Name))
+			ctx := options.ToContext(env.Context, &options.Options{})
+			nodeInstance := instance.NewInstance(ctx, env.GetInstance(node.Name))
 			Expect(nodeInstance.Tags).To(HaveKeyWithValue("Name", node.Name))
 			Expect(nodeInstance.Tags).To(HaveKeyWithValue("karpenter.sh/nodeclaim", nodeClaim.Name))
 			Expect(nodeInstance.Tags).To(HaveKeyWithValue("eks:eks-cluster-name", env.ClusterName))
@@ -147,7 +149,8 @@ var _ = Describe("Tags", func() {
 				g.Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1.AnnotationClusterNameTaggedCompatability, "true"))
 			}, time.Minute).Should(Succeed())
 
-			nodeInstance := instance.NewInstance(env.GetInstance(node.Name))
+			ctx := options.ToContext(env.Context, &options.Options{})
+			nodeInstance := instance.NewInstance(ctx, env.GetInstance(node.Name))
 			Expect(nodeInstance.Tags).To(HaveKeyWithValue("Name", "custom-name"))
 			Expect(nodeInstance.Tags).To(HaveKeyWithValue("karpenter.sh/nodeclaim", nodeClaim.Name))
 			Expect(nodeInstance.Tags).To(HaveKeyWithValue("eks:eks-cluster-name", env.ClusterName))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7866 <!-- issue number -->

**Description**
On 1.3.0 and 1.3.1, Karpenter will initiate drift whenever an instance is launched into an open ODCR when the `ReservedCapacity` flag is set to false. This is due to insufficient gating when generating instances, resulting in a capacity reservation label being added to the node / nodeclaim. This then triggers dynamic drift since the reservation is not resolved by the nodeclass.

Note: this should only impact NodeClaims created after an upgrade to v1.3+. NodeClaims created previously won't have the `karpenter.k8s.aws/capacity-reservation-id` label which is responsible for initiating drift.

**How was this change tested?**
- manual testing
- `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.