### PR TITLE
feat: use IamInstanceProfile.Arn field with AWS API Call when instance profile is ARN format

### DIFF
--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -355,6 +355,23 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			Expect(*ltInput.LaunchTemplateData.IamInstanceProfile.Name).To(Equal("overridden-profile"))
 		})
 	})
+	It("should set IamInstanceProfile.Arn when spec.InstanceProfile is an ARN", func() {
+
+		nodeClass.Spec.Role = ""
+		nodeClass.Spec.InstanceProfile = aws.String("arn:aws:iam::123456789012:instance-profile/overridden-profile")
+		nodeClass.Status.InstanceProfile = "arn:aws:iam::123456789012:instance-profile/overridden-profile"
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		pod := coretest.UnschedulablePod()
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		ExpectScheduled(ctx, env.Client, pod)
+		Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
+		awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
+			Expect(*ltInput.LaunchTemplateData.IamInstanceProfile.Arn).To(Equal("arn:aws:iam::123456789012:instance-profile/overridden-profile"))
+		})
+
+	})
 	Context("Cache", func() {
 		It("should use same launch template for equivalent constraints", func() {
 			t1 := corev1.Toleration{

--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -91,7 +91,7 @@ spec:
   # Must specify one of "role" or "instanceProfile" for Karpenter to launch nodes
   role: "KarpenterNodeRole-${CLUSTER_NAME}"
 
-  # Optional, IAM instance profile to use for the node identity.
+  # Optional, IAM instance profile name or ARN to use for the node identity.
   # Must specify one of "role" or "instanceProfile" for Karpenter to launch nodes
   instanceProfile: "KarpenterNodeInstanceProfile-${CLUSTER_NAME}"
 
@@ -700,6 +700,8 @@ spec:
 ## spec.instanceProfile
 
 `InstanceProfile` is an optional field and tells Karpenter which IAM identity nodes should assume. You must specify one of `role` or `instanceProfile` when creating a Karpenter `EC2NodeClass`. If you use the `instanceProfile` field instead of `role`, Karpenter will not manage the InstanceProfile on your behalf; instead, it expects that you have pre-provisioned an IAM instance profile and assigned it a role.
+
+This parameter accepts both name and ARN formats.
 
 You can provision and assign a role to an IAM instance profile using [CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html) or by using the [`aws iam create-instance-profile`](https://docs.aws.amazon.com/cli/latest/reference/iam/create-instance-profile.html) and [`aws iam add-role-to-instance-profile`](https://docs.aws.amazon.com/cli/latest/reference/iam/add-role-to-instance-profile.html) commands in the CLI.
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -88,7 +88,7 @@ spec:
   # Must specify one of "role" or "instanceProfile" for Karpenter to launch nodes
   role: "KarpenterNodeRole-${CLUSTER_NAME}"
 
-  # Optional, IAM instance profile to use for the node identity.
+  # Optional, IAM instance profile name or ARN to use for the node identity.
   # Must specify one of "role" or "instanceProfile" for Karpenter to launch nodes
   instanceProfile: "KarpenterNodeInstanceProfile-${CLUSTER_NAME}"
 
@@ -697,6 +697,8 @@ spec:
 ## spec.instanceProfile
 
 `InstanceProfile` is an optional field and tells Karpenter which IAM identity nodes should assume. You must specify one of `role` or `instanceProfile` when creating a Karpenter `EC2NodeClass`. If you use the `instanceProfile` field instead of `role`, Karpenter will not manage the InstanceProfile on your behalf; instead, it expects that you have pre-provisioned an IAM instance profile and assigned it a role.
+
+This parameter accepts both name and ARN formats.
 
 You can provision and assign a role to an IAM instance profile using [CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html) or by using the [`aws iam create-instance-profile`](https://docs.aws.amazon.com/cli/latest/reference/iam/create-instance-profile.html) and [`aws iam add-role-to-instance-profile`](https://docs.aws.amazon.com/cli/latest/reference/iam/add-role-to-instance-profile.html) commands in the CLI.
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #8312 

**Description**

- Abount this issue

  The `EC2NodeClass.spec.instanceProfile` value was always mapped to `IamInstanceProfile.Name` when executing CreateLaunchTemplate or RunInstances API calls, regardless of whether the value was an ARN or a simple name.

  Users who specify ARN values may not realize that ARNs aren't supported in the Name field, and since the CRD accepts the value and `instanceProfileReady` shows as True, it becomes difficult to identify the root cause of provisioning failures. 
  
  Additionally, Karpenter logs don't show any errors related to this misconfiguration.

- How I Resolved This Issue

  I implemented logic to detect whether the specified value is an ARN or a name using `arn.IsARN()` of aws-sdk-go-v2 liberary. When an ARN is detected, the value is now mapped to `IamInstanceProfile.Arn` instead of `IamInstanceProfile.Name`, ensuring that API calls succeed regardless of the format used.


**How was this change tested?**

- Added unit test in `pkg/providers/launchtemplate/suite_test.go`: "should set IamInstanceProfile.Arn when spec.InstanceProfile is an ARN"
- Verified that both name and ARN formats work correctly: EC2NodeClass status becomes Ready and nodes are successfully provisioned by Karpenter on my EKS cluster

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.