### PR TITLE
Revert "test: add race detection to E2Es (#7966)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ e2etests: ## Run the e2e suite against your local cluster
 		CLUSTER_NAME=${CLUSTER_NAME} \
 		INTERRUPTION_QUEUE=${CLUSTER_NAME} \
 		go test \
-		-race \
 		-p 1 \
 		-count 1 \
 		-timeout 3.25h \


### PR DESCRIPTION
This reverts commit 71e8fca284b6233288dd47a2a2762366f66ba71c.

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This reverts a recent change that added the `-race` flag to the E2Es. It looks like there is a data race that occurs in the testing framework and I've created an issue [here](https://github.com/issues/created?issue=onsi%7Cgomega%7C840) for tracking.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.