### PR TITLE
fix(al2/bootstrap): set max pods through dedicated flag

### DIFF
--- a/pkg/providers/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/eksbootstrap.go
@@ -72,7 +72,7 @@ func (e EKS) eksBootstrapScript() string {
 		userData.WriteString(fmt.Sprintf(" \\\n--dns-cluster-ip '%s'", e.KubeletConfig.ClusterDNS[0]))
 	}
 	if e.KubeletConfig != nil && e.KubeletConfig.MaxPods != nil {
-		userData.WriteString(" \\\n--use-max-pods false")
+		userData.WriteString(fmt.Sprintf(" \\\n--use-max-pods false --max-pods-value %d", e.KubeletConfig.MaxPods))
 	}
 	if args := e.kubeletExtraArgs(); len(args) > 0 {
 		userData.WriteString(fmt.Sprintf(" \\\n--kubelet-extra-args '%s'", strings.Join(args, " ")))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Utilizes a new flag in the AL2 EKS AMI's bootstrap.sh script to specify the max pods value, in order to ensure that the memory reserved value is correctly calculated on changes.

**How was this change tested?**
WIP

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.