### PR TITLE
fix: kube-reserved memory calculation should match AL2/AL2023 calculation

### DIFF
--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1856,7 +1856,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 					nodeClass.AMIFamily(),
 					nil,
 				)
-				limitedPods := instancetype.ENILimitedPods(ctx, info)
+				limitedPods := instancetype.ENILimitedPods(ctx, info, 0)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", limitedPods.Value()))
 			}
 		})

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -143,7 +143,7 @@ func NewInstanceType(
 		Requirements: computeRequirements(info, region, offeringZones, subnetZonesToZoneIDs, amiFamily, capacityReservations),
 		Capacity:     computeCapacity(ctx, info, amiFamily, blockDeviceMappings, instanceStorePolicy, maxPods, podsPerCore),
 		Overhead: &cloudprovider.InstanceTypeOverhead{
-			KubeReserved:      kubeReservedResources(cpu(info), lo.Ternary(amiFamily.FeatureFlags().UsesENILimitedMemoryOverhead, ENILimitedPods(options.ToContext(ctx, &options.Options{ReservedENIs: 0}), info), pods(ctx, info, amiFamily, maxPods, podsPerCore)), kubeReserved),
+			KubeReserved:      kubeReservedResources(cpu(info), lo.Ternary(amiFamily.FeatureFlags().UsesENILimitedMemoryOverhead, ENILimitedPods(ctx, info, 0), pods(ctx, info, amiFamily, maxPods, podsPerCore)), kubeReserved),
 			SystemReserved:    systemReservedResources(systemReserved),
 			EvictionThreshold: evictionThreshold(memory(ctx, info), ephemeralStorage(info, amiFamily, blockDeviceMappings, instanceStorePolicy), amiFamily, evictionHard, evictionSoft),
 		},
@@ -454,7 +454,7 @@ func efas(info ec2types.InstanceTypeInfo) *resource.Quantity {
 	return resources.Quantity(fmt.Sprint(count))
 }
 
-func ENILimitedPods(ctx context.Context, info ec2types.InstanceTypeInfo) *resource.Quantity {
+func ENILimitedPods(ctx context.Context, info ec2types.InstanceTypeInfo, reservedENIs int) *resource.Quantity {
 	// The number of pods per node is calculated using the formula:
 	// max number of ENIs * (IPv4 Addresses per ENI -1) + 2
 	// https://github.com/awslabs/amazon-eks-ami/blob/main/templates/shared/runtime/eni-max-pods.txt
@@ -462,7 +462,7 @@ func ENILimitedPods(ctx context.Context, info ec2types.InstanceTypeInfo) *resour
 	// VPC CNI only uses the default network interface
 	// https://github.com/aws/amazon-vpc-cni-k8s/blob/3294231c0dce52cfe473bf6c62f47956a3b333b6/scripts/gen_vpc_ip_limits.go#L162
 	networkInterfaces := *info.NetworkInfo.NetworkCards[*info.NetworkInfo.DefaultNetworkCardIndex].MaximumNetworkInterfaces
-	usableNetworkInterfaces := lo.Max([]int64{int64(int(networkInterfaces) - options.FromContext(ctx).ReservedENIs), 0})
+	usableNetworkInterfaces := lo.Max([]int64{int64(int(networkInterfaces) - reservedENIs), 0})
 	if usableNetworkInterfaces == 0 {
 		return resource.NewQuantity(0, resource.DecimalSI)
 	}
@@ -552,7 +552,7 @@ func pods(ctx context.Context, info ec2types.InstanceTypeInfo, amiFamily amifami
 	case maxPods != nil:
 		count = int64(lo.FromPtr(maxPods))
 	case amiFamily.FeatureFlags().SupportsENILimitedPodDensity:
-		count = ENILimitedPods(ctx, info).Value()
+		count = ENILimitedPods(ctx, info, options.FromContext(ctx).ReservedENIs).Value()
 	default:
 		count = 110
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Our current calculation for kube-reserved memory for AL2 and AL2023 does not match that of the AMI. This is because of the difference in the maxPods value used in the calculation when using reserved ENI. For example, 

When `reservedENI=0` for an `m6g.xlarge` instance `maxPods=58`
kube-reserved memory = 11 * 58 + 255 = 893

When `reservedENI=2` for an `m6g.xlarge` instance `maxPods=30`
kube-reserved memory = 11 * 58 + 255 = 585

While Karpenter uses the correct calculation with `maxPods=30`, AMI doesn't. This can cause karpenter to overestimate the amount of allocatable memory on the node which could lead to workload not getting scheduled on the node launched by karpenter but karpenter would keep launching the same node over and over again.

**How was this change tested?**
1. Added unit tests
2. Deployed the change to my dev cluster - 
   Memory requirement on the workload `14460620Ki` and a daemonset with memory `1Ki`
```
    nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: karpenter.k8s.aws/instance-family
                operator: In
                values:
                - m6g
```
3. Set Reserved ENI=2, should launch `m6g.2xlarge` and not `m6g.xlarge`. Previously Karpenter would launch `m6g.xlarge` because it overestimates the available memory on the node.
4. Tested for both AL2 and AL2023
5. Validated the maxPods on the node is set to correct value when reserved ENI=2 i.e. 30
```
         Allocatable:
         cpu:                7910m
         ephemeral-storage:  18233774458
         memory:             31102708Ki
         pods:               30
```
6. Validated the maxPods on the node is set to correct value when reserved ENI=0 i.e. 58
```
  Allocatable:
  cpu:                7910m
  ephemeral-storage:  18233774458
  memory:             31102708Ki
  pods:               58
```
7. Validated the maxPods on the node is set to correct value when reserved ENI=0 and maxPods is set on the kubelet to 10.
```
Allocatable:
  cpu:                7910m
  ephemeral-storage:  18233774458
  memory:             31102708Ki
  pods:               10
```
8. Validated the kube-reserved memory value with and without reserved ENI should be same
```
{"level":"INFO","time":"2025-06-20T11:53:54.132-0700","logger":"controller","message":"For m6g.xlarge","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"default"},"namespace":"","name":"default","reconcileID":"7fab6ad8-eac2-4db8-a249-54ad5e51c40f","kube-reserved memory:":"893Mi"}
```


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.