### PR TITLE
docs: documentation update for instance type scheduling requirements

### DIFF
--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -440,6 +440,13 @@ nodeAffinity:
             values: ['us-east-1a', 'us-east-1b']
 ```
 
+### Log message of `no instance type met the scheduling requirements or had a required offering` is reported
+
+This error suggests that there is no instance type available that meets the pod's scheduling requirements. A pod may have resource requests that necessitate a minimum instance size. If the pod is confined to a Node Pool with a specific instance family and size, it might not find an instance type that aligns with its resource needs. Additionally, resource requests from daemonsets are considered when determining if an instance type is compatible with the pod.
+
+
+The phrase `had a required offering` pertains to the availability of an instance type in a specific location, such as an availability zone. This error can occur if a pod is restricted to a particular availability zone. For instance, consider a pod in a stateful set that previously had an EBS volume attached. If the subnet where the pod is scheduled changes, the pod might end up in a different availability zone than the EBS volume it needs to attach to. This mismatch in availability zones can lead to an error related to the required offering.
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v0.32/troubleshooting.md
+++ b/website/content/en/v0.32/troubleshooting.md
@@ -492,6 +492,13 @@ nodeAffinity:
             values: ['us-east-1a', 'us-east-1b']
 ```
 
+### Log message of `no instance type met the scheduling requirements or had a required offering` is reported
+
+This error suggests that there is no instance type available that meets the pod's scheduling requirements. A pod may have resource requests that necessitate a minimum instance size. If the pod is confined to a Node Pool with a specific instance family and size, it might not find an instance type that aligns with its resource needs. Additionally, resource requests from daemonsets are considered when determining if an instance type is compatible with the pod.
+
+
+The phrase `had a required offering` pertains to the availability of an instance type in a specific location, such as an availability zone. This error can occur if a pod is restricted to a particular availability zone. For instance, consider a pod in a stateful set that previously had an EBS volume attached. If the subnet where the pod is scheduled changes, the pod might end up in a different availability zone than the EBS volume it needs to attach to. This mismatch in availability zones can lead to an error related to the required offering.
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v1.0/troubleshooting.md
+++ b/website/content/en/v1.0/troubleshooting.md
@@ -431,6 +431,13 @@ nodeAffinity:
             values: ['us-east-1a', 'us-east-1b']
 ```
 
+### Log message of `no instance type met the scheduling requirements or had a required offering` is reported
+
+This error suggests that there is no instance type available that meets the pod's scheduling requirements. A pod may have resource requests that necessitate a minimum instance size. If the pod is confined to a Node Pool with a specific instance family and size, it might not find an instance type that aligns with its resource needs. Additionally, resource requests from daemonsets are considered when determining if an instance type is compatible with the pod.
+
+
+The phrase `had a required offering` pertains to the availability of an instance type in a specific location, such as an availability zone. This error can occur if a pod is restricted to a particular availability zone. For instance, consider a pod in a stateful set that previously had an EBS volume attached. If the subnet where the pod is scheduled changes, the pod might end up in a different availability zone than the EBS volume it needs to attach to. This mismatch in availability zones can lead to an error related to the required offering.
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v1.3/troubleshooting.md
+++ b/website/content/en/v1.3/troubleshooting.md
@@ -440,6 +440,13 @@ nodeAffinity:
             values: ['us-east-1a', 'us-east-1b']
 ```
 
+### Log message of `no instance type met the scheduling requirements or had a required offering` is reported
+
+This error suggests that there is no instance type available that meets the pod's scheduling requirements. A pod may have resource requests that necessitate a minimum instance size. If the pod is confined to a Node Pool with a specific instance family and size, it might not find an instance type that aligns with its resource needs. Additionally, resource requests from daemonsets are considered when determining if an instance type is compatible with the pod.
+
+
+The phrase `had a required offering` pertains to the availability of an instance type in a specific location, such as an availability zone. This error can occur if a pod is restricted to a particular availability zone. For instance, consider a pod in a stateful set that previously had an EBS volume attached. If the subnet where the pod is scheduled changes, the pod might end up in a different availability zone than the EBS volume it needs to attach to. This mismatch in availability zones can lead to an error related to the required offering.
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v1.4/troubleshooting.md
+++ b/website/content/en/v1.4/troubleshooting.md
@@ -440,6 +440,13 @@ nodeAffinity:
             values: ['us-east-1a', 'us-east-1b']
 ```
 
+### Log message of `no instance type met the scheduling requirements or had a required offering` is reported
+
+This error suggests that there is no instance type available that meets the pod's scheduling requirements. A pod may have resource requests that necessitate a minimum instance size. If the pod is confined to a Node Pool with a specific instance family and size, it might not find an instance type that aligns with its resource needs. Additionally, resource requests from daemonsets are considered when determining if an instance type is compatible with the pod.
+
+
+The phrase `had a required offering` pertains to the availability of an instance type in a specific location, such as an availability zone. This error can occur if a pod is restricted to a particular availability zone. For instance, consider a pod in a stateful set that previously had an EBS volume attached. If the subnet where the pod is scheduled changes, the pod might end up in a different availability zone than the EBS volume it needs to attach to. This mismatch in availability zones can lead to an error related to the required offering.
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v1.5/troubleshooting.md
+++ b/website/content/en/v1.5/troubleshooting.md
@@ -440,6 +440,13 @@ nodeAffinity:
             values: ['us-east-1a', 'us-east-1b']
 ```
 
+### Log message of `no instance type met the scheduling requirements or had a required offering` is reported
+
+This error suggests that there is no instance type available that meets the pod's scheduling requirements. A pod may have resource requests that necessitate a minimum instance size. If the pod is confined to a Node Pool with a specific instance family and size, it might not find an instance type that aligns with its resource needs. Additionally, resource requests from daemonsets are considered when determining if an instance type is compatible with the pod.
+
+
+The phrase `had a required offering` pertains to the availability of an instance type in a specific location, such as an availability zone. This error can occur if a pod is restricted to a particular availability zone. For instance, consider a pod in a stateful set that previously had an EBS volume attached. If the subnet where the pod is scheduled changes, the pod might end up in a different availability zone than the EBS volume it needs to attach to. This mismatch in availability zones can lead to an error related to the required offering.
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned


### PR DESCRIPTION
**Description**

Adds some useful troubleshooting information to the troubleshooting guide on launching a node. The `offering` is in the error message refers to scheduling requirements such as the availability zone: https://github.com/kubernetes-sigs/karpenter/blob/1b5c30b3299f5ef16ab2a0bb0cd5b1147795f679/pkg/cloudprovider/types.go#L255

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.