### PR TITLE
test: Reduce EFA resource requests for a test

### DIFF
--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -339,10 +339,10 @@ var _ = Describe("Extended Resources", func() {
 				},
 				ResourceRequirements: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						"vpc.amazonaws.com/efa": resource.MustParse("2"),
+						"vpc.amazonaws.com/efa": resource.MustParse("1"),
 					},
 					Limits: corev1.ResourceList{
-						"vpc.amazonaws.com/efa": resource.MustParse("2"),
+						"vpc.amazonaws.com/efa": resource.MustParse("1"),
 					},
 				},
 			},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Test: `should provision nodes for a deployment that requests vpc.amazonaws.com/efa`


- We are currently getting ICE for specific instances types that we need to launch (these are OD): https://github.com/aws/karpenter-provider-aws/actions/runs/14842018069/job/41667028013
- This is causing the test to run for 16 min and causing the whole test suite to timeout
- Reducing the resource request should allow Karpenter to send smaller instances type providing CreateFleet with more option when provisioning capacity for the test 

**How was this change tested?**
- `/karpenter snapshot`
- https://github.com/aws/karpenter-provider-aws/actions/runs/14852340056
- https://github.com/aws/karpenter-provider-aws/actions/runs/14853916174
- https://github.com/aws/karpenter-provider-aws/actions/runs/14861819163

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.