### PR TITLE
V1.4.0 capacity optimized

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.4
-	sigs.k8s.io/karpenter v1.3.2-0.20250415230907-3e7673a3f638
+	sigs.k8s.io/karpenter v1.4.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
-sigs.k8s.io/karpenter v1.3.2-0.20250415230907-3e7673a3f638 h1:lRtpjoO6sU8dEGl6znjDMEWq5FeLBLwZZEq75IBa/7g=
-sigs.k8s.io/karpenter v1.3.2-0.20250415230907-3e7673a3f638/go.mod h1:ZM5S7T9frHaDuXmck5KpunjCm9bDaaViLHe83kT29Rw=
+sigs.k8s.io/karpenter v1.4.0 h1:LXI9u2QC68FpA4Hw3+WtpT9WcRTkyEKIAFWcsdGXSGo=
+sigs.k8s.io/karpenter v1.4.0/go.mod h1:ZM5S7T9frHaDuXmck5KpunjCm9bDaaViLHe83kT29Rw=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aNqRlpuvjmwA=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -267,7 +267,7 @@ func (p *DefaultProvider) launchInstance(
 	// Create fleet
 	createFleetInput := GetCreateFleetInput(nodeClass, capacityType, tags, launchTemplateConfigs)
 	if capacityType == karpv1.CapacityTypeSpot {
-		createFleetInput.SpotOptions = &ec2types.SpotOptionsRequest{AllocationStrategy: ec2types.SpotAllocationStrategyPriceCapacityOptimized}
+		createFleetInput.SpotOptions = &ec2types.SpotOptionsRequest{AllocationStrategy: ec2types.SpotAllocationStrategyCapacityOptimized}
 	} else {
 		createFleetInput.OnDemandOptions = &ec2types.OnDemandOptionsRequest{AllocationStrategy: ec2types.FleetOnDemandAllocationStrategyLowestPrice}
 	}


### PR DESCRIPTION
we are observing high spot interruption in pod998 after changing to karpenter. the idea is to hard-code capacity-optimized-prioritized allocation strategy to see if we lower frequency of interruptions