### PR TITLE
chore: add karpenter suffix to default interruption queue name

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -18,7 +18,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
   --version 1.5.0 \
   --set "serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN}" \
   --set settings.clusterName=${CLUSTER_NAME} \
-  --set settings.interruptionQueue=${CLUSTER_NAME} \
+  --set settings.interruptionQueue=${QUEUE_NAME} \
   --wait
 ```
 

--- a/charts/karpenter/README.md.gotmpl
+++ b/charts/karpenter/README.md.gotmpl
@@ -17,7 +17,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
   --version {{ template "chart.version" . }} \
   --set "serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN}" \
   --set settings.clusterName=${CLUSTER_NAME} \
-  --set settings.interruptionQueue=${CLUSTER_NAME} \
+  --set settings.interruptionQueue=${QUEUE_NAME} \
   --wait
 ```
 

--- a/kwok/Makefile
+++ b/kwok/Makefile
@@ -5,12 +5,13 @@ MEMORY_RESOURCES ?= "4Gi"
 
 ## Extra helm options
 CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
+QUEUE_NAME ?= "${CLUSTER_NAME}-karpenter-interruption"
 CLUSTER_ENDPOINT ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}')
 AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query Account --output text)
 KARPENTER_IAM_ROLE_ARN ?= arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-karpenter
 HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${KARPENTER_IAM_ROLE_ARN} \
       		--set settings.clusterName=${CLUSTER_NAME} \
-			--set settings.interruptionQueue=${CLUSTER_NAME} \
+			--set settings.interruptionQueue=${QUEUE_NAME} \
 			--set controller.resources.requests.cpu=${CPU_RESOURCES} \
 			--set controller.resources.requests.memory=${MEMORY_RESOURCES} \
 			--set controller.resources.limits.cpu=${CPU_RESOURCES} \

--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -1,5 +1,6 @@
 aws eks update-kubeconfig --name "$CLUSTER_NAME"
 
+QUEUE_NAME="${CLUSTER_NAME}-karpenter-interruption"
 CHART="oci://$ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/karpenter/snapshot/karpenter"
 ADDITIONAL_FLAGS=""
 if [[ "$PRIVATE_CLUSTER" == "true" ]]; then
@@ -15,7 +16,7 @@ helm upgrade --install karpenter "${CHART}" \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::$ACCOUNT_ID:role/karpenter-irsa-$CLUSTER_NAME" \
   $ADDITIONAL_FLAGS \
   --set settings.clusterName="$CLUSTER_NAME" \
-  --set settings.interruptionQueue="$CLUSTER_NAME" \
+  --set settings.interruptionQueue="$QUEUE_NAME" \
   --set settings.featureGates.spotToSpotConsolidation=true \
   --set settings.featureGates.nodeRepair=true \
   --set settings.featureGates.reservedCapacity=true \

--- a/website/content/en/v1.0/upgrading/v1-migration.md
+++ b/website/content/en/v1.0/upgrading/v1-migration.md
@@ -153,6 +153,7 @@ You should still review the upgrade procedure; the sequence of operations remain
     ```bash
     export AWS_PARTITION="aws" # if you are not using standard partitions, you may need to configure to aws-cn / aws-us-gov
     export CLUSTER_NAME="${USER}-karpenter-demo"
+    export QUEUE_NAME="${CLUSTER_NAME}-karpenter-interruption"
     export AWS_REGION="us-west-2"
     export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
     export KARPENTER_NAMESPACE=kube-system
@@ -190,7 +191,7 @@ You should still review the upgrade procedure; the sequence of operations remain
     helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
       --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
       --set settings.clusterName=${CLUSTER_NAME} \
-      --set settings.interruptionQueue=${CLUSTER_NAME} \
+      --set settings.interruptionQueue=${QUEUE_NAME} \
       --set controller.resources.requests.cpu=1 \
       --set controller.resources.requests.memory=1Gi \
       --set controller.resources.limits.cpu=1 \
@@ -287,7 +288,7 @@ You should still review the upgrade procedure; the sequence of operations remain
     helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
       --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
       --set settings.clusterName=${CLUSTER_NAME} \
-      --set settings.interruptionQueue=${CLUSTER_NAME} \
+      --set settings.interruptionQueue=${QUEUE_NAME} \
       --set controller.resources.requests.cpu=1 \
       --set controller.resources.requests.memory=1Gi \
       --set controller.resources.limits.cpu=1 \
@@ -400,7 +401,7 @@ For example: `kubectl get nodepool.v1beta1.karpenter.sh`.
    helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
      --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
      --set settings.clusterName=${CLUSTER_NAME} \
-     --set settings.interruptionQueue=${CLUSTER_NAME} \
+     --set settings.interruptionQueue=${QUEUE_NAME} \
      --set controller.resources.requests.cpu=1 \
      --set controller.resources.requests.memory=1Gi \
      --set controller.resources.limits.cpu=1 \


### PR DESCRIPTION
**Description**

I always found it irritating to use the ${CLUSTER_NAME} without any suffix or prefix as name for the interruption_queue. It also made it more complicated to provide an existing queue when setting up a development environment for Karpenter.

I suggest to have a separate `QUEUE_NAME` variable, which can be overwritten more easily. For the default value I suggest `${CLUSTER_NAME}-karpenter-interruption` 

**Does this change impact docs?**
- [x] Yes, PR includes docs updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.