### PR TITLE
fix: remove g6f from gpu int tests

### DIFF
--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -72,6 +72,13 @@ var _ = Describe("Extended Resources", func() {
 				Operator: corev1.NodeSelectorOpExists,
 			},
 		})
+		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+			NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+				Key:      v1.LabelInstanceFamily,
+				Operator: corev1.NodeSelectorOpNotIn,
+				Values:   []string{"g6f"},
+			},
+		})
 		env.ExpectCreated(nodeClass, nodePool, dep)
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
 		env.ExpectCreatedNodeCount("==", 1)
@@ -103,6 +110,13 @@ var _ = Describe("Extended Resources", func() {
 				Key:      v1.LabelInstanceCategory,
 				Operator: corev1.NodeSelectorOpExists,
 			}})
+		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+			NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+				Key:      v1.LabelInstanceFamily,
+				Operator: corev1.NodeSelectorOpNotIn,
+				Values:   []string{"g6f"},
+			},
+		})
 		env.ExpectCreated(nodeClass, nodePool, dep)
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
 		env.ExpectCreatedNodeCount("==", 1)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Removes `g6f` from the gpus selected in our tests to prevent unexpected performance degradation in the tests.

**How was this change tested?**
Local e2e

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.