### PR TITLE
fix: mark expiring capacity blocks as unavailable

### DIFF
--- a/pkg/providers/instancetype/offering/offering.go
+++ b/pkg/providers/instancetype/offering/offering.go
@@ -184,7 +184,7 @@ func (p *DefaultProvider) createOfferings(
 				scheduling.NewRequirement(v1.LabelCapacityReservationType, corev1.NodeSelectorOpIn, string(reservation.ReservationType)),
 			),
 			Price:               price,
-			Available:           reservationCapacity != 0 && itZones.Has(reservation.AvailabilityZone),
+			Available:           reservationCapacity != 0 && itZones.Has(reservation.AvailabilityZone) && reservation.State != v1.CapacityReservationStateExpiring,
 			ReservationCapacity: reservationCapacity,
 		}
 		if id, ok := subnetZonesToZoneIDs[reservation.AvailabilityZone]; ok {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -2850,6 +2850,62 @@ var _ = Describe("InstanceTypeProvider", func() {
 		}
 		wg.Wait()
 	})
+	Context("Capacity Blocks", func() {
+		const crInstanceType = "c6g.large"
+		const crZone = "test-zone-1a"
+		const crID = "cr-123"
+		const crCapacity = 1
+		BeforeEach(func() {
+			awsEnv.CapacityReservationProvider.SetAvailableInstanceCount(crID, crCapacity)
+			nodeClass.Status.CapacityReservations = []v1.CapacityReservation{{
+				AvailabilityZone: crZone,
+				ID:               crID,
+				InstanceType:     crInstanceType,
+				ReservationType:  v1.CapacityReservationTypeCapacityBlock,
+			}}
+		})
+		DescribeTable(
+			"should create an offering for a capacity block",
+			func(state v1.CapacityReservationState) {
+				nodeClass.Status.CapacityReservations[0].State = state
+				instanceTypes, err := awsEnv.InstanceTypesProvider.List(ctx, nodeClass)
+				Expect(err).ToNot(HaveOccurred())
+
+				var instanceType *corecloudprovider.InstanceType
+				for _, it := range instanceTypes {
+					if it.Name == crInstanceType {
+						instanceType = it
+						break
+					}
+				}
+				Expect(instanceType).ToNot(BeNil())
+
+				var offering *corecloudprovider.Offering
+				for _, o := range instanceType.Offerings {
+					if o.CapacityType() == karpv1.CapacityTypeReserved {
+						if offering != nil {
+							Fail("only a single reserved offering should exist")
+						}
+						offering = o
+					}
+				}
+				Expect(offering).ToNot(BeNil())
+
+				Expect(offering.Requirements.Has(karpv1.CapacityTypeLabelKey)).To(BeTrue())
+				Expect(offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Any()).To(Equal(karpv1.CapacityTypeReserved))
+				Expect(offering.Requirements.Has(corev1.LabelTopologyZone)).To(BeTrue())
+				Expect(offering.Requirements.Get(corev1.LabelTopologyZone).Any()).To(Equal(crZone))
+				Expect(offering.Requirements.Has(v1.LabelCapacityReservationType)).To(BeTrue())
+				Expect(offering.Requirements.Get(v1.LabelCapacityReservationType).Any()).To(Equal(string(v1.CapacityReservationTypeCapacityBlock)))
+				Expect(offering.Requirements.Has(v1.LabelCapacityReservationID)).To(BeTrue())
+				Expect(offering.Requirements.Get(v1.LabelCapacityReservationID).Any()).To(Equal(crID))
+				Expect(offering.Available).To(Equal(state != v1.CapacityReservationStateExpiring))
+				Expect(offering.ReservationCapacity).To(Equal(crCapacity))
+			},
+			Entry("when the capacity block is active", v1.CapacityReservationStateActive),
+			Entry("when the capacity block is expiring", v1.CapacityReservationStateExpiring),
+		)
+	})
 })
 
 func ExpectSameInstanceTypeLists(instanceTypesLists ...[]*corecloudprovider.InstanceType) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Ensure that we mark expiring capacity blocks as unavailable. This prevents attempted relaunches into the capacity block during the drain period.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.