### PR TITLE
feat: extend kubelet configuration in EC2NodeClass CRD with CPUManagerPolicy

### DIFF
--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -296,6 +296,12 @@ type KubeletConfiguration struct {
 	// CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
 	// +optional
 	CPUCFSQuota *bool `json:"cpuCFSQuota,omitempty"`
+	// CPUManagerPolicy is the name of the policy to use.
+	// Default: "None"
+	// +kubebuilder:validation:Enum:={None,Static}
+	// +kubebuilder:default=None
+	// +optional
+	CPUManagerPolicy string `json:"cpuManagerPolicy,omitempty"`
 }
 
 // MetadataOptions contains parameters for specifying the exposure of the


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
We require the usage of `CPUManagerPolicy` Kubelet Configuration for latency sensitive workloads running on Karpenter. This requires us to extend the CRD. The type and name of the parameter was taken from the upstream definition [here](https://pkg.go.dev/k8s.io/kubelet/config/v1beta1#KubeletConfiguration).

**How was this change tested?**
Not tested yet. This is a draft PR.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.