### PR TITLE
chore: Add error for AL2 with K8s 1.33+ 

### DIFF
--- a/pkg/controllers/nodeclass/ami.go
+++ b/pkg/controllers/nodeclass/ami.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -47,6 +48,9 @@ func NewAMIReconciler(provider amifamily.Provider) *AMI {
 func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	amis, err := a.amiProvider.List(ctx, nodeClass)
 	if err != nil {
+		if strings.Contains(err.Error(), "AL2 is no longer supported for EKS version") {
+			return reconcile.Result{}, reconcile.TerminalError(err)
+		}
 		return reconcile.Result{}, fmt.Errorf("getting amis, %w", err)
 	}
 	if len(amis) == 0 {

--- a/pkg/controllers/nodeclass/ami.go
+++ b/pkg/controllers/nodeclass/ami.go
@@ -48,7 +48,7 @@ func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconc
 	amis, err := a.amiProvider.List(ctx, nodeClass)
 	if err != nil {
 		if amifamily.IsAl2DeprecationError(err) {
-			nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "AL2Deprecation", err.Error())
+			nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "UnsupportedAlias", err.Error())
 			return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("getting amis, %w", err))
 		}
 		return reconcile.Result{}, fmt.Errorf("getting amis, %w", err)

--- a/pkg/controllers/nodeclass/ami.go
+++ b/pkg/controllers/nodeclass/ami.go
@@ -49,7 +49,7 @@ func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconc
 	amis, err := a.amiProvider.List(ctx, nodeClass)
 	if err != nil {
 		if strings.Contains(err.Error(), "AL2 is no longer supported for EKS version") {
-			return reconcile.Result{}, reconcile.TerminalError(err)
+			return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("getting amis, %w", err))
 		}
 		return reconcile.Result{}, fmt.Errorf("getting amis, %w", err)
 	}

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -91,7 +91,9 @@ func (p *DefaultProvider) DescribeImageQueries(ctx context.Context, nodeClass *v
 		if alias.Family == v1.AMIFamilyAL2 {
 			minorVersion, err := strconv.Atoi(strings.Split(kubernetesVersion, ".")[1])
 			if err == nil && minorVersion >= 33 {
-				return nil, fmt.Errorf("AL2 aliases are no longer supported on EKS 1.33+ (see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-33)")
+				return nil, &AL2DeprecationError{
+					Message: "AL2 aliases are no longer supported on EKS 1.33+ (see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-33)",
+				}
 			}
 		}
 		query, err := GetAMIFamily(alias.Family, nil).DescribeImageQuery(ctx, p.ssmProvider, kubernetesVersion, alias.Version)

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -17,6 +17,7 @@ package amifamily
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -87,8 +88,9 @@ func (p *DefaultProvider) DescribeImageQueries(ctx context.Context, nodeClass *v
 	// This is enforced by a CEL validation, we will treat this as an invariant.
 	if alias := nodeClass.Alias(); alias != nil {
 		kubernetesVersion := p.versionProvider.Get(ctx)
-		if alias.Family == "AL2" {
-			if strings.Compare(kubernetesVersion, "1.33") >= 0 {
+		if alias.Family == v1.AMIFamilyAL2 {
+			minorVersion, err := strconv.Atoi(strings.Split(kubernetesVersion, ".")[1])
+			if err == nil && minorVersion >= 33 {
 				return nil, fmt.Errorf("AL2 aliases are no longer supported on EKS 1.33+ (see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-33)")
 			}
 		}

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -92,7 +92,7 @@ func (p *DefaultProvider) DescribeImageQueries(ctx context.Context, nodeClass *v
 			minorVersion, err := strconv.Atoi(strings.Split(kubernetesVersion, ".")[1])
 			if err == nil && minorVersion >= 33 {
 				return nil, &AL2DeprecationError{
-					Message: "AL2 aliases are no longer supported on EKS 1.33+ (see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-33)",
+					error: fmt.Errorf("AL2 aliases are no longer supported on EKS 1.33+ (see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-33)"),
 				}
 			}
 		}

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -87,6 +87,11 @@ func (p *DefaultProvider) DescribeImageQueries(ctx context.Context, nodeClass *v
 	// This is enforced by a CEL validation, we will treat this as an invariant.
 	if alias := nodeClass.Alias(); alias != nil {
 		kubernetesVersion := p.versionProvider.Get(ctx)
+		if alias.Family == "AL2" {
+			if strings.Compare(kubernetesVersion, "1.33") >= 0 {
+				return nil, fmt.Errorf("AL2 is no longer supported for EKS versions %s + "+". Here is the deprecation notice: https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-deprecation-faqs.html", kubernetesVersion)
+			}
+		}
 		query, err := GetAMIFamily(alias.Family, nil).DescribeImageQuery(ctx, p.ssmProvider, kubernetesVersion, alias.Version)
 		if err != nil {
 			return []DescribeImageQuery{}, err

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -89,7 +89,7 @@ func (p *DefaultProvider) DescribeImageQueries(ctx context.Context, nodeClass *v
 		kubernetesVersion := p.versionProvider.Get(ctx)
 		if alias.Family == "AL2" {
 			if strings.Compare(kubernetesVersion, "1.33") >= 0 {
-				return nil, fmt.Errorf("AL2 is no longer supported for EKS versions %s + "+". Here is the deprecation notice: https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-deprecation-faqs.html", kubernetesVersion)
+				return nil, fmt.Errorf("AL2 aliases are no longer supported on EKS 1.33+ (see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-33)")
 			}
 		}
 		query, err := GetAMIFamily(alias.Family, nil).DescribeImageQuery(ctx, p.ssmProvider, kubernetesVersion, alias.Version)

--- a/pkg/providers/amifamily/suite_test.go
+++ b/pkg/providers/amifamily/suite_test.go
@@ -138,6 +138,33 @@ var _ = Describe("AMIProvider", func() {
 		version = awsEnv.VersionProvider.Get(ctx)
 		nodeClass = test.EC2NodeClass()
 	})
+	It("should fail when AL2 is used with Kubernetes version 1.33 or greater", func() {
+
+		// Test with Kubernetes 1.33
+		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
+		_, err := awsEnv.AMIProvider.DescribeImageQueries(ctx, nodeClass)
+		Expect(err).To(HaveOccurred())
+
+		// Test with Kubernetes 1.34
+		_, err = awsEnv.AMIProvider.DescribeImageQueries(ctx, nodeClass)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("AL2 is no longer supported for EKS version"))
+
+		// Test with Kubernetes 1.32 (should work)
+		// awsEnv.VersionProvider.Version = "1.32.0"
+		_, err = awsEnv.AMIProvider.DescribeImageQueries(ctx, nodeClass)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test with AL2023 and Kubernetes 1.33 (should work)
+		// awsEnv.VersionProvider.Version = "1.33.0"
+		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
+		_, err = awsEnv.AMIProvider.DescribeImageQueries(ctx, nodeClass)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Restore the original version
+		// awsEnv.VersionProvider.Version = originalVersion
+	})
+
 	It("should succeed to resolve AMIs (AL2)", func() {
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 		awsEnv.SSMAPI.Parameters = map[string]string{

--- a/pkg/providers/amifamily/suite_test.go
+++ b/pkg/providers/amifamily/suite_test.go
@@ -140,7 +140,7 @@ func (m *MockVersionProvider) Get(ctx context.Context) string {
 	return m.version
 }
 
-func withKubernetesVersion(version string) *amifamily.DefaultProvider {
+func mockAmiProvider(version string) *amifamily.DefaultProvider {
 	mockVersionProvider := &MockVersionProvider{version: version}
 	return amifamily.NewDefaultProvider(awsEnv.Clock, mockVersionProvider, awsEnv.SSMProvider, awsEnv.EC2API, awsEnv.EC2Cache)
 }
@@ -151,25 +151,23 @@ var _ = Describe("AMIProvider", func() {
 		version = awsEnv.VersionProvider.Get(ctx)
 		nodeClass = test.EC2NodeClass()
 	})
-	It("should fail when AL2 is used with Kubernetes version 1.33 or greater", func() {
-		amiProvider := withKubernetesVersion("1.33.0")
-		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
-		_, err := amiProvider.DescribeImageQueries(ctx, nodeClass)
-		Expect(err).To(HaveOccurred())
-
-		amiProvider = withKubernetesVersion("1.34.2")
-		_, err = amiProvider.DescribeImageQueries(ctx, nodeClass)
-		Expect(err).To(HaveOccurred())
-
-		amiProvider = withKubernetesVersion("1.32.0")
-		_, err = amiProvider.DescribeImageQueries(ctx, nodeClass)
-		Expect(err).ToNot(HaveOccurred())
-
-		amiProvider = withKubernetesVersion("1.33.0")
-		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
-		_, err = amiProvider.DescribeImageQueries(ctx, nodeClass)
-		Expect(err).ToNot(HaveOccurred())
-	})
+	DescribeTable(
+		"should fail when AL2 is used with Kubernetes version 1.33 or greater",
+		func(k8sVersion string, amiAlias string, expectError bool) {
+			amiProvider := mockAmiProvider(k8sVersion)
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: amiAlias}}
+			_, err := amiProvider.DescribeImageQueries(ctx, nodeClass)
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry("should fail for AL2 on 1.33.0", "1.33.0", "al2@latest", true),
+		Entry("should fail for AL2 on 1.34.2", "1.34.2", "al2@latest", true),
+		Entry("should succeed for AL2 on 1.32.0", "1.32.0", "al2@latest", false),
+		Entry("should succeed for AL2023 on 1.33.0", "1.33.0", "al2023@latest", false),
+	)
 
 	It("should succeed to resolve AMIs (AL2)", func() {
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}

--- a/pkg/providers/amifamily/suite_test.go
+++ b/pkg/providers/amifamily/suite_test.go
@@ -140,7 +140,7 @@ func (m *MockVersionProvider) Get(ctx context.Context) string {
 	return m.version
 }
 
-func mockAmiProvider(version string) *amifamily.DefaultProvider {
+func amiProviderWithEKSVersionOverride(version string) *amifamily.DefaultProvider {
 	mockVersionProvider := &MockVersionProvider{version: version}
 	return amifamily.NewDefaultProvider(awsEnv.Clock, mockVersionProvider, awsEnv.SSMProvider, awsEnv.EC2API, awsEnv.EC2Cache)
 }
@@ -154,7 +154,7 @@ var _ = Describe("AMIProvider", func() {
 	DescribeTable(
 		"should fail when AL2 is used with Kubernetes version 1.33 or greater",
 		func(k8sVersion string, amiAlias string, expectError bool) {
-			amiProvider := mockAmiProvider(k8sVersion)
+			amiProvider := amiProviderWithEKSVersionOverride(k8sVersion)
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: amiAlias}}
 			_, err := amiProvider.DescribeImageQueries(ctx, nodeClass)
 			if expectError {

--- a/pkg/providers/amifamily/types.go
+++ b/pkg/providers/amifamily/types.go
@@ -131,7 +131,7 @@ func (q DescribeImageQuery) RequirementsForImageWithArchitecture(image string, a
 }
 
 type AL2DeprecationError struct {
-	Message string
+	error
 }
 
 func (e *AL2DeprecationError) Error() string {

--- a/pkg/providers/amifamily/types.go
+++ b/pkg/providers/amifamily/types.go
@@ -134,10 +134,6 @@ type AL2DeprecationError struct {
 	error
 }
 
-func (e *AL2DeprecationError) Error() string {
-	return e.Message
-}
-
 func IsAl2DeprecationError(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/providers/amifamily/types.go
+++ b/pkg/providers/amifamily/types.go
@@ -15,6 +15,7 @@ limitations under the License.
 package amifamily
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -127,4 +128,20 @@ func (q DescribeImageQuery) RequirementsForImageWithArchitecture(image string, a
 		})
 	}
 	return []scheduling.Requirements{scheduling.NewRequirements(scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, arch))}
+}
+
+type AL2DeprecationError struct {
+	Message string
+}
+
+func (e *AL2DeprecationError) Error() string {
+	return e.Message
+}
+
+func IsAl2DeprecationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var al2Err *AL2DeprecationError
+	return errors.As(err, &al2Err)
 }

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -95,6 +95,7 @@ type Environment struct {
 	AMIResolver                 *amifamily.DefaultResolver
 	VersionProvider             *version.DefaultProvider
 	LaunchTemplateProvider      *launchtemplate.DefaultProvider
+	SSMProvider                 *ssmp.DefaultProvider
 }
 
 func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment {
@@ -205,6 +206,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		AMIProvider:                 amiProvider,
 		AMIResolver:                 amiResolver,
 		VersionProvider:             versionProvider,
+		SSMProvider:                 ssmProvider,
 	}
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR insures Karpenter provides a useful error message to customers who are still using alias: al2@* on EKS 1.33+

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.