### PR TITLE
docs: Update namespace on migrating from Cluster Autoscaler guide

### DIFF
--- a/website/content/en/docs/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/docs/getting-started/migrating-from-cas/_index.md
@@ -188,7 +188,7 @@ If you have a lot of nodes or workloads you may want to slowly scale down your n
 As nodegroup nodes are drained you can verify that Karpenter is creating nodes for your workloads.
 
 ```bash
-kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed

--- a/website/content/en/preview/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/preview/getting-started/migrating-from-cas/_index.md
@@ -188,7 +188,7 @@ If you have a lot of nodes or workloads you may want to slowly scale down your n
 As nodegroup nodes are drained you can verify that Karpenter is creating nodes for your workloads.
 
 ```bash
-kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed

--- a/website/content/en/v0.32/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.32/getting-started/migrating-from-cas/_index.md
@@ -188,7 +188,7 @@ If you have a lot of nodes or workloads you may want to slowly scale down your n
 As nodegroup nodes are drained you can verify that Karpenter is creating nodes for your workloads.
 
 ```bash
-kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed

--- a/website/content/en/v1.0/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v1.0/getting-started/migrating-from-cas/_index.md
@@ -188,7 +188,7 @@ If you have a lot of nodes or workloads you may want to slowly scale down your n
 As nodegroup nodes are drained you can verify that Karpenter is creating nodes for your workloads.
 
 ```bash
-kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed

--- a/website/content/en/v1.2/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v1.2/getting-started/migrating-from-cas/_index.md
@@ -188,7 +188,7 @@ If you have a lot of nodes or workloads you may want to slowly scale down your n
 As nodegroup nodes are drained you can verify that Karpenter is creating nodes for your workloads.
 
 ```bash
-kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed

--- a/website/content/en/v1.3/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v1.3/getting-started/migrating-from-cas/_index.md
@@ -188,7 +188,7 @@ If you have a lot of nodes or workloads you may want to slowly scale down your n
 As nodegroup nodes are drained you can verify that Karpenter is creating nodes for your workloads.
 
 ```bash
-kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed

--- a/website/content/en/v1.4/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v1.4/getting-started/migrating-from-cas/_index.md
@@ -188,7 +188,7 @@ If you have a lot of nodes or workloads you may want to slowly scale down your n
 As nodegroup nodes are drained you can verify that Karpenter is creating nodes for your workloads.
 
 ```bash
-kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #8086 

**Description**
- Update the Karpenter namespace on migrating from Cluster Autoscaler guide

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.