### PR TITLE
ci: Amplify Website Preview Workflow

### DIFF
--- a/.github/actions/deploy-website/action.yml
+++ b/.github/actions/deploy-website/action.yml
@@ -76,7 +76,7 @@ runs:
         aws s3 sync website/public/ "$S3_PATH" --delete
     - name: Create Amplify branch (if preview and doesn't exist)
       shell: bash
-      if: github.event_name != 'push'
+      if: github.event_name == 'workflow_run'
       run: |
         if ! aws amplify get-branch --app-id ${{ inputs.amplify-app-id }} --branch-name "${{ inputs.amplify-branch-name }}" 2>/dev/null; then
           aws amplify create-branch \

--- a/.github/actions/deploy-website/action.yml
+++ b/.github/actions/deploy-website/action.yml
@@ -47,7 +47,7 @@ runs:
         TZ: America/Los_Angeles
         HUGO_CACHEDIR: ${{ github.workspace }}/.hugo
         NPM_CONFIG_CACHE: ${{ github.workspace }}/.npm
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'workflow_run'
       run: |
         npm ci --prefer-offline
         hugo --gc --minify --buildFuture -b "${{ inputs.hugo-base-url }}"
@@ -76,7 +76,7 @@ runs:
         aws s3 sync website/public/ "$S3_PATH" --delete
     - name: Create Amplify branch (if preview and doesn't exist)
       shell: bash
-      if: github.event_name == 'pull_request'
+      if: github.event_name != 'push'
       run: |
         if ! aws amplify get-branch --app-id ${{ inputs.amplify-app-id }} --branch-name "${{ inputs.amplify-branch-name }}" 2>/dev/null; then
           aws amplify create-branch \

--- a/.github/workflows/approval-comment.yaml
+++ b/.github/workflows/approval-comment.yaml
@@ -4,7 +4,7 @@ on:
     types: [submitted]
 jobs:
   approval-comment:
-    if: startsWith(github.event.review.body, '/karpenter snapshot') || startsWith(github.event.review.body, '/karpenter scale') || startsWith(github.event.review.body, '/karpenter versionCompatibility')
+    if: startsWith(github.event.review.body, '/karpenter snapshot') || startsWith(github.event.review.body, '/karpenter scale') || startsWith(github.event.review.body, '/karpenter versionCompatibility') || startsWith(github.event.review.body, '/karpenter preview')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/website-cleanup-preview.yaml
+++ b/.github/workflows/website-cleanup-preview.yaml
@@ -1,6 +1,6 @@
 name: Cleanup Website PR Preview
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed ]
     paths: [ website/** ]
 jobs:

--- a/.github/workflows/website-cleanup-preview.yaml
+++ b/.github/workflows/website-cleanup-preview.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    if: github.repository == 'aws/karpenter-provider-aws'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository == 'aws/karpenter-provider-aws'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/website-preview.yaml
+++ b/.github/workflows/website-preview.yaml
@@ -6,14 +6,19 @@ on:
     types:
       - completed
 jobs:
+  resolve:
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/resolve-args.yaml
+    with:
+      allowed_comment: "preview"
   preview:
     permissions:
       id-token: write
       contents: read
       pull-requests: write
       statuses: write
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    needs: [ resolve ]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: ./.github/actions/download-artifact
@@ -74,4 +79,3 @@ jobs:
         with:
           name: "${{ github.workflow }} / ${{ github.job }} (pull_request_review)"
           git_ref: ${{ env.PR_COMMIT }}
-

--- a/.github/workflows/website-preview.yaml
+++ b/.github/workflows/website-preview.yaml
@@ -1,27 +1,38 @@
 name: Deploy Website Preview to Amplify
 on:
-  pull_request:
-    types: [ opened, synchronize, reopened ]
-    branches: [ main ]
-    paths: [ website/** ]
+  workflow_run:
+    workflows:
+      - ApprovalComment
+    types:
+      - completed
 jobs:
   preview:
-    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
       pull-requests: write
+      statuses: write
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: ./.github/actions/download-artifact
       - id: metadata
         run: |
-          pr_number="${{ github.event.number }}"
-          pr_commit="${{ github.event.pull_request.head.sha }}"
+          pr_number="$(head -n 2 /tmp/artifacts/metadata.txt | tail -n 1)"
+          pr_commit="$(tail -n 1 /tmp/artifacts/metadata.txt)"
           {
             echo PR_COMMIT="$pr_commit"
             echo PR_NUMBER="$pr_number"
             echo BRANCH_NAME="pr-$pr_number"
           } >> "$GITHUB_ENV"
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          ref: ${{ env.PR_COMMIT }}
+      - uses: ./.github/actions/commit-status/start
+        with:
+          name: "${{ github.workflow }} / ${{ github.job }} (pull_request_review)"
+          git_ref: ${{ env.PR_COMMIT }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
@@ -58,3 +69,9 @@ jobs:
             
             Built from commit \`${process.env.PR_COMMIT}\``
             })
+      - if: always()
+        uses: ./.github/actions/commit-status/end
+        with:
+          name: "${{ github.workflow }} / ${{ github.job }} (pull_request_review)"
+          git_ref: ${{ env.PR_COMMIT }}
+


### PR DESCRIPTION
Fixes #N/A

**Description**
* Changed GitHub workflow for Amplify website preview to run on `/karpenter preview` comments
* Added repo scoping for Amplify website workflows

**How was this change tested?**
* Creating a PR from another account to my own fork and running `/karpenter preview`
   * https://github.com/ryan-mist/karpenter-provider-aws/pull/34

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.