### PR TITLE
test: ensure karpenter respects restricted PSS

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -57,7 +57,11 @@ runs:
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       PRIVATE_CLUSTER: ${{ inputs.private_cluster }}
     run: |
-      ./test/hack/e2e_scripts/install_karpenter.sh
+      output=$(./test/hack/e2e_scripts/install_karpenter.sh 2>&1)
+      if echo "$output" | grep -i "warning.*violate.*podsecurity"; then
+        echo "ERROR: Karpenter does not respect restricted Pod Security Standard"
+        exit 1
+      fi
   - name: diff-karpenter
     shell: bash
     env:


### PR DESCRIPTION
test: ensure karpenter respects restricted PSS

Fixes #5442

**Description**
Ensure Karpenter respects the "Restricted" Pod Security Standard when installing in E2E. This is done by checking the output of `install_karpenter.sh` for a pod security warning.

**How was this change tested?**
(1) locally by:
- modifying [deployment.yaml](https://github.com/aws/karpenter-provider-aws/blob/main/charts/karpenter/templates/deployment.yaml#L67) to `allowPrivilegeEscalation: true`
- create karpenter image & deploying
- confirming grep logic

Example output:
```
if echo "$output" | grep -i "warning.*violate.*podsecurity"; then
  echo "ERROR: Karpenter does not respect restricted Pod Security Standard"
fi
"Warning: would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"controller\" must set securityContext.allowPrivilegeEscalation=false)"
ERROR: Karpenter does not respect restricted Pod Security Standard
```
(2) `make presubmit`


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.