### PR TITLE
format + document kubeReservedResources

### DIFF
--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -143,9 +143,19 @@ func NewInstanceType(
 		Requirements: computeRequirements(info, region, offeringZones, subnetZoneInfo, amiFamily, capacityReservations),
 		Capacity:     computeCapacity(ctx, info, amiFamily, blockDeviceMappings, instanceStorePolicy, maxPods, podsPerCore),
 		Overhead: &cloudprovider.InstanceTypeOverhead{
-			KubeReserved:      kubeReservedResources(cpu(info), lo.Ternary(amiFamily.FeatureFlags().UsesENILimitedMemoryOverhead, ENILimitedPods(ctx, info, 0), pods(ctx, info, amiFamily, maxPods, podsPerCore)), kubeReserved),
-			SystemReserved:    systemReservedResources(systemReserved),
-			EvictionThreshold: evictionThreshold(memory(ctx, info), ephemeralStorage(info, amiFamily, blockDeviceMappings, instanceStorePolicy), amiFamily, evictionHard, evictionSoft),
+			KubeReserved: kubeReservedResources(
+				cpu(info),
+				lo.Ternary(amiFamily.FeatureFlags().UsesENILimitedMemoryOverhead, ENILimitedPods(ctx, info, 0), pods(ctx, info, amiFamily, maxPods, podsPerCore)),
+				kubeReserved,
+			),
+			SystemReserved: systemReservedResources(systemReserved),
+			EvictionThreshold: evictionThreshold(
+				memory(ctx, info),
+				ephemeralStorage(info, amiFamily, blockDeviceMappings, instanceStorePolicy),
+				amiFamily,
+				evictionHard,
+				evictionSoft,
+			),
 		},
 	}
 	if it.Requirements.Compatible(scheduling.NewRequirements(scheduling.NewRequirement(corev1.LabelOSStable, corev1.NodeSelectorOpIn, string(corev1.Windows)))) == nil {
@@ -489,33 +499,38 @@ func systemReservedResources(systemReserved map[string]string) corev1.ResourceLi
 	})
 }
 
+// set default reserved resources for those not defined via configured kubeReserved
 func kubeReservedResources(cpus, pods *resource.Quantity, kubeReserved map[string]string) corev1.ResourceList {
 	resources := corev1.ResourceList{
 		corev1.ResourceMemory:           resource.MustParse(fmt.Sprintf("%dMi", (11*pods.Value())+255)),
 		corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"), // default kube-reserved ephemeral-storage
 	}
-	// kube-reserved Computed from
-	// https://github.com/bottlerocket-os/bottlerocket/pull/1388/files#diff-bba9e4e3e46203be2b12f22e0d654ebd270f0b478dd34f40c31d7aa695620f2fR611
-	for _, cpuRange := range []struct {
-		start      int64
-		end        int64
-		percentage float64
-	}{
-		{start: 0, end: 1000, percentage: 0.06},
-		{start: 1000, end: 2000, percentage: 0.01},
-		{start: 2000, end: 4000, percentage: 0.005},
-		{start: 4000, end: 1 << 31, percentage: 0.0025},
-	} {
-		if cpu := cpus.MilliValue(); cpu >= cpuRange.start {
-			r := float64(cpuRange.end - cpuRange.start)
-			if cpu < cpuRange.end {
-				r = float64(cpu - cpuRange.start)
+	if _, ok := kubeReserved[string(corev1.ResourceCPU)]; !ok {
+		// kube-reserved Computed from
+		// https://github.com/bottlerocket-os/bottlerocket/pull/1388/files#diff-bba9e4e3e46203be2b12f22e0d654ebd270f0b478dd34f40c31d7aa695620f2fR611
+		cpu := cpus.MilliValue()
+		cpuOverhead := int64(0)
+		for _, cpuRange := range []struct {
+			start      int64
+			end        int64
+			percentage float64
+		}{
+			{start: 0, end: 1000, percentage: 0.06},
+			{start: 1000, end: 2000, percentage: 0.01},
+			{start: 2000, end: 4000, percentage: 0.005},
+			{start: 4000, end: 1 << 31, percentage: 0.0025},
+		} {
+			if cpu >= cpuRange.start {
+				r := float64(cpuRange.end - cpuRange.start)
+				if cpu < cpuRange.end {
+					r = float64(cpu - cpuRange.start)
+				}
+				cpuOverhead += int64(r * cpuRange.percentage)
 			}
-			cpuOverhead := resources.Cpu()
-			cpuOverhead.Add(*resource.NewMilliQuantity(int64(r*cpuRange.percentage), resource.DecimalSI))
-			resources[corev1.ResourceCPU] = *cpuOverhead
 		}
+		resources[corev1.ResourceCPU] = *resource.NewMilliQuantity(cpuOverhead, resource.DecimalSI)
 	}
+
 	return lo.Assign(resources, lo.MapEntries(kubeReserved, func(k string, v string) (corev1.ResourceName, resource.Quantity) {
 		return corev1.ResourceName(k), resource.MustParse(v)
 	}))


### PR DESCRIPTION
perf:            do not do cpu math when it is not needed + do it more simple and efficient
docs:            document the logic of kubeReserved

Fixes #N/A

**Description**
was working in this area and the endless line size made it really hard to read
also missing docs made me take a while to understand how the code works

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.