### PR TITLE
Fix: Properly Ignore sigs.k8s.io/karpenter package in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # We are currently pinning to pseudo-version for sigs.k8s.io/karpenter package, so that we can take later changes into the AWS provider. 
+      # This may change later, but this is how we have it configured right now.
+      # https://github.com/aws/karpenter-provider-aws/issues/7826
+      - dependency-name: sigs.k8s.io/karpenter 
     groups:
       # Group updates together, so that they are all applied in a single PR.
       # Grouped updates are currently in beta and is subject to change.

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
       # We are currently pinning to pseudo-version for sigs.k8s.io/karpenter package, so that we can take later changes into the AWS provider. 
       # This may change later, but this is how we have it configured right now.
       # https://github.com/aws/karpenter-provider-aws/issues/7826
-      - dependency-name: sigs.k8s.io/karpenter 
+      - dependency-name: sigs.k8s.io/karpenter
     groups:
       # Group updates together, so that they are all applied in a single PR.
       # Grouped updates are currently in beta and is subject to change.


### PR DESCRIPTION
### What this PR does  
This PR fixes an issue where Dependabot continues to create PRs to update `sigs.k8s.io/karpenter`, despite the `exclude-patterns` configuration in `dependabot.yaml`. 

### Root Cause  
The `exclude-patterns` directive only applies to dependencies within a defined Dependabot group. However, when Dependabot processes dependencies outside of groups, it treats them as standalone dependencies and continues creating PRs. This is why PRs for `sigs.k8s.io/karpenter` were still being generated.

You can distinguish between grouped and standalone dependency updates by checking the PR titles:
- **Standalone package update (without a group name):**  https://github.com/aws/karpenter-provider-aws/pull/7819/files
- **Grouped package update (with a group name):**  https://github.com/aws/karpenter-provider-aws/pull/7909/files

### Solution  
To fully prevent Dependabot from bumping `sigs.k8s.io/karpenter`, we have to use `ignore` directive. This explicitly tells Dependabot to ignore updates for this package across all dependency updates.

Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#ignoring-specific-dependencies

### Verification  
- After applying this change, Dependabot should no longer generate PRs for `sigs.k8s.io/karpenter` updates.
- Existing dependencies should still receive updates as expected.

### References  
- Issue: https://github.com/aws/karpenter-provider-aws/issues/7826
