### PR TITLE
test: adding new functionality to return vpc information when calling DescribeSubnets

### DIFF
--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -485,6 +485,7 @@ func (e *EC2API) DescribeSubnets(_ context.Context, input *ec2.DescribeSubnetsIn
 					{Key: aws.String("Name"), Value: aws.String("test-subnet-1")},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
+				VpcId: aws.String("vpc-test1"),
 			},
 			{
 				SubnetId:                aws.String("subnet-test2"),
@@ -496,6 +497,7 @@ func (e *EC2API) DescribeSubnets(_ context.Context, input *ec2.DescribeSubnetsIn
 					{Key: aws.String("Name"), Value: aws.String("test-subnet-2")},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
+				VpcId: aws.String("vpc-test1"),
 			},
 			{
 				SubnetId:                aws.String("subnet-test3"),
@@ -507,6 +509,7 @@ func (e *EC2API) DescribeSubnets(_ context.Context, input *ec2.DescribeSubnetsIn
 					{Key: aws.String("TestTag")},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
+				VpcId: aws.String("vpc-test1"),
 			},
 			{
 				SubnetId:                aws.String("subnet-test4"),
@@ -517,6 +520,7 @@ func (e *EC2API) DescribeSubnets(_ context.Context, input *ec2.DescribeSubnetsIn
 				Tags: []ec2types.Tag{
 					{Key: aws.String("Name"), Value: aws.String("test-subnet-4")},
 				},
+				VpcId: aws.String("vpc-test1"),
 			},
 		}
 		if len(input.Filters) == 0 {

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -113,6 +113,7 @@ var _ = Describe("SubnetProvider", func() {
 					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1a"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 			}, subnets)
 		})
@@ -133,12 +134,14 @@ var _ = Describe("SubnetProvider", func() {
 					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1a"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 				{
 					SubnetId:                lo.ToPtr("subnet-test2"),
 					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1b"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 			}, subnets)
 		})
@@ -161,12 +164,14 @@ var _ = Describe("SubnetProvider", func() {
 					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1a"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 				{
 					SubnetId:                lo.ToPtr("subnet-test2"),
 					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1b"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 			}, subnets)
 		})
@@ -184,6 +189,7 @@ var _ = Describe("SubnetProvider", func() {
 					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1a"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 			}, subnets)
 		})
@@ -204,12 +210,14 @@ var _ = Describe("SubnetProvider", func() {
 					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1a"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 				{
 					SubnetId:                lo.ToPtr("subnet-test2"),
 					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1b"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 			}, subnets)
 		})
@@ -228,6 +236,7 @@ var _ = Describe("SubnetProvider", func() {
 					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1b"),
 					AvailableIpAddressCount: lo.ToPtr[int32](100),
+					VpcId:                   lo.ToPtr("vpc-test1"),
 				},
 			}, subnets)
 		})
@@ -250,6 +259,7 @@ var _ = Describe("SubnetProvider", func() {
 					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
 					AvailabilityZoneId:      lo.ToPtr("tstz1-1a"),
 					AvailableIpAddressCount: lo.ToPtr[int32](10),
+					VpcId:                   lo.ToPtr("vpc-test-1"),
 				},
 			}, subnets)
 			Expect(awsEnv.EC2API.DescribeSubnetsBehavior.Calls()).To(Equal(2))
@@ -264,7 +274,8 @@ var _ = Describe("SubnetProvider", func() {
 				&ec2.DescribeSubnetsOutput{
 					Subnets: []ec2types.Subnet{
 						{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(10),
-							Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}},
+							Tags:  []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}},
+							VpcId: lo.ToPtr("vpc-test1"),
 						},
 					},
 				},
@@ -273,7 +284,8 @@ var _ = Describe("SubnetProvider", func() {
 				&ec2.DescribeSubnetsOutput{
 					Subnets: []ec2types.Subnet{
 						{SubnetId: aws.String("test-subnet-3"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(10),
-							Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-3")}},
+							Tags:  []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-3")}},
+							VpcId: lo.ToPtr("vpc-test1"),
 						},
 					},
 				},
@@ -282,13 +294,16 @@ var _ = Describe("SubnetProvider", func() {
 			Expect(err).To(BeNil())
 			ExpectConsistsOfSubnets([]ec2types.Subnet{
 				{SubnetId: aws.String("test-subnet-1"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(10),
-					Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-1")}},
+					Tags:  []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-1")}},
+					VpcId: lo.ToPtr("vpc-test1"),
 				},
 				{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(10),
-					Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}},
+					Tags:  []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}},
+					VpcId: lo.ToPtr("vpc-test1"),
 				},
 				{SubnetId: aws.String("test-subnet-3"), AvailabilityZone: aws.String("test-zone-1a"), AvailabilityZoneId: aws.String("tstz1-1a"), AvailableIpAddressCount: aws.Int32(10),
-					Tags: []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-3")}},
+					Tags:  []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-3")}},
+					VpcId: lo.ToPtr("vpc-test1"),
 				},
 			}, subnets)
 			Expect(awsEnv.EC2API.DescribeSubnetsBehavior.Calls()).To(Equal(3))
@@ -375,6 +390,7 @@ var _ = Describe("SubnetProvider", func() {
 								Value: lo.ToPtr("bar"),
 							},
 						},
+						VpcId: lo.ToPtr("vpc-test1"),
 					},
 					{
 						AvailabilityZone:        lo.ToPtr("test-zone-1b"),
@@ -393,6 +409,7 @@ var _ = Describe("SubnetProvider", func() {
 								Value: lo.ToPtr("bar"),
 							},
 						},
+						VpcId: lo.ToPtr("vpc-test1"),
 					},
 					{
 						AvailabilityZone:        lo.ToPtr("test-zone-1c"),
@@ -412,6 +429,7 @@ var _ = Describe("SubnetProvider", func() {
 								Value: lo.ToPtr("bar"),
 							},
 						},
+						VpcId: lo.ToPtr("vpc-test1"),
 					},
 					{
 						AvailabilityZone:        lo.ToPtr("test-zone-1a-local"),
@@ -425,6 +443,7 @@ var _ = Describe("SubnetProvider", func() {
 								Value: lo.ToPtr("test-subnet-4"),
 							},
 						},
+						VpcId: lo.ToPtr("vpc-test1"),
 					},
 				}))
 			}()


### PR DESCRIPTION


<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change just adds the vpcId field into the fake DescribeSubnets.

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.