### PR TITLE
Don't ignore instance profile error if it is explicitly set

### DIFF
--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -267,7 +267,7 @@ func (v *Validation) validateRunInstancesAuthorization(
 	}); awserrors.IgnoreDryRunError(err) != nil {
 		// If we get InstanceProfile NotFound, but we have a resolved instance profile in the status,
 		// this means there is most likely an eventual consistency issue and we just need to requeue
-		if awserrors.IsInstanceProfileNotFound(err) || awserrors.IsRateLimitedError(err) {
+		if (awserrors.IsInstanceProfileNotFound(err) && nodeClass.Spec.InstanceProfile == nil) || awserrors.IsRateLimitedError(err) {
 			return "", true, nil
 		}
 		if awserrors.IgnoreUnauthorizedOperationError(err) != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #8072 <!-- issue number -->

**Description**
Instance profile error was ignored because of race conditions. When it is explicitly set, the expectation is that the instance profile already exists, and hence no race condition.
**How was this change tested?**
Unit tests
**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.