### PR TITLE
ci: Remove jitter step for forked repositories

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -105,6 +105,7 @@ jobs:
           aws-region: ${{ inputs.region }}
           role-duration-seconds: 21600
       - name: add jitter on cluster setup
+        if: github.repository == 'aws/karpenter-provider-aws'
         run: |
           # Creating jitter so that we can stagger cluster creation to avoid throttling
           sleep $(( RANDOM % 300 + 1 ))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The jitter step in GitHub Actions adds unnecessary delay when testing workflows in forked repositories. Removing this step will speed up development and testing cycles while maintaining jitter in main repository workflows.

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.