### PR TITLE
chore: add cloudformation target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,15 @@ update-karpenter: ## Update kubernetes-sigs/karpenter to latest
 	go get -u sigs.k8s.io/karpenter@HEAD
 	go mod tidy
 
+.PHONY: deploy-cfn
+deploy-cfn: ## Deploys the cloudformation stack defined in the docs preview directory
+	aws cloudformation deploy \
+		--stack-name "Karpenter-${CLUSTER_NAME}" \
+		--template-file "./website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml" \
+		--capabilities CAPABILITY_NAMED_IAM \
+		--parameter-overrides "ClusterName=${CLUSTER_NAME}"
+
+
 .PHONY: help presubmit ci-test ci-non-test run test deflake e2etests e2etests-deflake benchmark coverage verify vulncheck licenses image apply install delete docgen codegen stable-release-pr snapshot release prepare-website toolchain issues website tidy download update-karpenter
 
 define newline


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a target to the makefile to deploy cloudformation stack changes. These are the same deployment steps documented in the Karpenter Getting Started Guide and speeds up development when iterating on Karpenter's IAM permissions.

**How was this change tested?**
Tested manually

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.