### PR TITLE
ICE spot capacity when there is no permission to create spot SLR

### DIFF
--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -32,16 +32,21 @@ import (
 // GetInstanceTypes responses
 type UnavailableOfferings struct {
 	// key: <capacityType>:<instanceType>:<zone>, value: struct{}{}
-	cache  *cache.Cache
-	SeqNum uint64
+	offeringCache     *cache.Cache
+	capacityTypeCache *cache.Cache
+	SeqNum            uint64
 }
 
 func NewUnavailableOfferings() *UnavailableOfferings {
 	uo := &UnavailableOfferings{
-		cache:  cache.New(UnavailableOfferingsTTL, UnavailableOfferingsCleanupInterval),
-		SeqNum: 0,
+		offeringCache:     cache.New(UnavailableOfferingsTTL, UnavailableOfferingsCleanupInterval),
+		capacityTypeCache: cache.New(UnavailableOfferingsTTL, UnavailableOfferingsCleanupInterval),
+		SeqNum:            0,
 	}
-	uo.cache.OnEvicted(func(_ string, _ interface{}) {
+	uo.offeringCache.OnEvicted(func(_ string, _ interface{}) {
+		atomic.AddUint64(&uo.SeqNum, 1)
+	})
+	uo.capacityTypeCache.OnEvicted(func(_ string, _ interface{}) {
 		atomic.AddUint64(&uo.SeqNum, 1)
 	})
 	return uo
@@ -49,8 +54,9 @@ func NewUnavailableOfferings() *UnavailableOfferings {
 
 // IsUnavailable returns true if the offering appears in the cache
 func (u *UnavailableOfferings) IsUnavailable(instanceType ec2types.InstanceType, zone, capacityType string) bool {
-	_, found := u.cache.Get(u.key(instanceType, zone, capacityType))
-	return found
+	_, offeringFound := u.offeringCache.Get(u.key(instanceType, zone, capacityType))
+	_, capacityTypeFound := u.capacityTypeCache.Get(capacityType)
+	return offeringFound || capacityTypeFound
 }
 
 // MarkUnavailable communicates recently observed temporary capacity shortages in the provided offerings
@@ -62,7 +68,7 @@ func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableR
 		"zone", zone,
 		"capacity-type", capacityType,
 		"ttl", UnavailableOfferingsTTL).V(1).Info("removing offering from offerings")
-	u.cache.SetDefault(u.key(instanceType, zone, capacityType), struct{}{})
+	u.offeringCache.SetDefault(u.key(instanceType, zone, capacityType), struct{}{})
 	atomic.AddUint64(&u.SeqNum, 1)
 }
 
@@ -72,12 +78,18 @@ func (u *UnavailableOfferings) MarkUnavailableForFleetErr(ctx context.Context, f
 	u.MarkUnavailable(ctx, lo.FromPtr(fleetErr.ErrorCode), instanceType, zone, capacityType)
 }
 
+func (u *UnavailableOfferings) MarkCapacityTypeUnavailable(capacityType string) {
+	u.capacityTypeCache.SetDefault(capacityType, struct{}{})
+	atomic.AddUint64(&u.SeqNum, 1)
+}
+
 func (u *UnavailableOfferings) Delete(instanceType ec2types.InstanceType, zone string, capacityType string) {
-	u.cache.Delete(u.key(instanceType, zone, capacityType))
+	u.offeringCache.Delete(u.key(instanceType, zone, capacityType))
 }
 
 func (u *UnavailableOfferings) Flush() {
-	u.cache.Flush()
+	u.offeringCache.Flush()
+	u.capacityTypeCache.Flush()
 }
 
 // key returns the cache key for all offerings in the cache

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -24,11 +24,12 @@ import (
 )
 
 const (
-	launchTemplateNameNotFoundCode        = "InvalidLaunchTemplateName.NotFoundException"
-	RunInstancesInvalidParameterValueCode = "InvalidParameterValue"
-	DryRunOperationErrorCode              = "DryRunOperation"
-	UnauthorizedOperationErrorCode        = "UnauthorizedOperation"
-	RateLimitingErrorCode                 = "RequestLimitExceeded"
+	launchTemplateNameNotFoundCode                 = "InvalidLaunchTemplateName.NotFoundException"
+	RunInstancesInvalidParameterValueCode          = "InvalidParameterValue"
+	DryRunOperationErrorCode                       = "DryRunOperation"
+	UnauthorizedOperationErrorCode                 = "UnauthorizedOperation"
+	RateLimitingErrorCode                          = "RequestLimitExceeded"
+	ServiceLinkedRoleCreationNotPermittedErrorCode = "AuthFailure.ServiceLinkedRoleCreationNotPermitted"
 )
 
 var (
@@ -152,6 +153,10 @@ func IgnoreRateLimitedError(err error) error {
 // could be due to account limits, insufficient ec2 capacity, etc.
 func IsUnfulfillableCapacity(err ec2types.CreateFleetError) bool {
 	return unfulfillableCapacityErrorCodes.Has(*err.ErrorCode)
+}
+
+func IsServiceLinkedRoleCreationNotPermitted(err ec2types.CreateFleetError) bool {
+	return *err.ErrorCode == ServiceLinkedRoleCreationNotPermittedErrorCode
 }
 
 // IsReservationCapacityExceeded returns true if the fleet error means there is no remaining capacity for the provided

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -198,6 +198,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	instanceProvider := instance.NewDefaultProvider(
 		ctx,
 		cfg.Region,
+		operator.EventRecorder,
 		ec2api,
 		unavailableOfferingsCache,
 		subnetProvider,

--- a/pkg/providers/instance/events.go
+++ b/pkg/providers/instance/events.go
@@ -1,0 +1,34 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/events"
+
+	"github.com/aws/karpenter-provider-aws/pkg/errors"
+)
+
+func SpotServiceLinkedRoleCreationFailure(nodeClaim *v1.NodeClaim) events.Event {
+	return events.Event{
+		InvolvedObject: nodeClaim,
+		Type:           corev1.EventTypeWarning,
+		Message:        fmt.Sprintf("Attempted to launch a spot instance but failed due to %q", errors.ServiceLinkedRoleCreationNotPermittedErrorCode),
+		DedupeValues:   []string{string(nodeClaim.UID)},
+	}
+}

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -138,6 +138,80 @@ var _ = Describe("InstanceProvider", func() {
 		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
+
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeOnDemand)).To(BeFalse())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeOnDemand)).To(BeFalse())
+
+		// Try creating again for on-demand
+		instanceTypes, err = cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Filter down to a single instance type
+		instanceTypes = lo.Filter(instanceTypes, func(i *corecloudprovider.InstanceType, _ int) bool { return i.Name == "m5.xlarge" })
+
+		instance, err = awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
+		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
+		Expect(instance).To(BeNil())
+
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeOnDemand)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeOnDemand)).To(BeTrue())
+	})
+	It("should return an ICE error when spot instances are used and SpotSLR can't be created", func() {
+		ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		awsEnv.EC2API.CreateFleetBehavior.Output.Set(&ec2.CreateFleetOutput{
+			Errors: []ec2types.CreateFleetError{
+				{
+					ErrorCode:    lo.ToPtr("AuthFailure.ServiceLinkedRoleCreationNotPermitted"),
+					ErrorMessage: lo.ToPtr("The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances."),
+					LaunchTemplateAndOverrides: &ec2types.LaunchTemplateAndOverridesResponse{
+						Overrides: &ec2types.FleetLaunchTemplateOverrides{
+							InstanceType:     "m5.xlarge",
+							AvailabilityZone: lo.ToPtr("test-zone-1a"),
+						},
+					},
+				},
+				{
+					ErrorCode:    lo.ToPtr("AuthFailure.ServiceLinkedRoleCreationNotPermitted"),
+					ErrorMessage: lo.ToPtr("The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances."),
+					LaunchTemplateAndOverrides: &ec2types.LaunchTemplateAndOverridesResponse{
+						Overrides: &ec2types.FleetLaunchTemplateOverrides{
+							InstanceType:     "m5.xlarge",
+							AvailabilityZone: lo.ToPtr("test-zone-1b"),
+						},
+					},
+				},
+			},
+		})
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Filter down to a single instance type
+		instanceTypes = lo.Filter(instanceTypes, func(i *corecloudprovider.InstanceType, _ int) bool {
+			return i.Name == "m5.xlarge"
+		})
+
+		// Since all the capacity pools are ICEd. This should return back an ICE error
+		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
+		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
+		Expect(instance).To(BeNil())
+
+		// Capacity should get ICEd when this error is received
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.large", "test-zone-1a", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.large", "test-zone-1b", karpv1.CapacityTypeSpot)).To(BeTrue())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeOnDemand)).To(BeFalse())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeOnDemand)).To(BeFalse())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.large", "test-zone-1a", karpv1.CapacityTypeOnDemand)).To(BeFalse())
+		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.large", "test-zone-1b", karpv1.CapacityTypeOnDemand)).To(BeFalse())
+
+		// Expect that an event is fired for Spot SLR not being created
+		awsEnv.EventRecorder.DetectedEvent(`Attempted to launch a spot instance but failed due to "AuthFailure.ServiceLinkedRoleCreationNotPermitted"`)
 	})
 	It("should return an ICE error when all attempted instance types return a ReservedCapacityReservation error", func() {
 		const targetReservationID = "cr-m5.large-1a-1"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change ensures that when we get a `AuthFailure.ServiceLinkedRoleCreationNotPermitted` error code response, we treat this as an ICE error. In general, users that are leveraging spot should enable the SLR before attempting to launch spot capacity, but (if they have not applied the Spot SLR for some reason), this ensures that we still allow on-demand capacity to be launched if the NodePool supports both.

#### Example Response

```
"errorSet": {
                "item": [
                    {
                        "lifecycle": "spot",
                        "launchTemplateAndOverrides": {
                            "overrides": {
                                "subnetId": "subnet-0dc970abd02c2e322",
                                "imageId": "ami-0e042be748dae7ca0",
                                "instanceType": "r7a.medium",
                                "availabilityZone": "us-west-2c"
                            },
                            "launchTemplateSpecification": {
                                "launchTemplateId": "lt-04a55ad0a639804fc",
                                "version": 1
                            }
                        },
                        "errorMessage": "The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.",
                        "errorCode": "AuthFailure.ServiceLinkedRoleCreationNotPermitted"
                    },
                    {
                        "lifecycle": "spot",
                        "launchTemplateAndOverrides": {
                            "overrides": {
                                "subnetId": "subnet-0dc970abd02c2e322",
                                "imageId": "ami-0e042be748dae7ca0",
                                "instanceType": "c5d.large",
                                "availabilityZone": "us-west-2c"
                            },
                            "launchTemplateSpecification": {
                                "launchTemplateId": "lt-09f9a511f3ecf6a19",
                                "version": 1
                            }
                        },
                        "errorMessage": "The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.",
                        "errorCode": "AuthFailure.ServiceLinkedRoleCreationNotPermitted"
                    },
                    {
                        "lifecycle": "spot",
                        "launchTemplateAndOverrides": {
                            "overrides": {
                                "subnetId": "subnet-0dc970abd02c2e322",
                                "imageId": "ami-0e042be748dae7ca0",
                                "instanceType": "c7i-flex.large",
                                "availabilityZone": "us-west-2c"
                            },
                            "launchTemplateSpecification": {
                                "launchTemplateId": "lt-09f9a511f3ecf6a19",
                                "version": 1
                            }
                        },
                        "errorMessage": "The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.",
                        "errorCode": "AuthFailure.ServiceLinkedRoleCreationNotPermitted"
                    },
...
}
```

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.