### PR TITLE
Handle InvalidBlockDeviceMapping Errors in EC2NodeClass Validation Controller

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	launchTemplateNameNotFoundCode = "InvalidLaunchTemplateName.NotFoundException"
-	DryRunOperationErrorCode       = "DryRunOperation"
-	UnauthorizedOperationErrorCode = "UnauthorizedOperation"
+	launchTemplateNameNotFoundCode     = "InvalidLaunchTemplateName.NotFoundException"
+	DryRunOperationErrorCode           = "DryRunOperation"
+	UnauthorizedOperationErrorCode     = "UnauthorizedOperation"
+	InvalidBlockDeviceMappingErrorCode = "InvalidBlockDeviceMapping"
 )
 
 var (
@@ -171,6 +172,9 @@ func ToReasonMessage(err error) (string, string) {
 	if strings.Contains(err.Error(), "InvalidAMIID.Malformed") {
 		return "InvalidAMIID", "AMI used for instance launch is invalid"
 	}
+	if strings.Contains(err.Error(), "InvalidBlockDeviceMapping") {
+		return "InvalidBlockDeviceMapping", "Block device mapping configuration is invalid"
+	}
 	if strings.Contains(err.Error(), "RequestLimitExceeded") {
 		return "RequestLimitExceeded", "Request limit exceeded"
 	}
@@ -195,4 +199,15 @@ func ToReasonMessage(err error) (string, string) {
 		return "InsufficientFreeAddressesInSubnet", "There are not enough free IP addresses to launch an instance in this subnet"
 	}
 	return "LaunchFailed", "Instance launch failed"
+}
+
+func IsInvalidBlockDeviceMappingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode() == InvalidBlockDeviceMappingErrorCode
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #8148 

**Description**
This PR improves the EC2NodeClass validation controller by properly handling InvalidBlockDeviceMapping errors returned from the AWS EC2 RunInstances API during dry-run validation. Previously, these errors were treated as an authorization errors, resulting in unclear feedback to users when their block device mapping configuration was invalid.
With this change:
* The validation controller now detects InvalidBlockDeviceMapping errors and sets a clear status condition on the EC2NodeClass resource, indicating the specific configuration issue.
* The AWS error handling package is updated to recognize and classify InvalidBlockDeviceMapping errors.
* Tests are added to ensure the new error handling logic works as expected and that users receive actionable feedback for block device mapping misconfigurations.

This enhancement helps users quickly identify and resolve configuration issues related to block device mappings, improving the overall user experience and debuggability of EC2NodeClass resources.

**How was this change tested?**
Added and updated unit tests in pkg/controllers/nodeclass/validation_test.go to verify that InvalidBlockDeviceMapping errors are correctly detected and surfaced in the EC2NodeClass status conditions.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.