### PR TITLE
docs: update link for prometheus endpoint documentation

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -32,7 +32,7 @@ serviceMonitor:
   additionalLabels: {}
   # -- Configuration on `http-metrics` endpoint for the ServiceMonitor.
   # Not to be used to add additional endpoints.
-  # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+  # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint
   endpointConfig: {}
 # -- Number of replicas.
 replicas: 2


### PR DESCRIPTION
**Description**
Just updating the documentation link for the Service Monitor's endpoint configuration.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.