### PR TITLE
docs: remove make setup from development guide

### DIFF
--- a/website/content/en/docs/contributing/development-guide.md
+++ b/website/content/en/docs/contributing/development-guide.md
@@ -152,12 +152,6 @@ export KO_DOCKER_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws
 aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "${KO_DOCKER_REPO}"
 ```
 
-Finally, to deploy the correct IAM permissions, including the instance profile for provisioned nodes, run
-
-```bash
-make setup
-```
-
 ## Profiling
 Karpenter exposes a pprof endpoint on its metrics port when [profiling]({{< relref "../reference/settings" >}}) is enabled.
 

--- a/website/content/en/preview/contributing/development-guide.md
+++ b/website/content/en/preview/contributing/development-guide.md
@@ -152,12 +152,6 @@ export KO_DOCKER_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws
 aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "${KO_DOCKER_REPO}"
 ```
 
-Finally, to deploy the correct IAM permissions, including the instance profile for provisioned nodes, run
-
-```bash
-make setup
-```
-
 ## Profiling
 Karpenter exposes a pprof endpoint on its metrics port when [profiling]({{< relref "../reference/settings" >}}) is enabled.
 


### PR DESCRIPTION
Fixes https://github.com/aws/karpenter-provider-aws/issues/6501

**Description**

The command "make setup" has been removed in https://github.com/aws/karpenter-provider-aws/pull/5661 but is still referred to in the Development Guide.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.