### PR TITLE
chore: Add spot interruption event for pods

### DIFF
--- a/pkg/controllers/interruption/events/events.go
+++ b/pkg/controllers/interruption/events/events.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 )
 
-func SpotInterrupted(node *corev1.Node, nodeClaim *karpv1.NodeClaim) (evts []events.Event) {
+func SpotInterrupted(pods []*corev1.Pod, node *corev1.Node, nodeClaim *karpv1.NodeClaim) (evts []events.Event) {
 	evts = append(evts, events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
@@ -36,6 +36,15 @@ func SpotInterrupted(node *corev1.Node, nodeClaim *karpv1.NodeClaim) (evts []eve
 			Reason:         "SpotInterrupted",
 			Message:        "Spot interruption warning was triggered",
 			DedupeValues:   []string{string(node.UID)},
+		})
+	}
+	for _, pod := range pods {
+		evts = append(evts, events.Event{
+			InvolvedObject: pod,
+			Type:           corev1.EventTypeWarning,
+			Reason:         "SpotInterrupted",
+			Message:        "Spot interruption warning was triggered",
+			DedupeValues:   []string{string(pod.UID)},
 		})
 	}
 	return evts


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

**Description**

It would be helpful to also emit spot interruption events for pods. Currently, these events are only emitted for nodes and nodeclaims, so users cannot easily view that their pod will be disrupted.

**How was this change tested?**
Local tests pass (includes one new test)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.