### PR TITLE
docs: changing nodepool in start guide to select correct security group

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-nodepool.sh
@@ -46,5 +46,5 @@ spec:
         karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+        kubernetes.io/cluster/${CLUSTER_NAME}: "owned" # replace with your cluster name
 EOF


### PR DESCRIPTION
Fixes #8257

**Description**
Today on start guide we are selecting security group to EC2 instances which does not have correct tags to spin up load balancers. So, selecting correct security group is essential to users be able to spin up load balancers later on.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [x] Yes, issue opened: #8257
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.