### PR TITLE
fix: ami discovery error message

### DIFF
--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -41,6 +41,7 @@ type AL2 struct {
 
 func (a AL2) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
 	ids := map[string][]Variant{}
+	var errs []error
 	for path, variants := range map[string][]Variant{
 		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/%s/image_id", k8sVersion, lo.Ternary(
 			amiVersion == v1.AliasVersionLatest,
@@ -63,12 +64,20 @@ func (a AL2) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k
 			IsMutable: amiVersion == v1.AliasVersionLatest,
 		})
 		if err != nil {
+			errs = append(errs, err)
 			continue
 		}
 		ids[imageID] = variants
 	}
 	// Failed to discover any AMIs, we should short circuit AMI discovery
 	if len(ids) == 0 {
+		if len(errs) > 0 {
+			return DescribeImageQuery{}, fmt.Errorf(
+				`failed to discover any AMIs for alias "al2@%s": one of the errors was: %w`,
+				amiVersion,
+				errs[0],
+			)
+		}
 		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "al2@%s"`, amiVersion)
 	}
 

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -52,7 +52,7 @@ func (w Windows) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provide
 		IsMutable: true,
 	})
 	if err != nil {
-		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "windows%s@%s"`, w.Version, amiVersion)
+		return DescribeImageQuery{}, fmt.Errorf(`failed to discover any AMIs for alias "windows%s@%s": %w`, w.Version, amiVersion, err)
 	}
 	return DescribeImageQuery{
 		Filters: []ec2types.Filter{{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7723 <!-- issue number -->

**Description**

This PR improves the error message when AMI discovery fails for a given alias.
When an error occurs, this change appends an SSM parameter fetch-related error to the existing error message. If multiple errors are present, only one representative error message is included to improve readability.

**How was this change tested?**

When actually executed, the error appears as follows:

```
{"level":"ERROR","time":"2025-03-22T01:33:27.024Z","logger":"controller","caller":"controller/controller.go:288","message":"Reconciler error","commit":"5d32d5d-dirty","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"default"},"namespace":"","name":"default","reconcileID":"2c4a9ac7-4131-43ce-b9d1-fb120cbf62a2","error":"getting amis, getting AMI queries, failed to discover any AMIs for alias \"bottlerocket@latest\": one of the errors was: getting ssm parameter \"/aws/service/bottlerocket/aws-k8s-1.32/x86_64/latest/image_id\", operation error SSM: GetParameter, https response error StatusCode: 400, RequestID: 55a5a65b-3fb7-41ba-9d8c-001b81a179b3, api error AccessDeniedException: User: arn:aws:sts::xxxxxxxxxx:assumed-role/KarpenterController-xxxxxxxx/eks-karpenter-karpenter is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:ap-northeast-1::parameter/aws/service/bottlerocket/aws-k8s-1.32/x86_64/latest/image_id because no identity-based policy allows the ssm:GetParameter action"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.