### PR TITLE
chore: Log rejected instance types in Create() path

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -111,6 +111,11 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 	if err != nil {
 		return nil, cloudprovider.NewCreateError(fmt.Errorf("resolving instance types, %w", err), "InstanceTypeResolutionFailed", "Error resolving instance types")
 	}
+	instanceTypes, rejectedInstanceTypes, err := instance.FilterRejectInstanceTypes(nodeClaim, instanceTypes)
+	if err != nil {
+		return nil, cloudprovider.NewCreateError(fmt.Errorf("filtering instance types, %w", err), "InstanceTypeFilteringFailed", "Error filtering instance types")
+	}
+	log.FromContext(ctx).WithValues("instance-types", utils.PrettySlice(rejectedInstanceTypes, 10)).V(1).Info("filtered out instance types from launch")
 	if len(instanceTypes) == 0 {
 		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all requested instance types were unavailable during launch"))
 	}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -111,11 +111,6 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 	if err != nil {
 		return nil, cloudprovider.NewCreateError(fmt.Errorf("resolving instance types, %w", err), "InstanceTypeResolutionFailed", "Error resolving instance types")
 	}
-	instanceTypes, rejectedInstanceTypes, err := instance.FilterRejectInstanceTypes(nodeClaim, instanceTypes)
-	if err != nil {
-		return nil, cloudprovider.NewCreateError(fmt.Errorf("filtering instance types, %w", err), "InstanceTypeFilteringFailed", "Error filtering instance types")
-	}
-	log.FromContext(ctx).WithValues("instance-types", utils.PrettySlice(rejectedInstanceTypes, 10)).V(1).Info("filtered out instance types from launch")
 	if len(instanceTypes) == 0 {
 		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all requested instance types were unavailable during launch"))
 	}
@@ -332,11 +327,21 @@ func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, nodeClaim *kar
 		return nil, fmt.Errorf("getting instance types, %w", err)
 	}
 	reqs := scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...)
-	return lo.Filter(instanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
+	instanceTypes = lo.Filter(instanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
 		return reqs.Compatible(i.Requirements, scheduling.AllowUndefinedWellKnownLabels) == nil &&
 			len(i.Offerings.Compatible(reqs).Available()) > 0 &&
 			resources.Fits(nodeClaim.Spec.Resources.Requests, i.Allocatable())
-	}), nil
+	})
+	// Filter out exotic instance types, spot instance types more expensive than the cheapest on-demand instance type, etc.
+	var rejectedInstanceTypes []*cloudprovider.InstanceType
+	instanceTypes, rejectedInstanceTypes, err = instance.FilterRejectInstanceTypes(nodeClaim, instanceTypes)
+	if err != nil {
+		return nil, fmt.Errorf("filtering instance types, %w", err)
+	}
+	if len(rejectedInstanceTypes) > 0 {
+		log.FromContext(ctx).WithValues("instance-types", utils.PrettySlice(lo.Map(rejectedInstanceTypes, func(i *cloudprovider.InstanceType, _ int) string { return i.Name }), 10)).V(1).Info("filtered out instance types from launch")
+	}
+	return instanceTypes, nil
 }
 
 func (c *CloudProvider) resolveInstanceTypeFromInstance(ctx context.Context, instance *instance.Instance) (*cloudprovider.InstanceType, error) {

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -311,6 +311,8 @@ var _ = Describe("InstanceProvider", func() {
 
 		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
 		Expect(err).ToNot(HaveOccurred())
+		instanceTypes, _, err = instance.FilterRejectInstanceTypes(nodeClaim, instanceTypes)
+		Expect(err).ToNot(HaveOccurred())
 		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(instance.CapacityType).To(Equal(karpv1.CapacityTypeReserved))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Update our debug logging to log when we are filtering out the instance types that we are removing when we are removing them due to being exotic or not having reserved offerings.

```
{"level":"INFO","time":"2025-04-09T01:11:42.759Z","logger":"controller","caller":"provisioning/provisioner.go:364","message":"computed new nodeclaim(s) to fit pod(s)","commit":"7473e53","controller":"provisioner","namespace":"","name":"","reconcileID":"282ce943-daac-48fb-b933-d92290108952","nodeclaims":5,"pods":10}
{"level":"INFO","time":"2025-04-09T01:11:42.777Z","logger":"controller","caller":"provisioning/provisioner.go:152","message":"created nodeclaim","commit":"7473e53","controller":"provisioner","namespace":"","name":"","reconcileID":"282ce943-daac-48fb-b933-d92290108952","NodePool":{"name":"default"},"NodeClaim":{"name":"default-bqtt7"},"requests":{"cpu":"3210m","memory":"1364Mi","pods":"8"},"instance-types":"a1.xlarge, c3.xlarge, c4.xlarge, c5.xlarge, c5a.xlarge and 55 other(s)"}
{"level":"INFO","time":"2025-04-09T01:11:42.777Z","logger":"controller","caller":"provisioning/provisioner.go:152","message":"created nodeclaim","commit":"7473e53","controller":"provisioner","namespace":"","name":"","reconcileID":"282ce943-daac-48fb-b933-d92290108952","NodePool":{"name":"default"},"NodeClaim":{"name":"default-z5tsc"},"requests":{"cpu":"2315m","memory":"1492Mi","pods":"8"},"instance-types":"a1.xlarge, c3.xlarge, c4.xlarge, c5.xlarge, c5a.xlarge and 55 other(s)"}
{"level":"INFO","time":"2025-04-09T01:11:42.787Z","logger":"controller","caller":"provisioning/provisioner.go:152","message":"created nodeclaim","commit":"7473e53","controller":"provisioner","namespace":"","name":"","reconcileID":"282ce943-daac-48fb-b933-d92290108952","NodePool":{"name":"default"},"NodeClaim":{"name":"default-x87lc"},"requests":{"cpu":"2210m","memory":"1364Mi","pods":"8"},"instance-types":"a1.xlarge, c3.xlarge, c4.xlarge, c5.xlarge, c5a.xlarge and 55 other(s)"}
{"level":"INFO","time":"2025-04-09T01:11:42.788Z","logger":"controller","caller":"provisioning/provisioner.go:152","message":"created nodeclaim","commit":"7473e53","controller":"provisioner","namespace":"","name":"","reconcileID":"282ce943-daac-48fb-b933-d92290108952","NodePool":{"name":"default"},"NodeClaim":{"name":"default-dhzv2"},"requests":{"cpu":"2210m","memory":"1364Mi","pods":"8"},"instance-types":"a1.xlarge, c3.xlarge, c4.xlarge, c5.xlarge, c5a.xlarge and 55 other(s)"}
{"level":"INFO","time":"2025-04-09T01:11:42.788Z","logger":"controller","caller":"provisioning/provisioner.go:152","message":"created nodeclaim","commit":"7473e53","controller":"provisioner","namespace":"","name":"","reconcileID":"282ce943-daac-48fb-b933-d92290108952","NodePool":{"name":"default"},"NodeClaim":{"name":"default-gwfz6"},"requests":{"cpu":"2210m","memory":"1364Mi","pods":"8"},"instance-types":"a1.xlarge, c3.xlarge, c4.xlarge, c5.xlarge, c5a.xlarge and 55 other(s)"}
{"level":"DEBUG","time":"2025-04-09T01:11:42.848Z","logger":"controller","caller":"metrics/cloudprovider.go:99","message":"filtered out instance types from launch","commit":"7473e53","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-bqtt7"},"namespace":"","name":"default-bqtt7","reconcileID":"c5b36088-6185-4ea0-a29a-e275a98e2caa","instance-types":"inf1.xlarge"}
{"level":"DEBUG","time":"2025-04-09T01:11:42.864Z","logger":"controller","caller":"metrics/cloudprovider.go:99","message":"filtered out instance types from launch","commit":"7473e53","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-gwfz6"},"namespace":"","name":"default-gwfz6","reconcileID":"eb5ea844-9eec-45ac-a8fa-1aa465b7ae8c","instance-types":"inf1.xlarge"}
{"level":"DEBUG","time":"2025-04-09T01:11:42.876Z","logger":"controller","caller":"metrics/cloudprovider.go:99","message":"filtered out instance types from launch","commit":"7473e53","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-dhzv2"},"namespace":"","name":"default-dhzv2","reconcileID":"c443930f-9f2a-4e16-9322-dbda5685f8f6","instance-types":"inf1.xlarge"}
{"level":"DEBUG","time":"2025-04-09T01:11:42.903Z","logger":"controller","caller":"metrics/cloudprovider.go:99","message":"filtered out instance types from launch","commit":"7473e53","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-x87lc"},"namespace":"","name":"default-x87lc","reconcileID":"e876db8e-7391-43e4-afdc-0738054310f1","instance-types":"inf1.xlarge"}
{"level":"DEBUG","time":"2025-04-09T01:11:42.915Z","logger":"controller","caller":"metrics/cloudprovider.go:99","message":"filtered out instance types from launch","commit":"7473e53","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-z5tsc"},"namespace":"","name":"default-z5tsc","reconcileID":"28eed3cb-916f-4a76-abdc-b6d0e5928635","instance-types":"inf1.xlarge"}
```

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.