### PR TITLE
feat: support additional bottlerocket log settings

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -83,9 +83,10 @@ type BottlerocketKubernetes struct {
 	SeccompDefault                     *bool                                     `toml:"seccomp-default,omitempty"`
 	PodPidsLimit                       *int                                      `toml:"pod-pids-limit,omitempty"`
 	DeviceOwnershipFromSecurityContext *bool                                     `toml:"device-ownership-from-security-context,omitempty"`
-	SingleProcessOOMKill               *bool                                     `toml:"single-process-oom-kill"`
+	SingleProcessOOMKill               *bool                                     `toml:"single-process-oom-kill,omitempty"`
+	ContainerLogMaxWorkers             *int                                      `toml:"container-log-max-workers,omitempty"`
+	ContainerLogMonitorInterval        *string                                   `toml:"container-log-monitor-interval,omitempty"`
 }
-
 type BottlerocketStaticPod struct {
 	Enabled  *bool   `toml:"enabled,omitempty"`
 	Manifest *string `toml:"manifest,omitempty"`


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Support the following fields for Bottlerocket AMIs
```
      "container-log-max-workers"
      "container-log-monitor-interval"
```

**How was this change tested?**
Confirmed in a cluster via kubectl and via system manager
```
[ssm-user@control]$ apiclient get settings.kubernetes
{
  "settings": {
    "kubernetes": {
      ......
      "container-log-max-workers": 10,
      "container-log-monitor-interval": "10s",
...
```
via kubectl
```
❯ k get --raw "/api/v1/nodes/ip-xxx-xxx-xx-xx.us-west-2.compute.internal/proxy/configz" | jq | grep -i3 containerLog
...
    "containerLogMaxSize": "10Mi",
    "containerLogMaxFiles": 5,
    "containerLogMaxWorkers": 10,
    "containerLogMonitorInterval": "10s",
...
```

EC2NodeClass used
```
 k get ec2nodeclass default -o yaml
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  annotations:
    karpenter.k8s.aws/ec2nodeclass-hash: "15681121203250656044"
    karpenter.k8s.aws/ec2nodeclass-hash-version: v4
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"karpenter.k8s.aws/v1","kind":"EC2NodeClass","metadata":{"annotations":{},"name":"default"},"spec":{"amiSelectorTerms":[{"alias":"al2023@v20250620"}],"role":"KarpenterNodeRole-golang-tester-karpenter","securityGroupSelectorTerms":[{"tags":{"karpenter.sh/discovery":"golang-tester-karpenter"}}],"subnetSelectorTerms":[{"tags":{"karpenter.sh/discovery":"golang-tester-karpenter"}}]}}
  creationTimestamp: "2025-06-25T15:24:01Z"
  finalizers:
  - karpenter.k8s.aws/termination
  generation: 8
  name: default
  resourceVersion: "139948"
  uid: a09461f6-0c9d-4f9d-814d-1e947a59cfce
spec:
  amiSelectorTerms:
  - alias: bottlerocket@latest
  metadataOptions:
    httpEndpoint: enabled
    httpProtocolIPv6: disabled
    httpPutResponseHopLimit: 1
    httpTokens: required
  role: KarpenterNodeRole-golang-tester-karpenter
  securityGroupSelectorTerms:
  - tags:
      karpenter.sh/discovery: golang-tester-karpenter
  subnetSelectorTerms:
  - tags:
      karpenter.sh/discovery: golang-tester-karpenter
  userData: |
    [settings.kubernetes]
    "container-log-max-workers" = 10
    "container-log-monitor-interval" = "10s"
```


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.