### PR TITLE
fix: Fix spot pricing data being overridden when fetched

### DIFF
--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -322,7 +322,7 @@ var _ = Describe("CloudProvider", func() {
 			awsEnv.EC2API.DescribeInstanceTypesOutput.Set(&ec2.DescribeInstanceTypesOutput{InstanceTypes: instances})
 			awsEnv.EC2API.DescribeInstanceTypeOfferingsOutput.Set(&ec2.DescribeInstanceTypeOfferingsOutput{InstanceTypeOfferings: fake.MakeInstanceOfferings(instances)})
 			now := time.Now()
-			awsEnv.EC2API.DescribeSpotPriceHistoryOutput.Set(&ec2.DescribeSpotPriceHistoryOutput{
+			awsEnv.EC2API.DescribeSpotPriceHistoryBehavior.Output.Set(&ec2.DescribeSpotPriceHistoryOutput{
 				SpotPriceHistory: []ec2types.SpotPrice{
 					{
 						AvailabilityZone: aws.String("test-zone-1a"),
@@ -420,7 +420,7 @@ var _ = Describe("CloudProvider", func() {
 			awsEnv.EC2API.DescribeInstanceTypesOutput.Set(&ec2.DescribeInstanceTypesOutput{InstanceTypes: instances})
 			awsEnv.EC2API.DescribeInstanceTypeOfferingsOutput.Set(&ec2.DescribeInstanceTypeOfferingsOutput{InstanceTypeOfferings: fake.MakeInstanceOfferings(instances)})
 			now := time.Now()
-			awsEnv.EC2API.DescribeSpotPriceHistoryOutput.Set(&ec2.DescribeSpotPriceHistoryOutput{
+			awsEnv.EC2API.DescribeSpotPriceHistoryBehavior.Output.Set(&ec2.DescribeSpotPriceHistoryOutput{
 				SpotPriceHistory: []ec2types.SpotPrice{
 					{
 						AvailabilityZone: aws.String("test-zone-1a"),
@@ -519,7 +519,7 @@ var _ = Describe("CloudProvider", func() {
 			awsEnv.EC2API.DescribeInstanceTypesOutput.Set(&ec2.DescribeInstanceTypesOutput{InstanceTypes: uniqInstanceTypes})
 			awsEnv.EC2API.DescribeInstanceTypeOfferingsOutput.Set(&ec2.DescribeInstanceTypeOfferingsOutput{InstanceTypeOfferings: fake.MakeInstanceOfferings(uniqInstanceTypes)})
 			now := time.Now()
-			awsEnv.EC2API.DescribeSpotPriceHistoryOutput.Set(&ec2.DescribeSpotPriceHistoryOutput{
+			awsEnv.EC2API.DescribeSpotPriceHistoryBehavior.Output.Set(&ec2.DescribeSpotPriceHistoryOutput{
 				SpotPriceHistory: []ec2types.SpotPrice{
 					{
 						AvailabilityZone: aws.String("test-zone-1a"),

--- a/pkg/fake/atomic.go
+++ b/pkg/fake/atomic.go
@@ -158,7 +158,14 @@ func (a *AtomicPtrSlice[T]) Pop() *T {
 
 	last := a.values[len(a.values)-1]
 	a.values = a.values[0 : len(a.values)-1]
-	return last
+	return clone(last)
+}
+
+func (a *AtomicPtrSlice[T]) At(index int) *T {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return clone(a.values[index])
 }
 
 func (a *AtomicPtrSlice[T]) ForEach(fn func(*T)) {

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -55,8 +55,7 @@ type EC2Behavior struct {
 	DescribeInstanceTypesOutput         AtomicPtr[ec2.DescribeInstanceTypesOutput]
 	DescribeInstanceTypeOfferingsOutput AtomicPtr[ec2.DescribeInstanceTypeOfferingsOutput]
 	DescribeAvailabilityZonesOutput     AtomicPtr[ec2.DescribeAvailabilityZonesOutput]
-	DescribeSpotPriceHistoryInput       AtomicPtr[ec2.DescribeSpotPriceHistoryInput]
-	DescribeSpotPriceHistoryOutput      AtomicPtr[ec2.DescribeSpotPriceHistoryOutput]
+	DescribeSpotPriceHistoryBehavior    MockedFunction[ec2.DescribeSpotPriceHistoryInput, ec2.DescribeSpotPriceHistoryOutput]
 	CreateFleetBehavior                 MockedFunction[ec2.CreateFleetInput, ec2.CreateFleetOutput]
 	TerminateInstancesBehavior          MockedFunction[ec2.TerminateInstancesInput, ec2.TerminateInstancesOutput]
 	DescribeInstancesBehavior           MockedFunction[ec2.DescribeInstancesInput, ec2.DescribeInstancesOutput]
@@ -99,8 +98,7 @@ func (e *EC2API) Reset() {
 	e.DescribeInstancesBehavior.Reset()
 	e.CreateLaunchTemplateBehavior.Reset()
 	e.CalledWithDescribeImagesInput.Reset()
-	e.DescribeSpotPriceHistoryInput.Reset()
-	e.DescribeSpotPriceHistoryOutput.Reset()
+	e.DescribeSpotPriceHistoryBehavior.Reset()
 	e.Instances.Range(func(k, v any) bool {
 		e.Instances.Delete(k)
 		return true
@@ -718,16 +716,10 @@ func (e *EC2API) DescribeInstanceTypeOfferings(_ context.Context, _ *ec2.Describ
 }
 
 func (e *EC2API) DescribeSpotPriceHistory(_ context.Context, input *ec2.DescribeSpotPriceHistoryInput, _ ...func(*ec2.Options)) (*ec2.DescribeSpotPriceHistoryOutput, error) {
-	e.DescribeSpotPriceHistoryInput.Set(input)
-	if !e.NextError.IsNil() {
-		defer e.NextError.Reset()
-		return nil, e.NextError.Get()
-	}
-	if !e.DescribeSpotPriceHistoryOutput.IsNil() {
-		return e.DescribeSpotPriceHistoryOutput.Clone(), nil
-	}
-	// fail if the test doesn't provide specific data which causes our pricing provider to use its static price list
-	return nil, errors.New("no pricing data provided")
+	return e.DescribeSpotPriceHistoryBehavior.Invoke(input, func(input *ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
+		// fail if the test doesn't provide specific data which causes our pricing provider to use its static price list
+		return nil, errors.New("no pricing data provided")
+	})
 }
 
 func (e *EC2API) RunInstances(ctx context.Context, input *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error) {

--- a/pkg/fake/types.go
+++ b/pkg/fake/types.go
@@ -15,14 +15,21 @@ limitations under the License.
 package fake
 
 import (
+	"reflect"
+	"sync"
 	"sync/atomic"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
 )
 
 type MockedFunction[I any, O any] struct {
-	Output          AtomicPtr[O]      // Output to return on call to this function
+	Output          AtomicPtr[O] // Output to return on call to this function
+	OutputPages     AtomicPtrSlice[O]
 	CalledWithInput AtomicPtrSlice[I] // Slice used to keep track of passed input to this function
 	Error           AtomicError       // Error to return a certain number of times defined by custom error options
 
+	pageMapping     sync.Map     // token uuid -> page number: Internal construct to keep track of the page that we are on
 	successfulCalls atomic.Int32 // Internal construct to keep track of the number of times this function has successfully been called
 	failedCalls     atomic.Int32 // Internal construct to keep track of the number of times this function has failed (with error)
 }
@@ -31,11 +38,13 @@ type MockedFunction[I any, O any] struct {
 // each other.
 func (m *MockedFunction[I, O]) Reset() {
 	m.Output.Reset()
+	m.OutputPages.Reset()
 	m.CalledWithInput.Reset()
 	m.Error.Reset()
 
 	m.successfulCalls.Store(0)
 	m.failedCalls.Store(0)
+	m.pageMapping.Clear()
 }
 
 func (m *MockedFunction[I, O]) Invoke(input *I, defaultTransformer func(*I) (*O, error)) (*O, error) {
@@ -50,6 +59,23 @@ func (m *MockedFunction[I, O]) Invoke(input *I, defaultTransformer func(*I) (*O,
 	if !m.Output.IsNil() {
 		m.successfulCalls.Add(1)
 		return m.Output.Clone(), nil
+	}
+	// This output pages multi-threaded handling isn't perfect
+	// It will fail if pages are asynchronously requested from the same NextToken
+	if m.OutputPages.Len() > 0 {
+		token := uuid.New().String() // generate a token so that each paginated request set gets its own mapping
+		if !reflect.ValueOf(input).Elem().FieldByName("NextToken").Elem().CanSet() {
+			m.pageMapping.Store(token, 0)
+		} else {
+			token = reflect.ValueOf(input).Elem().FieldByName("NextToken").Elem().String()
+		}
+		pageNum := lo.Must(m.pageMapping.Load(token)).(int)
+		page := m.OutputPages.At(pageNum)
+		if pageNum < m.OutputPages.Len()-1 {
+			reflect.ValueOf(page).Elem().FieldByName("NextToken").Set(reflect.ValueOf(lo.ToPtr(token)))
+		}
+		m.pageMapping.Store(token, pageNum+1)
+		return page, nil
 	}
 	out, err := defaultTransformer(input)
 	if err != nil {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -472,7 +472,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-		awsEnv.EC2API.DescribeSpotPriceHistoryOutput.Set(generateSpotPricing(cloudProvider, nodePool))
+		awsEnv.EC2API.DescribeSpotPriceHistoryBehavior.Output.Set(generateSpotPricing(cloudProvider, nodePool))
 		Expect(awsEnv.PricingProvider.UpdateSpotPricing(ctx)).To(Succeed())
 		Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypes(ctx)).To(Succeed())
 		Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypeOfferings(ctx)).To(Succeed())
@@ -2219,7 +2219,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 		})
 		It("should fail to launch capacity when there is no zonal availability for spot", func() {
 			now := time.Now()
-			awsEnv.EC2API.DescribeSpotPriceHistoryOutput.Set(&ec2.DescribeSpotPriceHistoryOutput{
+			awsEnv.EC2API.DescribeSpotPriceHistoryBehavior.Output.Set(&ec2.DescribeSpotPriceHistoryOutput{
 				SpotPriceHistory: []ec2types.SpotPrice{
 					{
 						AvailabilityZone: aws.String("test-zone-1a"),
@@ -2245,7 +2245,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 		})
 		It("should succeed to launch spot instance when zonal availability exists", func() {
 			now := time.Now()
-			awsEnv.EC2API.DescribeSpotPriceHistoryOutput.Set(&ec2.DescribeSpotPriceHistoryOutput{
+			awsEnv.EC2API.DescribeSpotPriceHistoryBehavior.Output.Set(&ec2.DescribeSpotPriceHistoryOutput{
 				SpotPriceHistory: []ec2types.SpotPrice{
 					{
 						AvailabilityZone: aws.String("test-zone-1a"),

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -78,6 +77,19 @@ type DefaultProvider struct {
 type zonal struct {
 	defaultPrice float64 // Used until we get the spot pricing data
 	prices       map[string]float64
+}
+
+func combineZonalPricing(pricingData ...zonal) zonal {
+	z := newZonalPricing(0)
+	for _, elem := range pricingData {
+		if elem.defaultPrice != 0 {
+			z.defaultPrice = elem.defaultPrice
+		}
+		for zone, price := range elem.prices {
+			z.prices[zone] = price
+		}
+	}
+	return z
 }
 
 func newZonalPricing(defaultPrice float64) zonal {
@@ -218,7 +230,8 @@ func (p *DefaultProvider) UpdateOnDemandPricing(ctx context.Context) error {
 		return fmt.Errorf("no on-demand pricing found")
 	}
 
-	p.onDemandPrices = lo.Assign(onDemandPrices, onDemandMetalPrices)
+	// Maintain previously retrieved pricing data
+	p.onDemandPrices = lo.Assign(p.onDemandPrices, onDemandPrices, onDemandMetalPrices)
 	if p.cm.HasChanged("on-demand-prices", p.onDemandPrices) {
 		log.FromContext(ctx).WithValues("instance-type-count", len(p.onDemandPrices)).V(1).Info("updated on-demand pricing")
 	}
@@ -374,25 +387,24 @@ func (p *DefaultProvider) UpdateSpotPricing(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("retrieving spot pricing data, %w", err)
 		}
-		prices = lo.Assign(prices, p.spotPage(ctx, output))
+		for it, z := range p.spotPage(ctx, output) {
+			prices[it] = combineZonalPricing(prices[it], z)
+		}
 	}
 	if len(prices) == 0 {
 		return fmt.Errorf("no spot pricing found")
 	}
-
 	totalOfferings := 0
 	for it, zoneData := range prices {
-		if _, ok := p.spotPrices[it]; !ok {
-			p.spotPrices[it] = newZonalPricing(0)
-		}
-		maps.Copy(p.spotPrices[it].prices, zoneData.prices)
+		// Maintain previously retrieved pricing data
+		p.spotPrices[it] = combineZonalPricing(p.spotPrices[it], zoneData)
 		totalOfferings += len(zoneData.prices)
 	}
 
 	p.spotPricingUpdated = true
 	if p.cm.HasChanged("spot-prices", p.spotPrices) {
 		log.FromContext(ctx).WithValues(
-			"instance-type-count", len(p.onDemandPrices),
+			"instance-type-count", len(p.spotPrices),
 			"offering-count", totalOfferings).V(1).Info("updated spot pricing with instance types and offerings")
 	}
 	return nil


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Spot pricing information was being incorrectly assigned to the [spotPrices map](https://github.com/aws/karpenter-provider-aws/blob/main/pkg/providers/pricing/pricing.go#L70). This bug was caused by https://github.com/aws/karpenter-provider-aws/pull/7198, specifically on [this line](https://github.com/aws/karpenter-provider-aws/blob/main/pkg/providers/pricing/pricing.go#L377) where we fully override the zonalData from a previous page. This meant that if a previous page had different zones, we wouldn't maintain that zone pricing information and would fully override it.

Practically, this would mean that we would report that certain AZs didn't have spot availability when the API actually did report that there was spot availability there

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.