### PR TITLE
chore: genericize launch mode evaulation for lts

### DIFF
--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -205,7 +205,7 @@ func (v *Validation) validateCreateLaunchTemplateAuthorization(
 	if err != nil {
 		return "", false, fmt.Errorf("generating options, %w", err)
 	}
-	createLaunchTemplateInput := launchtemplate.GetCreateLaunchTemplateInput(ctx, opts, corev1.IPv4Protocol, "")
+	createLaunchTemplateInput := launchtemplate.NewCreateLaunchTemplateInputBuilder(opts, corev1.IPv4Protocol, "").Build(ctx)
 	createLaunchTemplateInput.DryRun = lo.ToPtr(true)
 	// Adding NopRetryer to avoid aggressive retry when rate limited
 	if _, err := v.ec2api.CreateLaunchTemplate(ctx, createLaunchTemplateInput, func(o *ec2.Options) {
@@ -237,7 +237,7 @@ func (v *Validation) validateRunInstancesAuthorization(
 
 	// We can directly marshal from CreateLaunchTemplate LaunchTemplate data
 	runInstancesInput := &ec2.RunInstancesInput{}
-	raw, err := json.Marshal(launchtemplate.GetCreateLaunchTemplateInput(ctx, opts, corev1.IPv4Protocol, "").LaunchTemplateData)
+	raw, err := json.Marshal(launchtemplate.NewCreateLaunchTemplateInputBuilder(opts, corev1.IPv4Protocol, "").Build(ctx).LaunchTemplateData)
 	if err != nil {
 		return "", false, fmt.Errorf("converting launch template input to run instances input, %w", err)
 	}

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/awslabs/operatorpkg/option"
 	"github.com/awslabs/operatorpkg/serrors"
 	"go.uber.org/multierr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -40,8 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
-	karpoptions "sigs.k8s.io/karpenter/pkg/operator/options"
-
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
@@ -56,23 +55,21 @@ import (
 	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
 )
 
-type Provider interface {
-	EnsureAll(context.Context, *v1.EC2NodeClass, *karpv1.NodeClaim,
-		[]*cloudprovider.InstanceType, string, map[string]string) ([]*LaunchTemplate, error)
-	DeleteAll(context.Context, *v1.EC2NodeClass) error
-	InvalidateCache(context.Context, string, string)
-	ResolveClusterCIDR(context.Context) error
-	CreateAMIOptions(context.Context, *v1.EC2NodeClass, map[string]string, map[string]string) (*amifamily.Options, error)
+type DefaultProviderOpts = option.Function[defaultProviderOpts]
+
+type defaultProviderOpts struct {
+	launchModeProvider LaunchModeProvider
 }
-type LaunchTemplate struct {
-	Name                  string
-	InstanceTypes         []*cloudprovider.InstanceType
-	ImageID               string
-	CapacityReservationID string
+
+func WithLaunchModeProvider(provider LaunchModeProvider) DefaultProviderOpts {
+	return func(opts *defaultProviderOpts) {
+		opts.launchModeProvider = provider
+	}
 }
 
 type DefaultProvider struct {
 	sync.Mutex
+	LaunchModeProvider
 	ec2api                sdk.EC2API
 	eksapi                sdk.EKSAPI
 	amiFamily             amifamily.Resolver
@@ -87,10 +84,26 @@ type DefaultProvider struct {
 	ClusterIPFamily       corev1.IPFamily
 }
 
-func NewDefaultProvider(ctx context.Context, cache *cache.Cache, ec2api sdk.EC2API, eksapi sdk.EKSAPI, amiFamily amifamily.Resolver,
-	securityGroupProvider securitygroup.Provider, subnetProvider subnet.Provider,
-	caBundle *string, startAsync <-chan struct{}, kubeDNSIP net.IP, clusterEndpoint string) *DefaultProvider {
+func NewDefaultProvider(
+	ctx context.Context,
+	cache *cache.Cache,
+	ec2api sdk.EC2API,
+	eksapi sdk.EKSAPI,
+	amiFamily amifamily.Resolver,
+	securityGroupProvider securitygroup.Provider,
+	subnetProvider subnet.Provider,
+	caBundle *string,
+	startAsync <-chan struct{},
+	kubeDNSIP net.IP,
+	clusterEndpoint string,
+	opts ...DefaultProviderOpts,
+) *DefaultProvider {
+	resolvedOpts := option.Resolve(opts...)
+	if resolvedOpts.launchModeProvider == nil {
+		resolvedOpts.launchModeProvider = defaultLaunchModeProvider{}
+	}
 	l := &DefaultProvider{
+		LaunchModeProvider:    resolvedOpts.launchModeProvider,
 		ec2api:                ec2api,
 		eksapi:                eksapi,
 		amiFamily:             amiFamily,
@@ -165,9 +178,11 @@ func (p *DefaultProvider) InvalidateCache(ctx context.Context, ltName string, lt
 	log.FromContext(ctx).V(1).Info("invalidating launch template in the cache because it no longer exists")
 	p.cache.Delete(ltName)
 }
+
 func LaunchTemplateName(options *amifamily.LaunchTemplate) string {
 	return fmt.Sprintf("%s/%d", v1.LaunchTemplateNamePrefix, lo.Must(hashstructure.Hash(options, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})))
 }
+
 func (p *DefaultProvider) CreateAMIOptions(ctx context.Context, nodeClass *v1.EC2NodeClass, labels, tags map[string]string) (*amifamily.Options, error) {
 	// Remove any labels passed into userData that are prefixed with "node-restriction.kubernetes.io" or "kops.k8s.io" since the kubelet can't
 	// register the node with any labels from this domain: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
@@ -242,86 +257,13 @@ func (p *DefaultProvider) createLaunchTemplate(ctx context.Context, options *ami
 	if err != nil {
 		return ec2types.LaunchTemplate{}, err
 	}
-	createLaunchTemplateInput := GetCreateLaunchTemplateInput(ctx, options, p.ClusterIPFamily, userData)
+	createLaunchTemplateInput := NewCreateLaunchTemplateInputBuilder(options, p.ClusterIPFamily, userData).WithLaunchModeProvider(p).Build(ctx)
 	output, err := p.ec2api.CreateLaunchTemplate(ctx, createLaunchTemplateInput)
 	if err != nil {
 		return ec2types.LaunchTemplate{}, err
 	}
 	log.FromContext(ctx).WithValues("id", aws.ToString(output.LaunchTemplate.LaunchTemplateId)).V(1).Info("created launch template")
 	return lo.FromPtr(output.LaunchTemplate), nil
-}
-
-// you need UserData, AmiID, tags, blockdevicemappings, instance profile,
-func GetCreateLaunchTemplateInput(
-	ctx context.Context,
-	options *amifamily.LaunchTemplate,
-	ClusterIPFamily corev1.IPFamily,
-	userData string,
-) *ec2.CreateLaunchTemplateInput {
-	launchTemplateDataTags := []ec2types.LaunchTemplateTagSpecificationRequest{
-		{ResourceType: ec2types.ResourceTypeNetworkInterface, Tags: utils.EC2MergeTags(options.Tags)},
-	}
-	if options.CapacityType == karpv1.CapacityTypeSpot {
-		launchTemplateDataTags = append(launchTemplateDataTags, ec2types.LaunchTemplateTagSpecificationRequest{ResourceType: ec2types.ResourceTypeSpotInstancesRequest, Tags: utils.EC2MergeTags(options.Tags)})
-	}
-	networkInterfaces := generateNetworkInterfaces(options, ClusterIPFamily)
-	lt := &ec2.CreateLaunchTemplateInput{
-		LaunchTemplateName: aws.String(LaunchTemplateName(options)),
-		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
-			BlockDeviceMappings: blockDeviceMappings(options.BlockDeviceMappings),
-			IamInstanceProfile: &ec2types.LaunchTemplateIamInstanceProfileSpecificationRequest{
-				Name: aws.String(options.InstanceProfile),
-			},
-			Monitoring: &ec2types.LaunchTemplatesMonitoringRequest{
-				Enabled: aws.Bool(options.DetailedMonitoring),
-			},
-			// If the network interface is defined, the security groups are defined within it
-			SecurityGroupIds: lo.Ternary(networkInterfaces != nil, nil, lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })),
-			UserData:         aws.String(userData),
-			ImageId:          aws.String(options.AMIID),
-			MetadataOptions: &ec2types.LaunchTemplateInstanceMetadataOptionsRequest{
-				HttpEndpoint:     ec2types.LaunchTemplateInstanceMetadataEndpointState(lo.FromPtr(options.MetadataOptions.HTTPEndpoint)),
-				HttpProtocolIpv6: ec2types.LaunchTemplateInstanceMetadataProtocolIpv6(lo.FromPtr(options.MetadataOptions.HTTPProtocolIPv6)),
-				//Will be removed when we update options.MetadataOptions.HTTPPutResponseHopLimit type to be int32
-				//nolint: gosec
-				HttpPutResponseHopLimit: lo.ToPtr(int32(lo.FromPtr(options.MetadataOptions.HTTPPutResponseHopLimit))),
-				HttpTokens:              ec2types.LaunchTemplateHttpTokensState(lo.FromPtr(options.MetadataOptions.HTTPTokens)),
-				// We statically set the InstanceMetadataTags to "disabled" for all new instances since
-				// account-wide defaults can override instance defaults on metadata settings
-				// This can cause instance failure on accounts that default to instance tags since Karpenter
-				// can't support instance tags with its current tags (e.g. kubernetes.io/cluster/*, karpenter.k8s.aws/ec2nodeclass)
-				// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html#instance-metadata-options-order-of-precedence
-				InstanceMetadataTags: ec2types.LaunchTemplateInstanceMetadataTagsStateDisabled,
-			},
-			NetworkInterfaces: networkInterfaces,
-			TagSpecifications: launchTemplateDataTags,
-		},
-		TagSpecifications: []ec2types.TagSpecification{
-			{
-				ResourceType: ec2types.ResourceTypeLaunchTemplate,
-				Tags:         utils.EC2MergeTags(options.Tags),
-			},
-		},
-	}
-	// Gate this specifically since the update to CapacityReservationPreference will opt od / spot launches out of open
-	// ODCRs, which is a breaking change from the pre-native ODCR support behavior.
-	if karpoptions.FromContext(ctx).FeatureGates.ReservedCapacity {
-		lt.LaunchTemplateData.CapacityReservationSpecification = &ec2types.LaunchTemplateCapacityReservationSpecificationRequest{
-			CapacityReservationPreference: lo.Ternary(
-				options.CapacityType == karpv1.CapacityTypeReserved,
-				ec2types.CapacityReservationPreferenceCapacityReservationsOnly,
-				ec2types.CapacityReservationPreferenceNone,
-			),
-			CapacityReservationTarget: lo.Ternary(
-				options.CapacityType == karpv1.CapacityTypeReserved,
-				&ec2types.CapacityReservationTarget{
-					CapacityReservationId: &options.CapacityReservationID,
-				},
-				nil,
-			),
-		}
-	}
-	return lt
 }
 
 // generateNetworkInterfaces generates network interfaces for the launch template.

--- a/pkg/providers/launchtemplate/types.go
+++ b/pkg/providers/launchtemplate/types.go
@@ -1,0 +1,163 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launchtemplate
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
+	"github.com/aws/karpenter-provider-aws/pkg/utils"
+)
+
+type Provider interface {
+	EnsureAll(context.Context, *v1.EC2NodeClass, *karpv1.NodeClaim,
+		[]*cloudprovider.InstanceType, string, map[string]string) ([]*LaunchTemplate, error)
+	DeleteAll(context.Context, *v1.EC2NodeClass) error
+	InvalidateCache(context.Context, string, string)
+	ResolveClusterCIDR(context.Context) error
+	CreateAMIOptions(context.Context, *v1.EC2NodeClass, map[string]string, map[string]string) (*amifamily.Options, error)
+}
+
+type LaunchTemplate struct {
+	Name                  string
+	InstanceTypes         []*cloudprovider.InstanceType
+	ImageID               string
+	CapacityReservationID string
+}
+
+type LaunchMode int
+
+const (
+	LaunchModeOpen LaunchMode = iota
+	LaunchModeTargeted
+)
+
+type LaunchModeProvider interface {
+	LaunchMode(context.Context) LaunchMode
+}
+
+type defaultLaunchModeProvider struct{}
+
+func (defaultLaunchModeProvider) LaunchMode(ctx context.Context) LaunchMode {
+	if options.FromContext(ctx).FeatureGates.ReservedCapacity {
+		return LaunchModeTargeted
+	}
+	return LaunchModeOpen
+}
+
+type CreateLaunchTemplateInputBuilder struct {
+	LaunchModeProvider
+	options         *amifamily.LaunchTemplate
+	clusterIPFamily corev1.IPFamily
+	userData        string
+}
+
+func NewCreateLaunchTemplateInputBuilder(
+	options *amifamily.LaunchTemplate,
+	clusterIPFamily corev1.IPFamily,
+	userData string,
+) *CreateLaunchTemplateInputBuilder {
+	return &CreateLaunchTemplateInputBuilder{
+		LaunchModeProvider: defaultLaunchModeProvider{},
+		options:            options,
+		clusterIPFamily:    clusterIPFamily,
+		userData:           userData,
+	}
+}
+
+func (b *CreateLaunchTemplateInputBuilder) WithLaunchModeProvider(provider LaunchModeProvider) *CreateLaunchTemplateInputBuilder {
+	b.LaunchModeProvider = provider
+	return b
+}
+
+func (b *CreateLaunchTemplateInputBuilder) Build(ctx context.Context) *ec2.CreateLaunchTemplateInput {
+	launchTemplateDataTags := []ec2types.LaunchTemplateTagSpecificationRequest{{
+		ResourceType: ec2types.ResourceTypeNetworkInterface,
+		Tags:         utils.EC2MergeTags(b.options.Tags),
+	}}
+	if b.options.CapacityType == karpv1.CapacityTypeSpot {
+		launchTemplateDataTags = append(launchTemplateDataTags, ec2types.LaunchTemplateTagSpecificationRequest{
+			ResourceType: ec2types.ResourceTypeSpotInstancesRequest,
+			Tags:         utils.EC2MergeTags(b.options.Tags),
+		})
+	}
+	networkInterfaces := generateNetworkInterfaces(b.options, b.clusterIPFamily)
+	lt := &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: lo.ToPtr(LaunchTemplateName(b.options)),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			BlockDeviceMappings: blockDeviceMappings(b.options.BlockDeviceMappings),
+			IamInstanceProfile: &ec2types.LaunchTemplateIamInstanceProfileSpecificationRequest{
+				Name: lo.ToPtr(b.options.InstanceProfile),
+			},
+			Monitoring: &ec2types.LaunchTemplatesMonitoringRequest{
+				Enabled: lo.ToPtr(b.options.DetailedMonitoring),
+			},
+			// If the network interface is defined, the security groups are defined within it
+			SecurityGroupIds: lo.Ternary(networkInterfaces != nil, nil, lo.Map(b.options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })),
+			UserData:         lo.ToPtr(b.userData),
+			ImageId:          lo.ToPtr(b.options.AMIID),
+			MetadataOptions: &ec2types.LaunchTemplateInstanceMetadataOptionsRequest{
+				HttpEndpoint:     ec2types.LaunchTemplateInstanceMetadataEndpointState(lo.FromPtr(b.options.MetadataOptions.HTTPEndpoint)),
+				HttpProtocolIpv6: ec2types.LaunchTemplateInstanceMetadataProtocolIpv6(lo.FromPtr(b.options.MetadataOptions.HTTPProtocolIPv6)),
+				//Will be removed when we update options.MetadataOptions.HTTPPutResponseHopLimit type to be int32
+				//nolint: gosec
+				HttpPutResponseHopLimit: lo.ToPtr(int32(lo.FromPtr(b.options.MetadataOptions.HTTPPutResponseHopLimit))),
+				HttpTokens:              ec2types.LaunchTemplateHttpTokensState(lo.FromPtr(b.options.MetadataOptions.HTTPTokens)),
+				// We statically set the InstanceMetadataTags to "disabled" for all new instances since
+				// account-wide defaults can override instance defaults on metadata settings
+				// This can cause instance failure on accounts that default to instance tags since Karpenter
+				// can't support instance tags with its current tags (e.g. kubernetes.io/cluster/*, karpenter.k8s.aws/ec2nodeclass)
+				// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html#instance-metadata-options-order-of-precedence
+				InstanceMetadataTags: ec2types.LaunchTemplateInstanceMetadataTagsStateDisabled,
+			},
+			NetworkInterfaces: networkInterfaces,
+			TagSpecifications: launchTemplateDataTags,
+		},
+		TagSpecifications: []ec2types.TagSpecification{
+			{
+				ResourceType: ec2types.ResourceTypeLaunchTemplate,
+				Tags:         utils.EC2MergeTags(b.options.Tags),
+			},
+		},
+	}
+	// Gate this specifically since the update to CapacityReservationPreference will opt od / spot launches out of open
+	// ODCRs, which is a breaking change from the pre-native ODCR support behavior.
+	if b.LaunchMode(ctx) == LaunchModeTargeted {
+		lt.LaunchTemplateData.CapacityReservationSpecification = &ec2types.LaunchTemplateCapacityReservationSpecificationRequest{
+			CapacityReservationPreference: lo.Ternary(
+				b.options.CapacityType == karpv1.CapacityTypeReserved,
+				ec2types.CapacityReservationPreferenceCapacityReservationsOnly,
+				ec2types.CapacityReservationPreferenceNone,
+			),
+			CapacityReservationTarget: lo.Ternary(
+				b.options.CapacityType == karpv1.CapacityTypeReserved,
+				&ec2types.CapacityReservationTarget{
+					CapacityReservationId: &b.options.CapacityReservationID,
+				},
+				nil,
+			),
+		}
+	}
+	return lt
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Adds an interface, `LaunchModeProvider`, which is consumed by the default launchtemplate provider implementation and the (new) CreateLaunchTemplateInput builder. 

**How was this change tested?**
`make presubmit` 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.