### PR TITLE
docs: Karpenter failed upgrade affects deletion of child Kubernetes objects

### DIFF
--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -110,6 +110,19 @@ kubectl annotate crd ec2nodeclasses.karpenter.k8s.aws nodepools.karpenter.sh nod
 kubectl annotate crd ec2nodeclasses.karpenter.k8s.aws nodepools.karpenter.sh nodeclaims.karpenter.sh meta.helm.sh/release-namespace="${KARPENTER_NAMESPACE}" --overwrite
 ```
 
+## Upgrade
+
+### Karpenter upgrade impairs cascade deletion of Kubernetes resources
+
+This error happens because of an upgrade between API versions of the Karpenter CRD (e.j. v1beta1 to v1). This issue can lead to child pods not being deleted when deleting the owner resource. For example, the deletion of a deployment does not delete the child pods afterwards.
+The kube-controller-manager logs will show the following message:
+
+```text
+conversion webhook for karpenter.k8s.aws/v1beta1, Kind=EC2NodeClass failed: Post "https://karpenter.kube-system.svc:8443/conversion/karpenter.k8s.aws?timeout=30s": no endpoints available for service "karpenter"
+```
+
+To fix the issue, delete all Karpenter CRDs from the cluster and perform a clean install of Karpenter. Make sure to backup any NodePool and NodeClass objects in the cluster. Follow the [Karpenter upgrade guide](https://karpenter.sh/docs/upgrading/upgrade-guide/) to avoid this from happening.
+
 ## Uninstallation
 
 ### Unable to delete nodes after uninstalling Karpenter


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

**Description**
There is a common issue when upgrading Karpenter incorrectly, from one API version to another. This affects the deletion of orphan Kubernetes resources by the Garbage collector controller under kube-controller-manager.

This affects unrelated resources as well.
One example of this is the deletion of a deployment will not delete the replicaSet or pods automatically.

**How was this change tested?**
There is some GH issues open to the Kubernetes project in GitHub
https://github.com/kubernetes/kubernetes/issues/101078
https://github.com/kubernetes/kubernetes/issues/110720

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.