### PR TITLE
chore: Switch All Github Action Triggers to Use a Source repository for E2E tests

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -124,5 +124,6 @@ jobs:
       k8s_version: ${{ inputs.k8s_version }}
       cleanup: ${{ inputs.cleanup }}
       workflow_trigger: ${{ inputs.workflow_trigger }}
+      source: aws
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-private-cluster-trigger.yaml
+++ b/.github/workflows/e2e-private-cluster-trigger.yaml
@@ -15,5 +15,6 @@ jobs:
       workflow_trigger: "private_cluster"
       cleanup: true
       codebuild_region: US_EAST_1
+      source: aws
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -41,6 +41,7 @@ jobs:
       region: ${{ inputs.region || 'us-west-2' }}
       enable_metrics: ${{ inputs.enable_metrics || true }}
       workflow_trigger: "scale"
+      source: aws
       # Default to true unless using a workflow_dispatch
       cleanup: ${{ github.event_name != 'workflow_dispatch' && true || inputs.cleanup }}
     secrets:

--- a/.github/workflows/e2e-soak-trigger.yaml
+++ b/.github/workflows/e2e-soak-trigger.yaml
@@ -48,5 +48,6 @@ jobs:
       cluster_name: ${{ matrix.cluster_name }}
       cleanup: ${{ matrix.cluster_cleanup }}
       git_ref: ${{ matrix.git_ref }}
+      source: aws
     secrets:
       SLACK_WEBHOOK_SOAK_URL: ${{ secrets.SLACK_WEBHOOK_SOAK_URL }}

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -29,6 +29,9 @@ on:
         required: true
         default: true
         type: boolean
+      source:
+        type: string
+        default: "aws" 
   workflow_call:
     inputs:
       from_git_ref:
@@ -47,6 +50,9 @@ on:
         type: boolean
       workflow_trigger:
         type: string
+      source:
+        type: string
+        default: "aws" 
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
@@ -128,6 +134,14 @@ jobs:
         run: |
           aws eks update-kubeconfig --name ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
           CLUSTER_NAME=${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }} INTERRUPTION_QUEUE=${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }} CLUSTER_ENDPOINT="$(aws eks describe-cluster --name ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }} --query "cluster.endpoint" --output text)" TEST_SUITE="Integration" make e2etests
+
+          if [[ "$SOURCE" == 'aws' ]]; then
+            TEST_SUITE="Integration" ENABLE_METRICS=$ENABLE_METRICS \
+              CLUSTER_NAME="${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}" CLUSTER_ENDPOINT="$(aws eks describe-cluster --name ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }} --query "cluster.endpoint" --output text)" \
+              INTERRUPTION_QUEUE="${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}" make e2etests
+          elif [[ "$SOURCE" == 'upstream' ]]; then
+            FOCUS="Integration" CLUSTER_NAME="${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}" make upstream-e2etests
+          fi
       - name: notify slack of success or failure
         uses: ./.github/actions/e2e/slack/notify
         if: (success() || failure()) && github.event_name != 'workflow_run' && inputs.workflow_trigger != 'versionCompatibility'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,6 +59,7 @@ on:
         type: string
       source:
         type: string
+        default: "aws" 
       region:
         type: string
         default: "us-east-2"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Now that we have verified that using pick a package with the source field works as expected. Switching all triggers to using a source package 

**How was this change tested?**
- Manually tested in a forked repo 
- https://github.com/engedaam/karpenter/actions/runs/14874479614/job/41769116618
- https://github.com/engedaam/karpenter/actions/runs/14874484906

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.