### PR TITLE
Improve the way that "Compatibility Matrix" table display

### DIFF
--- a/tools/kompat/README.md
+++ b/tools/kompat/README.md
@@ -5,7 +5,7 @@ Kompat is a simple CLI tool to interact with `compatibility.yaml` files which ho
 ## Installation 
 
 ```console
-go install github.com/aws/karpenter/tools/kompat/cmd/kompat@latest
+go install github.com/aws/karpenter-provider-aws/tools/kompat@latest
 ```
 
 ## Usage:

--- a/website/content/en/preview/upgrading/compatibility.md
+++ b/website/content/en/preview/upgrading/compatibility.md
@@ -15,9 +15,9 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 
 [comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)
 
-| KUBERNETES |   1.27   |   1.28   |   1.29   |   1.30   |   1.31    |  1.32   |  1.33   |
-|------------|----------|----------|----------|----------|-----------|---------|---------|
-| karpenter  | \>= 0.28 | \>= 0.31 | \>= 0.34 | \>= 0.37 | \>= 1.0.5 | \>= 1.2 | \>= 1.5 |
+| KUBERNETES |       1.27       |       1.28       |       1.29       |       1.30       |       1.31        |      1.32       |      1.33       |
+|------------|------------------|------------------|------------------|------------------|-------------------|-----------------|-----------------|
+| karpenter  | \>= 0.28 \<= 1.6 | \>= 0.31 \<= 1.6 | \>= 0.34 \<= 1.6 | \>= 0.37 \<= 1.6 | \>= 1.0.5 \<= 1.6 | \>= 1.2 \<= 1.6 | \>= 1.5 \<= 1.6 |
 
 [comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
 


### PR DESCRIPTION
**Description**

Improve the way that "Compatibility Matrix" table display, see #8237 for more details.

**How was this change tested?**

```bash
$ cd tools/kompat
```

```bash
$ ln -s ../../hack/docs/compatibilitymatrix_gen/compatibility.yaml k8s-compatibility.yaml
```

```bash
$ go run ./cmd/kompat/main.go -b release-v1.6.x -o md -n 7
| KUBERNETES |       1.27       |       1.28       |       1.29       |       1.30       |       1.31        |      1.32       |      1.33       |
|------------|------------------|------------------|------------------|------------------|-------------------|-----------------|-----------------|
| karpenter  | \>= 0.28 \<= 1.6 | \>= 0.31 \<= 1.6 | \>= 0.34 \<= 1.6 | \>= 0.37 \<= 1.6 | \>= 1.0.5 \<= 1.6 | \>= 1.2 \<= 1.6 | \>= 1.5 \<= 1.6 |
```

```bash
$ rm -vf k8s-compatibility.yaml
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [X] Yes, issue opened: #8237
- [x] No

> Question: should I tick "Yes" ?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.