### PR TITLE
chore: add "single-process-oom-kill" Bottlerocket setting

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -83,6 +83,7 @@ type BottlerocketKubernetes struct {
 	SeccompDefault                     *bool                                     `toml:"seccomp-default,omitempty"`
 	PodPidsLimit                       *int                                      `toml:"pod-pids-limit,omitempty"`
 	DeviceOwnershipFromSecurityContext *bool                                     `toml:"device-ownership-from-security-context,omitempty"`
+	SingleProcessOOMKill               *bool                                     `toml:"single-process-oom-kill"`
 }
 
 type BottlerocketStaticPod struct {


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->



Fixes #N/A <!-- issue number -->

**Description**

Bottlerocket v1.39.0 and up adds a setting,
`settings.kubernetes.single-process-oom-kill`, configurable on k8s-1.32+ nodes.

See:
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/489
* https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.39.0

**How was this change tested?**

`make run` against a test cluster. Testing with valid and invalid values for the new setting. Valid nodeclass.yaml:

```
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: default
spec:
...
  amiFamily: Bottlerocket
  userData: |
    [settings.kubernetes]
    "single-process-oom-kill" = true
  amiSelectorTerms:
    - alias: bottlerocket@v1.39.0
...
```

Inspected the launched node and verified setting is set:

```
[ssm-user@control]$ apiclient get settings.kubernetes.single
{
  "settings": {
    "kubernetes": {
      "single-process-oom-kill": true
    }
  }
}
```

Invalid integer used for `single-process-oom-kill`:

```
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: default
spec:
...
  amiFamily: Bottlerocket
  userData: |
    [settings.kubernetes]
    "single-process-oom-kill" = 123
  amiSelectorTerms:
    - alias: bottlerocket@v1.39.0
...
```
Controller shows error logs:

```
{"level":"INFO","time":"2025-05-22T18:28:28.917Z","logger":"controller","caller":"provisioning/provisioner.go:406","message":"created nodeclaim","controller":"disruption","namespace":"","name":"","reconcileID":"aa6449cf-e606-42ae-b6f9-cfad83b2eb24","NodePool":{"name":"default"},"NodeClaim":{"name":"default-647f5"},"requests":{"cpu":"550m","memory":"526Mi","pods":"6"},"instance-types":"c3.large, c4.large, c5.large, c5.xlarge, c5a.large and 55 other(s)"}
{"level":"ERROR","time":"2025-05-22T18:28:29.986Z","logger":"controller","caller":"controller/controller.go:347","message":"Reconciler error","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-647f5"},"namespace":"","name":"default-647f5","reconcileID":"e6ff07a4-d851-4460-9dac-b664e61b0020","error":"launching nodeclaim, creating instance, creating nodeclaim, getting launch template configs, getting launch templates, creating launch template, invalid UserData toml: cannot decode TOML integer into struct field bootstrap.BottlerocketKubernetes.SingleProcessOOMKill of type *bool"}
{"level":"ERROR","time":"2025-05-22T18:28:30.014Z","logger":"controller","caller":"controller/controller.go:347","message":"Reconciler error","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-647f5"},"namespace":"","name":"default-647f5","reconcileID":"dfee1f1e-5779-407a-ac09-a26acc62d4b5","error":"launching nodeclaim, creating instance, creating nodeclaim, getting launch template configs, getting launch templates, creating launch template, invalid UserData toml: cannot decode TOML integer into struct field bootstrap.BottlerocketKubernetes.SingleProcessOOMKill of type *bool"}
{"level":"ERROR","time":"2025-05-22T18:28:31.014Z","logger":"controller","caller":"controller/controller.go:347","message":"Reconciler error","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-647f5"},"namespace":"","name":"default-647f5","reconcileID":"cf1f3b84-443e-4f09-bdd8-af3c0fb9500d","error":"launching nodeclaim, creating instance, creating nodeclaim, getting launch template configs, getting launch templates, creating launch template, invalid UserData toml: cannot decode TOML integer into struct field bootstrap.BottlerocketKubernetes.SingleProcessOOMKill of type *bool"}
{"level":"ERROR","time":"2025-05-22T18:28:35.057Z","logger":"controller","caller":"controller/controller.go:347","message":"Reconciler error","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-647f5"},"namespace":"","name":"default-647f5","reconcileID":"18ce3ec2-c45a-478b-b68c-55600a51f70a","error":"launching nodeclaim, creating instance, creating nodeclaim, getting launch template configs, getting launch templates, creating launch template, invalid UserData toml: cannot decode TOML integer into struct field bootstrap.BottlerocketKubernetes.SingleProcessOOMKill of type *bool"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.