### PR TITLE
docs: Fix missing disruption.consolidateAfter default

### DIFF
--- a/website/content/en/docs/concepts/disruption.md
+++ b/website/content/en/docs/concepts/disruption.md
@@ -78,6 +78,7 @@ Disruption is configured through the NodePool's disruption block by the `consoli
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s
 ```
 {{% /alert %}}
 

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -78,6 +78,7 @@ Disruption is configured through the NodePool's disruption block by the `consoli
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s
 ```
 {{% /alert %}}
 

--- a/website/content/en/v1.0/concepts/disruption.md
+++ b/website/content/en/v1.0/concepts/disruption.md
@@ -78,6 +78,7 @@ Disruption is configured through the NodePool's disruption block by the `consoli
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s
 ```
 {{% /alert %}}
 

--- a/website/content/en/v1.4/concepts/disruption.md
+++ b/website/content/en/v1.4/concepts/disruption.md
@@ -78,6 +78,7 @@ Disruption is configured through the NodePool's disruption block by the `consoli
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s
 ```
 {{% /alert %}}
 

--- a/website/content/en/v1.5/concepts/disruption.md
+++ b/website/content/en/v1.5/concepts/disruption.md
@@ -78,6 +78,7 @@ Disruption is configured through the NodePool's disruption block by the `consoli
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s
 ```
 {{% /alert %}}
 

--- a/website/content/en/v1.6/concepts/disruption.md
+++ b/website/content/en/v1.6/concepts/disruption.md
@@ -78,6 +78,7 @@ Disruption is configured through the NodePool's disruption block by the `consoli
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s
 ```
 {{% /alert %}}
 


### PR DESCRIPTION
Fixes #N/A

**Description**
Adds the default for `spec.disruption.consolidateAfter`. It's mentioned in the text above but not shown in the example.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.