### PR TITLE
docs: clarify capacity block configuration

### DIFF
--- a/website/content/en/docs/tasks/odcrs.md
+++ b/website/content/en/docs/tasks/odcrs.md
@@ -1,6 +1,6 @@
 ---
-title: "Utilizing On-Demand Capacity Reservations"
-linkTitle: "Utilizing ODCRs"
+title: "Utilizing On-Demand Capacity Reservations and Capacity Blocks"
+linkTitle: "Utilizing ODCRs and Capacity Blocks"
 ---
 
 <i class="fa-solid fa-circle-info"></i> <b>Feature State: </b> [Beta]({{<ref "../reference/settings#feature-gates" >}})
@@ -28,6 +28,11 @@ capacityReservationSelectorTerms:
 ```
 
 For more information on configuring `capacityReservationSelectorTerms`, see the [NodeClass docs]({{< relref "../concepts/nodeclasses#speccapacityreservationselectorterms" >}}).
+
+{{% alert title="Note" color="primary" %}}
+Capacity blocks are modeled as on-demand capacity reservations in EC2.
+To select capacity blocks, specify them in your `capacityReservationSelectorTerms` in the same way you would for a default ODCR.
+{{% /alert %}}
 
 Additionally, you will need to update your NodePool to be compatible with ODCRs.
 Karpenter doesn't model ODCRs as standard on-demand capacity, and instead uses a dedicated capacity type: `reserved`.

--- a/website/content/en/preview/tasks/odcrs.md
+++ b/website/content/en/preview/tasks/odcrs.md
@@ -1,6 +1,6 @@
 ---
-title: "Utilizing On-Demand Capacity Reservations"
-linkTitle: "Utilizing ODCRs"
+title: "Utilizing On-Demand Capacity Reservations and Capacity Blocks"
+linkTitle: "Utilizing ODCRs and Capacity Blocks"
 ---
 
 <i class="fa-solid fa-circle-info"></i> <b>Feature State: </b> [Beta]({{<ref "../reference/settings#feature-gates" >}})
@@ -26,6 +26,11 @@ capacityReservationSelectorTerms:
     application: foobar
 - id: cr-56fac701cc1951b03
 ```
+
+{{% alert title="Note" color="primary" %}}
+Capacity blocks are modeled as on-demand capacity reservations in EC2.
+To select capacity blocks, specify them in your `capacityReservationSelectorTerms` in the same way you would for a default ODCR.
+{{% /alert %}}
 
 For more information on configuring `capacityReservationSelectorTerms`, see the [NodeClass docs]({{< relref "../concepts/nodeclasses#speccapacityreservationselectorterms" >}}).
 

--- a/website/content/en/v1.6/tasks/odcrs.md
+++ b/website/content/en/v1.6/tasks/odcrs.md
@@ -1,6 +1,6 @@
 ---
-title: "Utilizing On-Demand Capacity Reservations"
-linkTitle: "Utilizing ODCRs"
+title: "Utilizing On-Demand Capacity Reservations and Capacity Blocks"
+linkTitle: "Utilizing ODCRs and Capacity Blocks"
 ---
 
 <i class="fa-solid fa-circle-info"></i> <b>Feature State: </b> [Beta]({{<ref "../reference/settings#feature-gates" >}})
@@ -26,6 +26,11 @@ capacityReservationSelectorTerms:
     application: foobar
 - id: cr-56fac701cc1951b03
 ```
+
+{{% alert title="Note" color="primary" %}}
+Capacity blocks are modeled as on-demand capacity reservations in EC2.
+To select capacity blocks, specify them in your `capacityReservationSelectorTerms` in the same way you would for a default ODCR.
+{{% /alert %}}
 
 For more information on configuring `capacityReservationSelectorTerms`, see the [NodeClass docs]({{< relref "../concepts/nodeclasses#speccapacityreservationselectorterms" >}}).
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Clarify that Karpenter does not differentiate between capacity blocks and default ODCRs for selection.

**How was this change tested?**
Website preview

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.