### PR TITLE
chore: change Amplify PR preview to edit comment

### DIFF
--- a/.github/workflows/website-preview.yaml
+++ b/.github/workflows/website-preview.yaml
@@ -56,16 +56,36 @@ jobs:
           PR_COMMIT: ${{ env.PR_COMMIT }}
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: process.env.PR_NUMBER,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `**Preview deployment ready!**
+            const commentBody = `**Preview deployment ready!**
             
             **Preview URL:** ${process.env.PREVIEW_URL}
             
-            Built from commit \`${process.env.PR_COMMIT}\``
-            })
+            Built from commit \`${process.env.PR_COMMIT}\``;
+            
+            const existingComment = (await github.rest.issues.listComments({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })).data.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('**Preview deployment ready!**')
+            );
+            
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: process.env.PR_NUMBER,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+            }
       - if: always()
         uses: ./.github/actions/commit-status/end
         with:


### PR DESCRIPTION
Fixes #N/A

**Description**
* This PR changes the Amplify PR preview workflow to edit the existing PR preview comment (if one already exists) instead of creating a new one
  * The reason for this is Amplify PR comments we're cluttering up PRs with lots of commits

**How was this change tested?**
* making a PR against my own repo; making another commit and ensuring existing comment is edited
  * https://github.com/ryan-mist/karpenter-provider-aws/pull/47

In this image, a PR preview comment is made:
<img width="674" height="333" alt="Screenshot 2025-08-15 at 10 06 28 AM" src="https://github.com/user-attachments/assets/d4d39b7b-23d5-419d-9726-d9b07de6cca6" />

A new commit is made to the PR. As seen in the image below, the existing PR preview comment is modified with the new commit number (rather than a new comment being added): 
<img width="635" height="350" alt="Screenshot 2025-08-15 at 10 10 07 AM" src="https://github.com/user-attachments/assets/b778bb00-fa10-48d1-b111-c86478fafba7" />

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.