### PR TITLE
test: Add e2etests for checking metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -87,9 +88,11 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/PuerkitoBio/goquery v1.10.2 h1:7fh2BdHcG6VFZsK7toXBT/Bh1z5Wmy8Q9MV9Hq
 github.com/PuerkitoBio/goquery v1.10.2/go.mod h1:0guWGjcLu9AYC7C1GHnpysHy056u9aEkUHwhdnePMCU=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/amazon-vpc-resource-controller-k8s v1.6.3 h1:B4o15iZP8CQoyDjoNAoQiyEPabLsgxXLY5tv3uvvCic=
@@ -112,6 +114,8 @@ github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/Z
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -144,6 +148,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -151,6 +157,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.23.0 h1:FA1xjp8ieYDzlgS5ABTpdUDB7wtngggONc8a7ku2NqQ=

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -15,11 +15,16 @@ limitations under the License.
 package common
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"math"
+	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,8 +39,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport"
+	"k8s.io/client-go/transport/spdy"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,6 +53,10 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/test"
 	coreresources "sigs.k8s.io/karpenter/pkg/utils/resources"
+)
+
+var (
+	prometheusMetricRegex = regexp.MustCompile(`(?P<Name>.*){(?P<Labels>.*)} (?P<Value>\d*(?:\.\d*)?)`)
 )
 
 func (env *Environment) ExpectCreated(objects ...client.Object) {
@@ -402,6 +414,91 @@ func (env *Environment) ExpectKarpenterLeaseOwnerChanged() {
 			return p.Name == name
 		})).To(BeTrue())
 	}).Should(Succeed())
+}
+
+func (env *Environment) ExpectPodPortForwarded(ctx context.Context, pod *corev1.Pod, podPort, localPort int) {
+	GinkgoHelper()
+
+	roundTripper, upgrader, err := spdy.RoundTripperFor(env.Config)
+	Expect(err).ToNot(HaveOccurred())
+
+	serverURL := env.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(pod.Namespace).
+		Name(pod.Name).
+		SubResource("portforward").URL()
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, serverURL)
+
+	ready := make(chan struct{})
+	stop := make(chan struct{})
+	go func() {
+		GinkgoRecover()
+		<-ctx.Done()
+		close(stop)
+	}()
+	go func() {
+		fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, podPort)}, stop, ready, io.Discard, io.Discard)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fw.ForwardPorts())
+	}()
+	<-ready
+}
+
+type PrometheusMetric struct {
+	Name   string
+	Labels map[string]string
+	Value  float64
+}
+
+func (env *Environment) ExpectPodMetrics() (res []PrometheusMetric) {
+	GinkgoHelper()
+
+	ctx, cancel := context.WithCancel(env.Context)
+	defer cancel()
+
+	localPort := rand.IntnRange(1024, 49151)
+	env.ExpectPodPortForwarded(ctx, env.ExpectActiveKarpenterPod(), 8080, localPort)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", localPort))
+	Expect(err).ToNot(HaveOccurred())
+	reader := bufio.NewReader(resp.Body)
+	defer resp.Body.Close()
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			//nolint:errorlint
+			if err == io.EOF {
+				break
+			}
+			continue
+		}
+		metric, err := parseMetricsLine(string(line))
+		if err != nil {
+			continue
+		}
+		res = append(res, metric)
+	}
+	return res
+}
+
+func parseMetricsLine(line string) (metric PrometheusMetric, err error) {
+	groups := prometheusMetricRegex.FindStringSubmatch(line)
+	if len(groups) != 4 {
+		return PrometheusMetric{}, fmt.Errorf("metrics line doesn't match known prometheus syntax")
+	}
+
+	elems := strings.Split(groups[2], ",")
+	l := lo.SliceToMap(elems, func(elem string) (string, string) {
+		temp := strings.Split(elem, "=")
+		k, v := temp[0], temp[1]
+		return k, strings.Trim(v, "\"")
+	})
+	v, err := strconv.ParseFloat(groups[3], 64)
+	if err != nil {
+		return PrometheusMetric{}, fmt.Errorf("converting metrics value to an integer, %w", err)
+	}
+	return PrometheusMetric{Name: groups[1], Labels: l, Value: v}, nil
 }
 
 func (env *Environment) EventuallyExpectRollout(name, namespace string) {

--- a/test/suites/integration/metrics_test.go
+++ b/test/suites/integration/metrics_test.go
@@ -1,0 +1,87 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	"github.com/aws/karpenter-provider-aws/test/pkg/environment/common"
+)
+
+var _ = Describe("Metrics", func() {
+	var instanceTypeCount int
+	var availabilityZoneCount int
+	var capacityTypeCount int
+	BeforeEach(func() {
+		azOut, err := env.EC2API.DescribeAvailabilityZones(env.Context, &ec2.DescribeAvailabilityZonesInput{})
+		Expect(err).ToNot(HaveOccurred())
+		availabilityZoneCount = len(azOut.AvailabilityZones)
+
+		itOut, err := env.EC2API.DescribeInstanceTypes(env.Context, &ec2.DescribeInstanceTypesInput{})
+		Expect(err).ToNot(HaveOccurred())
+		instanceTypeCount = len(itOut.InstanceTypes)
+		capacityTypeCount = 3 // on-demand, spot, and reserved
+	})
+	It("should expose karpenter_cloudprovider_instance_type_offering_price_estimate metrics", func() {
+		env.ExpectCreated(nodeClass, nodePool)
+		Eventually(func(g Gomega) {
+			defer GinkgoRecover()
+			podMetrics := env.ExpectPodMetrics()
+			priceMetricCount := lo.CountBy(podMetrics, func(p common.PrometheusMetric) bool {
+				return p.Name == "karpenter_cloudprovider_instance_type_offering_price_estimate"
+			})
+			nonZeroPriceMetricCount := lo.CountBy(podMetrics, func(p common.PrometheusMetric) bool {
+				return p.Name == "karpenter_cloudprovider_instance_type_offering_price_estimate" &&
+					p.Value > 0
+			})
+			// We provide a 100 instance type buffer just in case instance types don't have offerings in every zone
+			// We provide a 200 instance type buffer for spot since there should be even less availability
+			expectedCount := (instanceTypeCount - 100) * availabilityZoneCount * capacityTypeCount
+			expectedNonZeroCount := (instanceTypeCount-100)*availabilityZoneCount + (instanceTypeCount-200)*availabilityZoneCount
+			g.Expect(priceMetricCount).To(BeNumerically(">", expectedCount))
+			g.Expect(nonZeroPriceMetricCount).To(BeNumerically(">", expectedNonZeroCount))
+		}, time.Minute, time.Second*5).Should(Succeed())
+
+	})
+	It("should expose karpenter_cloudprovider_instance_type_offering_available metrics", func() {
+		env.ExpectCreated(nodeClass, nodePool)
+		// Availability only has non-zero values for the subnets that we support
+		selectedAZCount := len(env.GetSubnets(map[string]string{"karpenter.sh/discovery": env.ClusterName}))
+
+		Eventually(func(g Gomega) {
+			defer GinkgoRecover()
+
+			podMetrics := env.ExpectPodMetrics()
+			availableMetricCount := lo.CountBy(podMetrics, func(p common.PrometheusMetric) bool {
+				return p.Name == "karpenter_cloudprovider_instance_type_offering_available"
+			})
+			nonZeroAvailableMetricCount := lo.CountBy(podMetrics, func(p common.PrometheusMetric) bool {
+				return p.Name == "karpenter_cloudprovider_instance_type_offering_available" &&
+					p.Value > 0
+			})
+			// We provide a 100 instance type buffer just in case instance types don't have offerings in every zone
+			// We provide a 200 instance type buffer for spot since there should be even less availability
+			expectedCount := (instanceTypeCount - 100) * selectedAZCount * capacityTypeCount
+			expectedNonZeroCount := (instanceTypeCount-100)*selectedAZCount + (instanceTypeCount-200)*selectedAZCount
+			g.Expect(availableMetricCount).To(BeNumerically(">", expectedCount))
+			g.Expect(nonZeroAvailableMetricCount).To(BeNumerically(">", expectedNonZeroCount))
+		}, time.Minute, time.Second*5).Should(Succeed())
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add e2etests for validating that a minimum number of metrics are returned back from Karpenter. This would have prevented the regression that was fixed in #7877.

The testing port-forwards the pods and directly hits their metrics endpoints, parsing the metrics, and ensuring the count of metrics is over a certain amount (which is estimated from the number of instance types/subnets that we support).

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.