### PR TITLE
fix(amifamily) remove HTTPProtocolIPv6 by default for unsupported reg…

### DIFF
--- a/hack/tools/launchtemplate_counter/main.go
+++ b/hack/tools/launchtemplate_counter/main.go
@@ -139,7 +139,7 @@ func main() {
 	})
 	fmt.Printf("Got %d instance types after filtering\n", len(instanceTypes))
 
-	resolver := amifamily.NewDefaultResolver()
+	resolver := amifamily.NewDefaultResolver(region)
 	launchTemplates, err := resolver.Resolve(nodeClass, &karpv1.NodeClaim{}, lo.Slice(instanceTypes, 0, 60), karpv1.CapacityTypeOnDemand, &amifamily.Options{InstanceStorePolicy: lo.ToPtr(v1.InstanceStorePolicyRAID0)})
 
 	if err != nil {

--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -139,7 +139,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	lo.Must0(versionProvider.UpdateVersion(ctx))
 	ssmProvider := ssmp.NewDefaultProvider(ssm.NewFromConfig(cfg), ssmCache)
 	amiProvider := amifamily.NewDefaultProvider(operator.Clock, versionProvider, ssmProvider, ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	amiResolver := amifamily.NewDefaultResolver()
+	amiResolver := amifamily.NewDefaultResolver(cfg.Region)
 	launchTemplateProvider := launchtemplate.NewDefaultProvider(
 		ctx,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -145,7 +145,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	lo.Must0(versionProvider.UpdateVersion(ctx))
 	ssmProvider := ssmp.NewDefaultProvider(ssm.NewFromConfig(cfg), ssmCache)
 	amiProvider := amifamily.NewDefaultProvider(operator.Clock, versionProvider, ssmProvider, ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	amiResolver := amifamily.NewDefaultResolver()
+	amiResolver := amifamily.NewDefaultResolver(cfg.Region)
 	launchTemplateProvider := launchtemplate.NewDefaultProvider(
 		ctx,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
@@ -47,7 +48,9 @@ type Resolver interface {
 }
 
 // DefaultResolver is able to fill-in dynamic launch template parameters
-type DefaultResolver struct{}
+type DefaultResolver struct {
+	region string
+}
 
 // Options define the static launch template parameters
 type Options struct {
@@ -117,8 +120,10 @@ func (d DefaultFamily) FeatureFlags() FeatureFlags {
 }
 
 // NewDefaultResolver constructs a new launch template DefaultResolver
-func NewDefaultResolver() *DefaultResolver {
-	return &DefaultResolver{}
+func NewDefaultResolver(region string) *DefaultResolver {
+	return &DefaultResolver{
+		region: region,
+	}
 }
 
 // Resolve generates launch templates using the static options and dynamically generates launch template parameters.
@@ -270,6 +275,15 @@ func (r DefaultResolver) resolveLaunchTemplates(
 	if len(capacityReservationIDs) == 0 {
 		capacityReservationIDs = append(capacityReservationIDs, "")
 	}
+	httpProtocolUnsupportedRegions := sets.New[string](
+		"eu-isoe-west-1",
+		"us-iso-east-1",
+		"us-iso-west-1",
+		"us-isob-east-1",
+		"us-isob-west-1",
+		"us-isof-south-1",
+		"us-isof-east-1",
+	)
 	return lo.Map(capacityReservationIDs, func(id string, _ int) *LaunchTemplate {
 		resolved := &LaunchTemplate{
 			Options: options,
@@ -297,6 +311,9 @@ func (r DefaultResolver) resolveLaunchTemplates(
 		}
 		if resolved.MetadataOptions == nil {
 			resolved.MetadataOptions = amiFamily.DefaultMetadataOptions()
+		}
+		if httpProtocolUnsupportedRegions.Has(r.region) {
+			resolved.MetadataOptions.HTTPProtocolIPv6 = nil
 		}
 		return resolved
 	})

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -145,7 +145,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	instanceProfileProvider := instanceprofile.NewDefaultProvider(iamapi, instanceProfileCache, protectedProfilesCache, fake.DefaultRegion)
 	ssmProvider := ssmp.NewDefaultProvider(ssmapi, ssmCache)
 	amiProvider := amifamily.NewDefaultProvider(clock, versionProvider, ssmProvider, ec2api, ec2Cache)
-	amiResolver := amifamily.NewDefaultResolver()
+	amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
 	instanceTypesResolver := instancetype.NewDefaultResolver(fake.DefaultRegion)
 	capacityReservationProvider := capacityreservation.NewProvider(ec2api, clock, capacityReservationCache, capacityReservationAvailabilityCache)
 	instanceTypesProvider := instancetype.NewDefaultProvider(instanceTypeCache, offeringCache, discoveredCapacityCache, ec2api, subnetProvider, pricingProvider, capacityReservationProvider, unavailableOfferingsCache, instanceTypesResolver)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7081


**Description**
This PR removes HTTPProtocolIPv6 from default `MetadataOptions` for launch templates in unsupported regions.
Currently consumers are having to address this by using `kubectl patch crd`, creating a kustomization file, or other workarounds. 
All affected regions addressed in this change.
https://github.com/aws/karpenter-provider-aws/issues/5700#issuecomment-1955475202

**How was this change tested?**
- Added new test to `amifamily` suite. 
- All tests passing locally

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.