### PR TITLE
fix: Add ClusterCIDRReady condition

### DIFF
--- a/pkg/apis/v1/ec2nodeclass_status.go
+++ b/pkg/apis/v1/ec2nodeclass_status.go
@@ -30,6 +30,7 @@ const (
 	ConditionTypeAMIsReady                 = "AMIsReady"
 	ConditionTypeInstanceProfileReady      = "InstanceProfileReady"
 	ConditionTypeCapacityReservationsReady = "CapacityReservationsReady"
+	ConditionTypeClusterCIDRReady          = "ClusterCIDRReady"
 	ConditionTypeValidationSucceeded       = "ValidationSucceeded"
 )
 
@@ -129,6 +130,7 @@ func (in *EC2NodeClass) StatusConditions() status.ConditionSet {
 		ConditionTypeSubnetsReady,
 		ConditionTypeSecurityGroupsReady,
 		ConditionTypeInstanceProfileReady,
+		ConditionTypeClusterCIDRReady,
 		ConditionTypeValidationSucceeded,
 	}
 	if CapacityReservationsEnabled {

--- a/pkg/controllers/nodeclass/readiness.go
+++ b/pkg/controllers/nodeclass/readiness.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/awslabs/operatorpkg/status"
-
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -43,9 +41,10 @@ func (n Readiness) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (r
 	// will not be done at startup but instead in a reconcile loop.
 	if nodeClass.AMIFamily() == v1.AMIFamilyAL2023 {
 		if err := n.launchTemplateProvider.ResolveClusterCIDR(ctx); err != nil {
-			nodeClass.StatusConditions().SetFalse(status.ConditionReady, "NodeClassNotReady", "Failed to detect the cluster CIDR")
+			nodeClass.StatusConditions().SetFalse(v1.ConditionTypeClusterCIDRReady, "ClusterCIDRNotResolved", "Failed to detect the cluster CIDR")
 			return reconcile.Result{}, fmt.Errorf("failed to detect the cluster CIDR, %w", err)
 		}
 	}
+    nodeClass.StatusConditions().SetTrue(v1.ConditionTypeClusterCIDRReady)
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclass/readiness_test.go
+++ b/pkg/controllers/nodeclass/readiness_test.go
@@ -57,7 +57,7 @@ var _ = Describe("NodeClass Status Condition Controller", func() {
 			ExpectApplied(ctx, env.Client, nodeClass)
 			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
-			Expect(nodeClass.Status.Conditions).To(HaveLen(lo.Ternary(reservedCapacity, 7, 6)))
+			Expect(nodeClass.Status.Conditions).To(HaveLen(lo.Ternary(reservedCapacity, 8, 7)))
 			Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsTrue()).To(BeTrue())
 		},
 		Entry("when reserved capacity feature flag is enabled", true),

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -268,6 +268,7 @@ func (*Validation) requiredConditions() []string {
 		v1.ConditionTypeInstanceProfileReady,
 		v1.ConditionTypeSecurityGroupsReady,
 		v1.ConditionTypeSubnetsReady,
+		v1.ConditionTypeClusterCIDRReady,
 	}
 }
 

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -41,6 +41,7 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 				v1.ConditionTypeInstanceProfileReady,
 				v1.ConditionTypeSecurityGroupsReady,
 				v1.ConditionTypeSubnetsReady,
+				v1.ConditionTypeClusterCIDRReady,
 			} {
 				nodeClass.StatusConditions().SetTrue(cond)
 			}
@@ -58,6 +59,7 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 			Entry(v1.ConditionTypeInstanceProfileReady, v1.ConditionTypeInstanceProfileReady),
 			Entry(v1.ConditionTypeSecurityGroupsReady, v1.ConditionTypeSecurityGroupsReady),
 			Entry(v1.ConditionTypeSubnetsReady, v1.ConditionTypeSubnetsReady),
+			Entry(v1.ConditionTypeClusterCIDRReady, v1.ConditionTypeClusterCIDRReady),
 		)
 		DescribeTable(
 			"should set validated status condition to unknown when no required condition is false and any are unknown",
@@ -72,6 +74,7 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 			Entry(v1.ConditionTypeInstanceProfileReady, v1.ConditionTypeInstanceProfileReady),
 			Entry(v1.ConditionTypeSecurityGroupsReady, v1.ConditionTypeSecurityGroupsReady),
 			Entry(v1.ConditionTypeSubnetsReady, v1.ConditionTypeSubnetsReady),
+			Entry(v1.ConditionTypeClusterCIDRReady, v1.ConditionTypeClusterCIDRReady),
 		)
 	})
 	Context("Tag Validation", func() {

--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -225,6 +225,9 @@ status:
     - lastTransitionTime: "2024-02-02T19:54:34Z"
       status: "True"
       type: Ready
+    - lastTransitionTime: "2024-02-02T19:54:34Z"
+      status: 'True'
+      type: ClusterCIDRReady
 ```
 Refer to the [NodePool docs]({{<ref "./nodepools" >}}) for settings applicable to all providers. To explore various `EC2NodeClass` configurations, refer to the examples provided [in the Karpenter Github repository](https://github.com/aws/karpenter/blob/main/examples/v1/).
 
@@ -1655,7 +1658,8 @@ NodeClasses have the following status conditions:
 | SubnetsReady         | Subnets are discovered.                                                                                                                                                                                                           |
 | SecurityGroupsReady  | Security Groups are discovered.                                                                                                                                                                                                   |
 | InstanceProfileReady | Instance Profile is discovered.                                                                                                                                                                                                   |
-| AMIsReady            | AMIs are discovered.                                                |
+| AMIsReady            | AMIs are discovered.                                                                                                                                                                                                              |
+| ClusterCIDRReady     | Cluster CIDR is discovered (AL2023 only).                                                                                                                                                                                         |
 | Ready                | Top level condition that indicates if the nodeClass is ready. If any of the underlying conditions is `False` then this condition is set to `False` and `Message` on the condition indicates the dependency that was not resolved. |
 
 If a NodeClass is not ready, NodePools that reference it through their `nodeClassRef` will not be considered for scheduling.


### PR DESCRIPTION
Fixes #7875

### Summary 

This PR addresses an issue where EC2NodeClass resources using AL2023 AMI family would become stuck in a `NotReady` state after temporary EKS API unavailability. The problem occurs when attempting to resolve Cluster CIDR during reconciliation - if the API call fails, the resource remains in a NotReady state indefinitely, even after the API becomes available again. 

### Changes 
- Added a new condition type ConditionTypeClusterCIDRReady to track the status of Cluster CIDR resolution separately
- Modified the Readiness controller to manage this specific condition instead of directly setting the general Ready condition
- Added the new condition to the list of required conditions in the validation controller


### Tested by: 

1.  Creating an EC2NodeClass with AL2023 AMI family
2. Temporarily revoking EKS DescribeCluster permissions to simulate API unavailability
3. Verifying the EC2NodeClass transitions to `NotReady` state
4. Restoring permissions
5. Verifying the EC2NodeClass correctly transitions back to Ready state during the next reconciliation


**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.