### PR TITLE
fix: should delete instanceProfile from cache when nodeclass is deleted

### DIFF
--- a/pkg/providers/instanceprofile/instanceprofile.go
+++ b/pkg/providers/instanceprofile/instanceprofile.go
@@ -128,5 +128,6 @@ func (p *DefaultProvider) Delete(ctx context.Context, instanceProfileName string
 	}); err != nil {
 		return awserrors.IgnoreNotFound(serrors.Wrap(fmt.Errorf("deleting instance profile, %w", err), "instance-profile", instanceProfileName))
 	}
+	p.cache.Delete(instanceProfileName)
 	return nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
If an ec2nodeclass is deleted and recreated again, the validation controller will requeue reconciliation because the dry run operation will fail to find the instanceProfile. This will cause the validation to remain stuck in unknown and that causes the ec2nodeclass ready stuck in unknown. The instance profile create call succeeds because we get it from the cache causing `InstanceProfileReady` to be in a `True` state. This PR fixes this by ensuring that we delete the instance profile entry from the cache when the nodeClass is deleted.

**How was this change tested?**
Added tests. Tested on dev cluster.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.