### PR TITLE
ci: debug variant for make apply and image

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -49,6 +49,9 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.5.0 \
 | controller.envFrom | list | `[]` |  |
 | controller.extraVolumeMounts | list | `[]` | Additional volumeMounts for the controller container. |
 | controller.healthProbe.port | int | `8081` | The container port to use for http health probe. |
+| controller.healthProbe.livenessProbeEnabled | bool | `true` | Enable or disable the liveness probe. |
+| controller.healthProbe.readinessProbeEnabled | bool | `true` | Enable or disable the readiness probe. |
+| disableLeaderElection | bool | `false` | Disable leader election for the controller |
 | controller.image.digest | string | `"sha256:339aef3f5ecdf6f94d1c7cc9d0e1d359c281b4f9b842877bdbf2acd3fa360521"` | SHA256 digest of the controller image. |
 | controller.image.repository | string | `"public.ecr.aws/karpenter/controller"` | Repository path to the controller image. |
 | controller.image.tag | string | `"1.5.0"` | Tag of the controller image. |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
               value: "1.19.0-0"
             - name: KARPENTER_SERVICE
               value: {{ include "karpenter.fullname" . }}
+          {{- if .Values.disableLeaderElection }}
+            - name: DISABLE_LEADER_ELECTION
+              value: "true"
+          {{- end }}
           {{- with .Values.logLevel }}
             - name: LOG_LEVEL
               value: "{{ . }}"
@@ -177,18 +181,22 @@ spec:
             - name: http
               containerPort: {{ .Values.controller.healthProbe.port }}
               protocol: TCP
+          {{- if .Values.controller.healthProbe.livenessProbeEnabled }}
           livenessProbe:
             initialDelaySeconds: 30
             timeoutSeconds: 30
             httpGet:
               path: /healthz
               port: http
+          {{- end }}
+          {{- if .Values.controller.healthProbe.readinessProbeEnabled }}
           readinessProbe:
             initialDelaySeconds: 5
             timeoutSeconds: 30
             httpGet:
               path: /readyz
               port: http
+          {{- end }}
           {{- with .Values.controller.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -12,6 +12,8 @@ additionalAnnotations: {}
 imagePullPolicy: IfNotPresent
 # -- Image pull secrets for Docker images.
 imagePullSecrets: []
+# -- Disable leader election for the controller
+disableLeaderElection: false
 service:
   # -- Additional annotations for the Service.
   annotations: {}
@@ -164,6 +166,10 @@ controller:
   healthProbe:
     # -- The container port to use for http health probe.
     port: 8081
+    # -- Enable or disable the liveness probe
+    livenessProbeEnabled: true
+    # -- Enable or disable the readiness probe
+    readinessProbeEnabled: true
 # -- Global log level, defaults to 'info'
 logLevel: info
 # -- Log outputPaths - defaults to stdout only


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Adds a debug variant for `make apply` and `make image`. This variant is configured to be more friendly for use with delve. The variant can be used like so:
```bash
$ DEBUG=true make apply
```

This variant differs in the following ways:
- There's only a single controller replica
- Leader election, liveness probe, and readiness probe are all disabled (debugger pauses can cause the container to restart)
- Optimizations and trimpath are disabled for the go build
  - Note: `ko` does not currently support disabling trimpath. This PR is blocked until this is addressed, or we have another workaround: https://github.com/ko-build/ko/issues/1524

I've been making use of this by deploying an ephemeral debug container attached to the pod and connecting to it with delve locally:

**Ephemeral Container Spec:**
```
name: delve
image: xxx.dkr.ecr.us-west-2.amazonaws.com/dlv:1.24.2
imagePullPolicy: Always
securityContext:
  privileged: true
command:
- dlv
- --listen=0.0.0.0:2345
- --headless=true
- --accept-multiclient
- --api-version=2
- attach
- '1'
```

**How was this change tested?**
Manual validation

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.