### PR TITLE
docs(website): adding volumeInitializationRate to spec.blockDeviceMappings

### DIFF
--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -981,6 +981,7 @@ spec:
         deleteOnTermination: true
         throughput: 125
         snapshotID: snap-0123456789
+        volumeInitializationRate: 100
 ```
 
 The following blockDeviceMapping defaults are used for each `AMIFamily` if no `blockDeviceMapping` overrides are specified in the `EC2NodeClass`

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -981,6 +981,7 @@ spec:
         deleteOnTermination: true
         throughput: 125
         snapshotID: snap-0123456789
+        volumeInitializationRate: 100
 ```
 
 The following blockDeviceMapping defaults are used for each `AMIFamily` if no `blockDeviceMapping` overrides are specified in the `EC2NodeClass`

--- a/website/content/en/v1.5/concepts/nodeclasses.md
+++ b/website/content/en/v1.5/concepts/nodeclasses.md
@@ -981,6 +981,7 @@ spec:
         deleteOnTermination: true
         throughput: 125
         snapshotID: snap-0123456789
+        volumeInitializationRate: 100
 ```
 
 The following blockDeviceMapping defaults are used for each `AMIFamily` if no `blockDeviceMapping` overrides are specified in the `EC2NodeClass`

--- a/website/content/en/v1.5/concepts/nodeclasses.md
+++ b/website/content/en/v1.5/concepts/nodeclasses.md
@@ -981,7 +981,6 @@ spec:
         deleteOnTermination: true
         throughput: 125
         snapshotID: snap-0123456789
-        volumeInitializationRate: 100
 ```
 
 The following blockDeviceMapping defaults are used for each `AMIFamily` if no `blockDeviceMapping` overrides are specified in the `EC2NodeClass`


### PR DESCRIPTION
Fixes #8154

**Description**
Add `volumeInitializationRate` property on https://karpenter.sh/docs/concepts/nodeclasses/#specblockdevicemappings. 

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [x] Yes, issue opened: #8154
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.