### PR TITLE
perf: re-use CreateFleet calls for validation

### DIFF
--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -184,6 +184,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		launchTemplateProvider,
 		capacityReservationProvider,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
+		validationCache,
 	)
 
 	// Setup field indexers on instanceID -- specifically for the interruption controller

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -91,6 +91,7 @@ func NewController(
 	disableDryRun bool,
 ) *Controller {
 	validation := NewValidationReconciler(kubeClient, cloudProvider, ec2api, amiResolver, instanceTypeProvider, launchTemplateProvider, validationCache, disableDryRun)
+	// Validation reconcile must occur after NewReadinessReconciler as CIDR must be resolved before CreateLaunchTemplate validation
 	return &Controller{
 		kubeClient:              kubeClient,
 		recorder:                recorder,
@@ -104,8 +105,8 @@ func NewController(
 			NewSubnetReconciler(subnetProvider),
 			NewSecurityGroupReconciler(securityGroupProvider),
 			NewInstanceProfileReconciler(instanceProfileProvider, region, recreationCache),
-			validation,
 			NewReadinessReconciler(launchTemplateProvider),
+			validation,
 		},
 	}
 }

--- a/pkg/controllers/nodeclass/launchtemplate_test.go
+++ b/pkg/controllers/nodeclass/launchtemplate_test.go
@@ -15,6 +15,9 @@ limitations under the License.
 package nodeclass_test
 
 import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/awslabs/operatorpkg/status"
@@ -30,6 +33,7 @@ import (
 
 var _ = Describe("NodeClass Launch Template CIDR Resolution Controller", func() {
 	BeforeEach(func() {
+		awsEnv.EC2API.Reset()
 		nodeClass = test.EC2NodeClass(v1.EC2NodeClass{
 			Spec: v1.EC2NodeClassSpec{
 				SubnetSelectorTerms: []v1.SubnetSelectorTerm{
@@ -52,6 +56,16 @@ var _ = Describe("NodeClass Launch Template CIDR Resolution Controller", func() 
 		})
 		// Cluster CIDR will only be resolved once per lifetime of the launch template provider, reset to nil between tests
 		awsEnv.LaunchTemplateProvider.ClusterCIDR.Store(nil)
+
+		// Mock EC2 Describe Launch Template API calls to ensure CreateLaunchTemplate validation passes
+		awsEnv.EC2API.DescribeLaunchTemplatesOutput.Set(&ec2.DescribeLaunchTemplatesOutput{
+			LaunchTemplates: []ec2types.LaunchTemplate{
+				{
+					LaunchTemplateName: aws.String("test-lt"),
+					LaunchTemplateId:   aws.String("lt-12345"),
+				},
+			},
+		})
 	})
 	DescribeTable(
 		"shouldn't resolve cluster CIDR for non-AL2023 NodeClasses",

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/fake"
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
+	"github.com/aws/karpenter-provider-aws/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -308,6 +309,53 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 		ExpectNotFound(ctx, env.Client, nodeClass)
 		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
+	})
+	It("should skip validation after successful instance creation", func() {
+		nodeSelectReq := []karpv1.NodeSelectorRequirementWithMinValues{
+			{
+				NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+					Key:      corev1.LabelInstanceTypeStable,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{string(ec2types.InstanceTypeM5Large)},
+				},
+			},
+		}
+		nodeClassRef := &karpv1.NodeClassReference{
+			Group: object.GVK(nodeClass).Group,
+			Kind:  object.GVK(nodeClass).Kind,
+			Name:  nodeClass.Name,
+		}
+		nodePool := coretest.NodePool(karpv1.NodePool{Spec: karpv1.NodePoolSpec{Template: karpv1.NodeClaimTemplate{
+			Spec: karpv1.NodeClaimTemplateSpec{Requirements: nodeSelectReq, NodeClassRef: nodeClassRef}}}})
+		nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{Spec: karpv1.NodeClaimSpec{Requirements: nodeSelectReq, NodeClassRef: nodeClassRef}})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)
+
+		// Run all controllers to resolve the NodeClass
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		// Remove any validation results from the first reconcile
+		awsEnv.ValidationCache.Flush()
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+		// Create instance with the resolved NodeClass
+		tags, err := utils.GetTags(nodeClass, nodeClaim, options.FromContext(ctx).ClusterName)
+		Expect(err).ToNot(HaveOccurred())
+		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, tags, instanceTypes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instance).ToNot(BeNil())
+		// Verify validation cache was populated by the successful CreateFleet
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(1))
+		// Reset API call counters to correctly count in validation controller reconcile
+		awsEnv.EC2API.Reset()
+		// Re-run controllers
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		// Validation should succeed without making any calls
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsTrue()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsTrue()).To(BeTrue())
+		Expect(awsEnv.EC2API.CreateFleetBehavior.Calls()).To(Equal(0))
+		Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.Calls()).To(Equal(0))
+		Expect(awsEnv.EC2API.RunInstancesBehavior.Calls()).To(Equal(0))
 	})
 	It("should pass validation when the validation controller is disabled", func() {
 		controller = nodeclass.NewController(

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -190,6 +190,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		launchTemplateProvider,
 		capacityReservationProvider,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
+		validationCache,
 	)
 
 	// Setup field indexers on instanceID -- specifically for the interruption controller

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -103,6 +103,7 @@ type DefaultProvider struct {
 	ec2Batcher                  *batcher.EC2API
 	capacityReservationProvider capacityreservation.Provider
 	instanceCache               *cache.Cache
+	validationCache             *cache.Cache
 }
 
 func NewDefaultProvider(
@@ -115,6 +116,7 @@ func NewDefaultProvider(
 	launchTemplateProvider launchtemplate.Provider,
 	capacityReservationProvider capacityreservation.Provider,
 	instanceCache *cache.Cache,
+	validationCache *cache.Cache,
 ) *DefaultProvider {
 	return &DefaultProvider{
 		region:                      region,
@@ -126,6 +128,7 @@ func NewDefaultProvider(
 		ec2Batcher:                  batcher.EC2(ctx, ec2api),
 		capacityReservationProvider: capacityReservationProvider,
 		instanceCache:               instanceCache,
+		validationCache:             validationCache,
 	}
 }
 
@@ -358,6 +361,8 @@ func (p *DefaultProvider) launchInstance(
 			middleware.AWSErrorCodeLogKey, "UnfulfillableCapacity",
 		)
 	}
+	// CreateFleet call is successful so we mark valdiation as successful
+	p.validationCache.SetDefault(utils.ValidationCacheKey(nodeClass, tags), "")
 	return createFleetOutput.Instances[0], nil
 }
 

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 	"github.com/awslabs/operatorpkg/object"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -139,6 +140,9 @@ var _ = Describe("InstanceProvider", func() {
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
 
+		// Validation cache should not be updated on failure
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
+
 		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeSpot)).To(BeTrue())
 		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeSpot)).To(BeTrue())
 		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeOnDemand)).To(BeFalse())
@@ -154,6 +158,9 @@ var _ = Describe("InstanceProvider", func() {
 		instance, err = awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
+
+		// Validation cache should still not be updated on failure
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
 
 		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeSpot)).To(BeTrue())
 		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1b", karpv1.CapacityTypeSpot)).To(BeTrue())
@@ -199,6 +206,9 @@ var _ = Describe("InstanceProvider", func() {
 		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
+
+		// Validation cache should not be updated on failure
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
 
 		// Capacity should get ICEd when this error is received
 		Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable("m5.xlarge", "test-zone-1a", karpv1.CapacityTypeSpot)).To(BeTrue())
@@ -255,6 +265,9 @@ var _ = Describe("InstanceProvider", func() {
 		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
+
+		// Validation cache should not be updated on failure
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
 
 		// Ensure we marked the reservation as unavailable after encountering the error
 		Expect(awsEnv.CapacityReservationProvider.GetAvailableInstanceCount(targetReservationID)).To(Equal(0))
@@ -376,6 +389,9 @@ var _ = Describe("InstanceProvider", func() {
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
 
+		// Validation cache should not be updated on failure
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
+
 		// We should have set the zone used in the request as unavailable for all instance types
 		for _, instance := range instanceTypes {
 			Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable(ec2types.InstanceType(instance.Name), "test-zone-1a", "on-demand")).To(BeTrue())
@@ -387,5 +403,39 @@ var _ = Describe("InstanceProvider", func() {
 				Expect(awsEnv.UnavailableOfferingsCache.IsUnavailable(ec2types.InstanceType(instance.Name), zone, "on-demand")).To(BeFalse())
 			}
 		}
+	})
+	It("should update validation cache when CreateFleet succeeds and launches instances", func() {
+		ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
+
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+
+		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instance).ToNot(BeNil())
+
+		// Validation cache should be updated on failure
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(1))
+	})
+	It("should not update validation cache when CreateFleet fails", func() {
+		ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
+
+		awsEnv.EC2API.CreateFleetBehavior.Error.Set(&smithy.GenericAPIError{
+			Code: "UnauthorizedOperation",
+		})
+
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+
+		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
+		Expect(err).To(HaveOccurred())
+		Expect(instance).To(BeNil())
+
+		// Validation cache should not be updated on failure
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(0))
 	})
 })

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -176,6 +176,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		launchTemplateProvider,
 		capacityReservationProvider,
 		instanceCache,
+		validationCache,
 	)
 
 	return &Environment{


### PR DESCRIPTION
Fixes #N/A

**Description**
* Note: Dependent on https://github.com/aws/karpenter-provider-aws/pull/8408
* Re-use existing successful `CreateFleet` calls to confirm that the EC2NodeClass is valid for launching nodes
  * i.e. when a successful `CreateFleet` call occurs, update the validation cache for the EC2NodeClass to allow next dry-run validation to be "skipped"

**How was this change tested?**
* `make presubmit`
*  `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.