### PR TITLE
refactor: instance profile provider

### DIFF
--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -491,11 +492,12 @@ func (in *EC2NodeClass) InstanceProfileRole() string {
 	return in.Spec.Role
 }
 
-func (in *EC2NodeClass) InstanceProfileTags(clusterName string) map[string]string {
+func (in *EC2NodeClass) InstanceProfileTags(clusterName string, region string) map[string]string {
 	return lo.Assign(in.Spec.Tags, map[string]string{
 		fmt.Sprintf("kubernetes.io/cluster/%s", clusterName): "owned",
-		EKSClusterNameTagKey: clusterName,
-		LabelNodeClass:       in.Name,
+		EKSClusterNameTagKey:   clusterName,
+		LabelNodeClass:         in.Name,
+		v1.LabelTopologyRegion: region,
 	})
 }
 

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -1186,7 +1186,7 @@ var _ = Describe("CloudProvider", func() {
 				{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(100),
 					Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}}},
 			}})
-			controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
+			controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, fake.DefaultRegion, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 			pod := coretest.UnschedulablePod(coretest.PodOptions{NodeSelector: map[string]string{corev1.LabelTopologyZone: "test-zone-1a"}})
@@ -1203,7 +1203,7 @@ var _ = Describe("CloudProvider", func() {
 				{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(11),
 					Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}}},
 			}})
-			controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
+			controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, fake.DefaultRegion, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				MaxPods: aws.Int32(1),
 			}
@@ -1242,7 +1242,7 @@ var _ = Describe("CloudProvider", func() {
 				Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}}})
 			nodeClass.Spec.SubnetSelectorTerms = []v1.SubnetSelectorTerm{{Tags: map[string]string{"Name": "test-subnet-1"}}}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-			controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
+			controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, fake.DefaultRegion, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
 			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 			podSubnet1 := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, podSubnet1)

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -88,7 +88,7 @@ func NewControllers(
 ) []controller.Controller {
 	controllers := []controller.Controller{
 		nodeclasshash.NewController(kubeClient),
-		nodeclass.NewController(clk, kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, launchTemplateProvider, capacityReservationProvider, ec2api, validationCache, amiResolver),
+		nodeclass.NewController(clk, kubeClient, recorder, cfg.Region, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, launchTemplateProvider, capacityReservationProvider, ec2api, validationCache, amiResolver),
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider),
 		nodeclaimtagging.NewController(kubeClient, cloudProvider, instanceProvider),
 		controllerspricing.NewController(pricingProvider),

--- a/pkg/controllers/nodeclass/capacityreservation_test.go
+++ b/pkg/controllers/nodeclass/capacityreservation_test.go
@@ -55,7 +55,7 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 					InstanceMatchCriteria:  ec2types.InstanceMatchCriteriaTargeted,
 					CapacityReservationId:  lo.ToPtr("cr-m5.large-1a-2"),
 					AvailableInstanceCount: lo.ToPtr[int32](10),
-					Tags:                   utils.MergeTags(discoveryTags),
+					Tags:                   utils.EC2MergeTags(discoveryTags),
 					State:                  ec2types.CapacityReservationStateActive,
 				},
 				{
@@ -74,7 +74,7 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 					InstanceMatchCriteria:  ec2types.InstanceMatchCriteriaTargeted,
 					CapacityReservationId:  lo.ToPtr("cr-m5.large-1b-2"),
 					AvailableInstanceCount: lo.ToPtr[int32](15),
-					Tags:                   utils.MergeTags(discoveryTags),
+					Tags:                   utils.EC2MergeTags(discoveryTags),
 					State:                  ec2types.CapacityReservationStateActive,
 				},
 			},

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -22,26 +22,34 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
 )
 
 type InstanceProfile struct {
 	instanceProfileProvider instanceprofile.Provider
+	region                  string
 }
 
-func NewInstanceProfileReconciler(instanceProfileProvider instanceprofile.Provider) *InstanceProfile {
+func NewInstanceProfileReconciler(instanceProfileProvider instanceprofile.Provider, region string) *InstanceProfile {
 	return &InstanceProfile{
 		instanceProfileProvider: instanceProfileProvider,
+		region:                  region,
 	}
 }
 
 func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	if nodeClass.Spec.Role != "" {
-		name, err := ip.instanceProfileProvider.Create(ctx, nodeClass)
-		if err != nil {
+		profileName := nodeClass.InstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
+		if err := ip.instanceProfileProvider.Create(
+			ctx,
+			profileName,
+			nodeClass.InstanceProfileRole(),
+			nodeClass.InstanceProfileTags(options.FromContext(ctx).ClusterName, ip.region),
+		); err != nil {
 			return reconcile.Result{}, fmt.Errorf("creating instance profile, %w", err)
 		}
-		nodeClass.Status.InstanceProfile = name
+		nodeClass.Status.InstanceProfile = profileName
 	} else {
 		nodeClass.Status.InstanceProfile = lo.FromPtr(nodeClass.Spec.InstanceProfile)
 	}

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -74,6 +74,7 @@ var _ = BeforeSuite(func() {
 		awsEnv.Clock,
 		env.Client,
 		events.NewRecorder(&record.FakeRecorder{}),
+		fake.DefaultRegion,
 		awsEnv.SubnetProvider,
 		awsEnv.SecurityGroupProvider,
 		awsEnv.AMIProvider,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -148,7 +148,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 
 	subnetProvider := subnet.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval), cache.New(awscache.AvailableIPAddressTTL, awscache.DefaultCleanupInterval), cache.New(awscache.AssociatePublicIPAddressTTL, awscache.DefaultCleanupInterval))
 	securityGroupProvider := securitygroup.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	instanceProfileProvider := instanceprofile.NewDefaultProvider(cfg.Region, iam.NewFromConfig(cfg), cache.New(awscache.InstanceProfileTTL, awscache.DefaultCleanupInterval))
+	instanceProfileProvider := instanceprofile.NewDefaultProvider(iam.NewFromConfig(cfg), cache.New(awscache.InstanceProfileTTL, awscache.DefaultCleanupInterval))
 	pricingProvider := pricing.NewDefaultProvider(
 		ctx,
 		pricing.NewAPI(cfg),

--- a/pkg/providers/capacityreservation/suite_test.go
+++ b/pkg/providers/capacityreservation/suite_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Capacity Reservation Provider", func() {
 				InstanceMatchCriteria:  ec2types.InstanceMatchCriteriaTargeted,
 				CapacityReservationId:  lo.ToPtr("cr-m5.large-1a-1"),
 				AvailableInstanceCount: lo.ToPtr[int32](10),
-				Tags:                   utils.MergeTags(discoveryTags),
+				Tags:                   utils.EC2MergeTags(discoveryTags),
 				State:                  ec2types.CapacityReservationStateActive,
 			},
 			{
@@ -83,7 +83,7 @@ var _ = Describe("Capacity Reservation Provider", func() {
 				InstanceMatchCriteria:  ec2types.InstanceMatchCriteriaTargeted,
 				CapacityReservationId:  lo.ToPtr("cr-m5.large-1a-2"),
 				AvailableInstanceCount: lo.ToPtr[int32](15),
-				Tags:                   utils.MergeTags(discoveryTags),
+				Tags:                   utils.EC2MergeTags(discoveryTags),
 				State:                  ec2types.CapacityReservationStateActive,
 			},
 		}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -309,9 +309,9 @@ func GetCreateFleetInput(nodeClass *v1.EC2NodeClass, capacityType string, tags m
 			TotalTargetCapacity: aws.Int32(1),
 		},
 		TagSpecifications: []ec2types.TagSpecification{
-			{ResourceType: ec2types.ResourceTypeInstance, Tags: utils.MergeTags(tags)},
-			{ResourceType: ec2types.ResourceTypeVolume, Tags: utils.MergeTags(tags)},
-			{ResourceType: ec2types.ResourceTypeFleet, Tags: utils.MergeTags(tags)},
+			{ResourceType: ec2types.ResourceTypeInstance, Tags: utils.EC2MergeTags(tags)},
+			{ResourceType: ec2types.ResourceTypeVolume, Tags: utils.EC2MergeTags(tags)},
+			{ResourceType: ec2types.ResourceTypeFleet, Tags: utils.EC2MergeTags(tags)},
 		},
 	}
 }

--- a/pkg/providers/instanceprofile/instanceprofile.go
+++ b/pkg/providers/instanceprofile/instanceprofile.go
@@ -19,122 +19,113 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
 	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
-	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/utils"
 )
 
-// ResourceOwner is an object that manages an instance profile
-type ResourceOwner interface {
-	GetUID() types.UID
-	InstanceProfileName(string, string) string
-	InstanceProfileRole() string
-	InstanceProfileTags(string) map[string]string
-}
-
 type Provider interface {
-	Create(context.Context, ResourceOwner) (string, error)
-	Delete(context.Context, ResourceOwner) error
+	Get(context.Context, string) (*iamtypes.InstanceProfile, error)
+	Create(context.Context, string, string, map[string]string) error
+	Delete(context.Context, string) error
 }
 
 type DefaultProvider struct {
-	region string
 	iamapi sdk.IAMAPI
-	cache  *cache.Cache
+	cache  *cache.Cache // instanceProfileName -> *iamtypes.InstanceProfile
 }
 
-func NewDefaultProvider(region string, iamapi sdk.IAMAPI, cache *cache.Cache) *DefaultProvider {
+func NewDefaultProvider(iamapi sdk.IAMAPI, cache *cache.Cache) *DefaultProvider {
 	return &DefaultProvider{
-		region: region,
 		iamapi: iamapi,
 		cache:  cache,
 	}
 }
 
-func (p *DefaultProvider) Create(ctx context.Context, m ResourceOwner) (string, error) {
-	profileName := m.InstanceProfileName(options.FromContext(ctx).ClusterName, p.region)
-	tags := map[string]string{}
-	if len(m.InstanceProfileTags(options.FromContext(ctx).ClusterName)) != 0 {
-		tags = lo.Assign(m.InstanceProfileTags(options.FromContext(ctx).ClusterName), map[string]string{corev1.LabelTopologyRegion: p.region})
+func (p *DefaultProvider) Get(ctx context.Context, instanceProfileName string) (*iamtypes.InstanceProfile, error) {
+	if instanceProfile, ok := p.cache.Get(instanceProfileName); ok {
+		return instanceProfile.(*iamtypes.InstanceProfile), nil
 	}
-	// An instance profile exists for this NodeClass
-	if _, ok := p.cache.Get(string(m.GetUID())); ok {
-		return profileName, nil
+	out, err := p.iamapi.GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{
+		InstanceProfileName: lo.ToPtr(instanceProfileName),
+	})
+	if err != nil {
+		return nil, err
 	}
-	// Validate if the instance profile exists and has the correct role assigned to it
-	var instanceProfile *iamtypes.InstanceProfile
-	out, err := p.iamapi.GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)})
+	p.cache.SetDefault(instanceProfileName, out.InstanceProfile)
+	return out.InstanceProfile, nil
+}
+
+func (p *DefaultProvider) Create(ctx context.Context, instanceProfileName string, roleName string, tags map[string]string) error {
+	instanceProfile, err := p.Get(ctx, instanceProfileName)
 	if err != nil {
 		if !awserrors.IsNotFound(err) {
-			return "", fmt.Errorf("getting instance profile %q, %w", profileName, err)
+			return fmt.Errorf("getting instance profile %q, %w", instanceProfileName, err)
 		}
 		o, err := p.iamapi.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
-			InstanceProfileName: aws.String(profileName),
-			Tags:                lo.MapToSlice(tags, func(k, v string) iamtypes.Tag { return iamtypes.Tag{Key: aws.String(k), Value: aws.String(v)} }),
+			InstanceProfileName: lo.ToPtr(instanceProfileName),
+			Tags:                utils.IAMMergeTags(tags),
 		})
 		if err != nil {
-			return "", fmt.Errorf("creating instance profile %q, %w", profileName, err)
+			return fmt.Errorf("creating instance profile %q, %w", instanceProfileName, err)
 		}
 		instanceProfile = o.InstanceProfile
-	} else {
-		instanceProfile = out.InstanceProfile
 	}
 	// Instance profiles can only have a single role assigned to them so this profile either has 1 or 0 roles
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 	if len(instanceProfile.Roles) == 1 {
-		if aws.ToString(instanceProfile.Roles[0].RoleName) == m.InstanceProfileRole() {
-			return profileName, nil
+		if lo.FromPtr(instanceProfile.Roles[0].RoleName) == roleName {
+			return nil
 		}
 		if _, err = p.iamapi.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
-			InstanceProfileName: aws.String(profileName),
+			InstanceProfileName: lo.ToPtr(instanceProfileName),
 			RoleName:            instanceProfile.Roles[0].RoleName,
 		}); err != nil {
-			return "", fmt.Errorf("removing role %q for instance profile %q, %w", aws.ToString(instanceProfile.Roles[0].RoleName), profileName, err)
+			return fmt.Errorf("removing role %q for instance profile %q, %w", lo.FromPtr(instanceProfile.Roles[0].RoleName), instanceProfileName, err)
 		}
 	}
 	// If the role has a path, ignore the path and take the role name only since AddRoleToInstanceProfile
 	// does not support paths in the role name.
-	instanceProfileRoleName := lo.LastOr(strings.Split(m.InstanceProfileRole(), "/"), m.InstanceProfileRole())
+	roleName = lo.LastOr(strings.Split(roleName, "/"), roleName)
 	if _, err = p.iamapi.AddRoleToInstanceProfile(ctx, &iam.AddRoleToInstanceProfileInput{
-		InstanceProfileName: aws.String(profileName),
-		RoleName:            aws.String(instanceProfileRoleName),
+		InstanceProfileName: lo.ToPtr(instanceProfileName),
+		RoleName:            lo.ToPtr(roleName),
 	}); err != nil {
-		return "", fmt.Errorf("adding role %q to instance profile %q, %w", m.InstanceProfileRole(), profileName, err)
+		return fmt.Errorf("adding role %q to instance profile %q, %w", roleName, instanceProfileName, err)
 	}
-	p.cache.SetDefault(string(m.GetUID()), nil)
-	return aws.ToString(instanceProfile.InstanceProfileName), nil
+	instanceProfile.Roles = []iamtypes.Role{{
+		RoleName: lo.ToPtr(roleName),
+	}}
+	p.cache.SetDefault(instanceProfileName, instanceProfile)
+	return nil
 }
 
-func (p *DefaultProvider) Delete(ctx context.Context, m ResourceOwner) error {
-	profileName := m.InstanceProfileName(options.FromContext(ctx).ClusterName, p.region)
+func (p *DefaultProvider) Delete(ctx context.Context, instanceProfileName string) error {
 	out, err := p.iamapi.GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{
-		InstanceProfileName: aws.String(profileName),
+		InstanceProfileName: lo.ToPtr(instanceProfileName),
 	})
 	if err != nil {
-		return awserrors.IgnoreNotFound(fmt.Errorf("getting instance profile %q, %w", profileName, err))
+		return awserrors.IgnoreNotFound(fmt.Errorf("getting instance profile %q, %w", instanceProfileName, err))
 	}
 	// Instance profiles can only have a single role assigned to them so this profile either has 1 or 0 roles
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 	if len(out.InstanceProfile.Roles) == 1 {
 		if _, err = p.iamapi.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
-			InstanceProfileName: aws.String(profileName),
+			InstanceProfileName: lo.ToPtr(instanceProfileName),
 			RoleName:            out.InstanceProfile.Roles[0].RoleName,
 		}); err != nil {
-			return fmt.Errorf("removing role %q from instance profile %q, %w", aws.ToString(out.InstanceProfile.Roles[0].RoleName), profileName, err)
+			return fmt.Errorf("removing role %q from instance profile %q, %w", lo.FromPtr(out.InstanceProfile.Roles[0].RoleName), instanceProfileName, err)
 		}
 	}
 	if _, err = p.iamapi.DeleteInstanceProfile(ctx, &iam.DeleteInstanceProfileInput{
-		InstanceProfileName: aws.String(profileName),
+		InstanceProfileName: lo.ToPtr(instanceProfileName),
 	}); err != nil {
-		return awserrors.IgnoreNotFound(fmt.Errorf("deleting instance profile %q, %w", profileName, err))
+		return awserrors.IgnoreNotFound(fmt.Errorf("deleting instance profile %q, %w", instanceProfileName, err))
 	}
 	return nil
 }

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -251,10 +251,10 @@ func GetCreateLaunchTemplateInput(
 	userData string,
 ) *ec2.CreateLaunchTemplateInput {
 	launchTemplateDataTags := []ec2types.LaunchTemplateTagSpecificationRequest{
-		{ResourceType: ec2types.ResourceTypeNetworkInterface, Tags: utils.MergeTags(options.Tags)},
+		{ResourceType: ec2types.ResourceTypeNetworkInterface, Tags: utils.EC2MergeTags(options.Tags)},
 	}
 	if options.CapacityType == karpv1.CapacityTypeSpot {
-		launchTemplateDataTags = append(launchTemplateDataTags, ec2types.LaunchTemplateTagSpecificationRequest{ResourceType: ec2types.ResourceTypeSpotInstancesRequest, Tags: utils.MergeTags(options.Tags)})
+		launchTemplateDataTags = append(launchTemplateDataTags, ec2types.LaunchTemplateTagSpecificationRequest{ResourceType: ec2types.ResourceTypeSpotInstancesRequest, Tags: utils.EC2MergeTags(options.Tags)})
 	}
 	networkInterfaces := generateNetworkInterfaces(options, ClusterIPFamily)
 	lt := &ec2.CreateLaunchTemplateInput{
@@ -291,7 +291,7 @@ func GetCreateLaunchTemplateInput(
 		TagSpecifications: []ec2types.TagSpecification{
 			{
 				ResourceType: ec2types.ResourceTypeLaunchTemplate,
-				Tags:         utils.MergeTags(options.Tags),
+				Tags:         utils.EC2MergeTags(options.Tags),
 			},
 		},
 	}

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2042,7 +2042,7 @@ essential = true
 				nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyCustom)
 				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Tags: map[string]string{"*": "*"}}}
 				ExpectApplied(ctx, env.Client, nodeClass)
-				controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
+				controller := nodeclass.NewController(awsEnv.Clock, env.Client, recorder, fake.DefaultRegion, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider, awsEnv.LaunchTemplateProvider, awsEnv.CapacityReservationProvider, awsEnv.EC2API, awsEnv.ValidationCache, awsEnv.AMIResolver)
 				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
 					{

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -134,7 +134,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	// Version updates are hydrated asynchronously after this, in the event of a failure
 	// the previously resolved value will be used.
 	lo.Must0(versionProvider.UpdateVersion(ctx))
-	instanceProfileProvider := instanceprofile.NewDefaultProvider(fake.DefaultRegion, iamapi, instanceProfileCache)
+	instanceProfileProvider := instanceprofile.NewDefaultProvider(iamapi, instanceProfileCache)
 	ssmProvider := ssmp.NewDefaultProvider(ssmapi, ssmCache)
 	amiProvider := amifamily.NewDefaultProvider(clock, versionProvider, ssmProvider, ec2api, ec2Cache)
 	amiResolver := amifamily.NewDefaultResolver()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -49,11 +50,19 @@ func ParseInstanceID(providerID string) (string, error) {
 	return "", fmt.Errorf("parsing instance id %s", providerID)
 }
 
-// MergeTags takes a variadic list of maps and merges them together into a list of
+// EC2MergeTags takes a variadic list of maps and merges them together into a list of
 // EC2 tags to be passed into EC2 API calls
-func MergeTags(tags ...map[string]string) []ec2types.Tag {
+func EC2MergeTags(tags ...map[string]string) []ec2types.Tag {
 	return lo.MapToSlice(lo.Assign(tags...), func(k, v string) ec2types.Tag {
 		return ec2types.Tag{Key: aws.String(k), Value: aws.String(v)}
+	})
+}
+
+// EC2MergeTags takes a variadic list of maps and merges them together into a list of
+// EC2 tags to be passed into EC2 API calls
+func IAMMergeTags(tags ...map[string]string) []iamtypes.Tag {
+	return lo.MapToSlice(lo.Assign(tags...), func(k, v string) iamtypes.Tag {
+		return iamtypes.Tag{Key: aws.String(k), Value: aws.String(v)}
 	})
 }
 

--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -547,7 +547,7 @@ func ExpectCapacityReservationCreated(
 		InstanceMatchCriteria: ec2types.InstanceMatchCriteriaTargeted,
 		TagSpecifications: lo.Ternary(len(tags) != 0, []ec2types.TagSpecification{{
 			ResourceType: ec2types.ResourceTypeCapacityReservation,
-			Tags:         utils.MergeTags(tags),
+			Tags:         utils.EC2MergeTags(tags),
 		}}, nil),
 	})
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Refactors the instance profile provider to introduce a `Get` method and take the instance profile name, role name, and tags directly in create / delete.

**How was this change tested?**
`make presubmit`+ `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.