### PR TITLE
feat: ICE AZs temporarily when subnets in that AZ run out of available ips

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -30,6 +30,7 @@ const (
 	UnauthorizedOperationErrorCode                 = "UnauthorizedOperation"
 	RateLimitingErrorCode                          = "RequestLimitExceeded"
 	ServiceLinkedRoleCreationNotPermittedErrorCode = "AuthFailure.ServiceLinkedRoleCreationNotPermitted"
+	InsufficientFreeAddressesInSubnetErrorCode     = "InsufficientFreeAddressesInSubnet"
 )
 
 var (
@@ -157,6 +158,10 @@ func IsUnfulfillableCapacity(err ec2types.CreateFleetError) bool {
 
 func IsServiceLinkedRoleCreationNotPermitted(err ec2types.CreateFleetError) bool {
 	return *err.ErrorCode == ServiceLinkedRoleCreationNotPermittedErrorCode
+}
+
+func IsInsufficientFreeAddressesInSubnet(err ec2types.CreateFleetError) bool {
+	return *err.ErrorCode == InsufficientFreeAddressesInSubnetErrorCode
 }
 
 // IsReservationCapacityExceeded returns true if the fleet error means there is no remaining capacity for the provided

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -454,6 +454,9 @@ func (p *DefaultProvider) updateUnavailableOfferingsCache(
 				p.unavailableOfferings.MarkCapacityTypeUnavailable(karpv1.CapacityTypeSpot)
 				p.recorder.Publish(SpotServiceLinkedRoleCreationFailure(nodeClaim))
 			}
+			if awserrors.IsInsufficientFreeAddressesInSubnet(err) {
+				p.unavailableOfferings.MarkAZUnavailable(*err.LaunchTemplateAndOverrides.Overrides.AvailabilityZone)
+			}
 		}
 		return
 	}

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -376,7 +376,16 @@ var _ = Describe("InstanceProvider", func() {
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
 
-		// We should have set the subnet used in the request as unavailable
-		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", "on-demand")).To(BeTrue())
+		// We should have set the zone used in the request as unavailable for all instance types
+		for _, instance := range instanceTypes {
+			Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable(ec2types.InstanceType(instance.Name), "test-zone-1a", "on-demand")).To(BeTrue())
+		}
+		// But we should not have set the other zones as unavailable
+		zones := []string{"test-zone-1b", "test-zone-1c"}
+		for _, zone := range zones {
+			for _, instance := range instanceTypes {
+				Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable(ec2types.InstanceType(instance.Name), zone, "on-demand")).To(BeFalse())
+			}
+		}
 	})
 })


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

When CreateFleet returns an `InsufficientFreeAddressesInSubnet` error, we temporarily ICE the AZ in which that subnet resides

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.