### PR TITLE
test: Launch newer generation instance types for E2E tests

### DIFF
--- a/test/pkg/environment/aws/default_nodepool.yaml
+++ b/test/pkg/environment/aws/default_nodepool.yaml
@@ -26,7 +26,7 @@ spec:
          values: ["c", "m", "r"]
        - key: karpenter.k8s.aws/instance-generation
          operator: Gt
-         values: ["2"]
+         values: ["4"]
        - key: karpenter.k8s.aws/instance-family
          operator: NotIn
          values: ["a1"]

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -163,7 +163,7 @@ func (env *Environment) DefaultNodePool(nodeClass *v1.EC2NodeClass) *karpv1.Node
 			NodeSelectorRequirement: corev1.NodeSelectorRequirement{
 				Key:      v1.LabelInstanceGeneration,
 				Operator: corev1.NodeSelectorOpGt,
-				Values:   []string{"2"},
+				Values:   []string{"4"},
 			},
 		},
 		// Filter out a1 instance types, which are incompatible with AL2023 AMIs

--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeEach(func() {
 			NodeSelectorRequirement: corev1.NodeSelectorRequirement{
 				Key:      corev1.LabelInstanceTypeStable,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"t3a.small"},
+				Values:   []string{"c5.large"},
 			},
 		},
 	)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Launch newer generation  instance types to avoid instance type retirement 

**How was this change tested?**
- `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.