### PR TITLE
chore: fix memory addresses in deleting log for launch templates

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -471,7 +471,7 @@ func (p *DefaultProvider) DeleteAll(ctx context.Context, nodeClass *v1.EC2NodeCl
 		deleteErr = multierr.Append(deleteErr, err)
 	}
 	if len(ltNames) > 0 {
-		log.FromContext(ctx).WithValues("launchTemplates", utils.PrettySlice(ltNames, 5)).V(1).Info("deleted launch templates")
+		log.FromContext(ctx).WithValues("launchTemplates", utils.PrettySlice(lo.FromSlicePtr(ltNames), 5)).V(1).Info("deleted launch templates")
 	}
 	if deleteErr != nil {
 		return fmt.Errorf("deleting launch templates, %w", deleteErr)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Before this, this log would have memory addresses instead of launch template names:
```
karpenter-6dff595756-zzvv6 controller {"level":"DEBUG","time":"2025-05-21T23:23:17.634Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:474","message":"deleted launch templates","commit":"91d8ecc-dirty","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"default-markglimmer-1-fuzbxqsnd0"},"namespace":"","name":"default-markglimmer-1-fuzbxqsnd0","reconcileID":"2fd1ccf4-7f08-4dd8-82b7-5dabad315097","launchTemplates":"karpenter.k8s.aws/12002143131405121058, karpenter.k8s.aws/15295270770572173640, karpenter.k8s.aws/12087419982868941428, karpenter.k8s.aws/10678046093716176425, karpenter.k8s.aws/15404340901152933663 and 1 other(s)"}
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.