### PR TITLE
doc: Updating CRD description for KmsKeyID to indicate that the field is not limited to ID or ARN

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -184,7 +184,7 @@ spec:
                             format: int64
                             type: integer
                           kmsKeyID:
-                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            description: Identifier (key ID, key alias, key ARN, or alias ARN) of the customer managed KMS key to use for EBS encryption.
                             type: string
                           snapshotID:
                             description: SnapshotID is the ID of an EBS snapshot

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -181,7 +181,7 @@ spec:
                             format: int64
                             type: integer
                           kmsKeyID:
-                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            description: Identifier (key ID, key alias, key ARN, or alias ARN) of the customer managed KMS key to use for EBS encryption.
                             type: string
                           snapshotID:
                             description: SnapshotID is the ID of an EBS snapshot

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -391,7 +391,7 @@ type BlockDevice struct {
 	// is not supported for gp2, st1, sc1, or standard volumes.
 	// +optional
 	IOPS *int64 `json:"iops,omitempty"`
-	// KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+	// Identifier (key ID, key alias, key ARN, or alias ARN) of the customer managed KMS key to use for EBS encryption.
 	// +optional
 	KMSKeyID *string `json:"kmsKeyID,omitempty"`
 	// SnapshotID is the ID of an EBS snapshot


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #3643 

**Description**
Update the CRD description for the KmsKeyID field to indicate all possible values.

Despite what the CRD says, Karpenter passes the value provided to the launch template [here](https://github.com/aws/karpenter-provider-aws/blob/main/pkg/providers/launchtemplate/launchtemplate.go#L370), which according to [`create-launch-template`](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-launch-template.html) is:

> Identifier (key ID, key alias, key ARN, or alias ARN) of the customer managed KMS key to use for EBS encryption.

**How was this change tested?**
Documentation only change.

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.