### PR TITLE
Fix outdated comments of hack/docs/*.go

### DIFF
--- a/hack/docs/compatibilitymatrix_gen/main.go
+++ b/hack/docs/compatibilitymatrix_gen/main.go
@@ -32,8 +32,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	genStart := "[comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)"
-	genEnd := "[comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)"
+	genStart := "[comment]: <> (the content below is generated from hack/docs/compatibilitymatrix_gen/main.go)"
+	genEnd := "[comment]: <> (end docs generated content from hack/docs/compatibilitymatrix_gen/main.go)"
 	startDocSections := strings.Split(string(mdFile), genStart)
 	if len(startDocSections) != 2 {
 		log.Fatalf("expected one generated comment block start but got %d", len(startDocSections)-1)

--- a/hack/docs/configuration_gen/main.go
+++ b/hack/docs/configuration_gen/main.go
@@ -37,8 +37,8 @@ func main() {
 		os.Exit(2)
 	}
 
-	genStart := "[comment]: <> (the content below is generated from hack/docs/configuration_gen_docs.go)"
-	genEnd := "[comment]: <> (end docs generated content from hack/docs/configuration_gen_docs.go)"
+	genStart := "[comment]: <> (the content below is generated from hack/docs/configuration_gen/main.go)"
+	genEnd := "[comment]: <> (end docs generated content from hack/docs/configuration_gen/main.go)"
 	startDocSections := strings.Split(string(mdFile), genStart)
 	if len(startDocSections) != 2 {
 		log.Fatalf("expected one generated comment block start but got %d", len(startDocSections)-1)

--- a/hack/docs/instancetypes_gen/main.go
+++ b/hack/docs/instancetypes_gen/main.go
@@ -113,7 +113,7 @@ description: >
   Evaluate Instance Type Resources
 ---
 `)
-	fmt.Fprintln(f, "<!-- this document is generated from hack/docs/instancetypes_gen_docs.go -->")
+	fmt.Fprintln(f, "<!-- this document is generated from hack/docs/instancetypes_gen/main.go -->")
 	fmt.Fprintln(f, `AWS instance types offer varying resources and can be selected by labels. The values provided
 below are the resources available with some assumptions and after the instance overhead has been subtracted:
 - `+"`blockDeviceMappings` are not configured"+`

--- a/hack/docs/metrics_gen/main.go
+++ b/hack/docs/metrics_gen/main.go
@@ -109,7 +109,7 @@ description: >
   Inspect Karpenter Metrics
 ---
 `)
-	fmt.Fprintf(f, "<!-- this document is generated from hack/docs/metrics_gen_docs.go -->\n")
+	fmt.Fprintf(f, "<!-- this document is generated from hack/docs/metrics_gen/main.go -->\n")
 	fmt.Fprintf(f, "Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. "+
 		"These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)\n")
 	previousSubsystem := ""


### PR DESCRIPTION
Fixes #N/A

**Description**

The path for the `docgen` changed, but comments not updated.

**How was this change tested?**

N/A, it's just comments.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.