### PR TITLE
chore: drop kubelet compatibility annotation check

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,10 +19,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	stdlog "log"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
@@ -44,7 +42,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	clinetconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -52,8 +49,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator"
 
 	prometheusv2 "github.com/jonathan-innis/aws-sdk-go-prometheus/v2"
-
-	"sigs.k8s.io/karpenter/pkg/apis"
 
 	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
 	awscache "github.com/aws/karpenter-provider-aws/pkg/cache"
@@ -99,21 +94,6 @@ type Operator struct {
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
-	kubeletCompatibilityAnnotationKey := fmt.Sprintf("%s/%s", apis.CompatibilityGroup, "v1beta1-kubelet-conversion")
-	// we are going to panic if any of the customer nodepools contain
-	// compatibility.karpenter.sh/v1beta1-kubelet-conversion
-	restConfig := clinetconfig.GetConfigOrDie()
-	kubeClient := lo.Must(client.New(restConfig, client.Options{}))
-	nodePoolList := &karpv1.NodePoolList{}
-	lo.Must0(kubeClient.List(ctx, nodePoolList))
-	npNames := lo.FilterMap(nodePoolList.Items, func(np karpv1.NodePool, _ int) (string, bool) {
-		_, ok := np.Annotations[kubeletCompatibilityAnnotationKey]
-		return np.Name, ok
-	})
-	if len(npNames) != 0 {
-		stdlog.Fatalf("The kubelet compatibility annotation, %s, is not supported on Karpenter v1.1+. Please refer to the upgrade guide in the docs. The following NodePools still have the compatibility annotation: %s", kubeletCompatibilityAnnotationKey, strings.Join(npNames, ", "))
-	}
-
 	cfg := prometheusv2.WithPrometheusMetrics(WithUserAgent(lo.Must(config.LoadDefaultConfig(ctx))), crmetrics.Registry)
 	cfg.APIOptions = append(cfg.APIOptions, middleware.StructuredErrorHandler)
 	if cfg.Region == "" {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Drops the kubelet compatibility annotation check from v1.1

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.