### PR TITLE
ci: Avoid using cache in GHA that have access to id-token on main

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -4,12 +4,16 @@ inputs:
   k8sVersion:
     description: Kubernetes version to use when installing the toolchain
     default: "1.32.x"
+  use-cache:
+    description: 'Whether to cache dependencies'
+    default: true
 runs:
   using: "composite"
   steps:
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       id: setup-go
       with:
+        cache: ${{ inputs.use-cache == 'true' }}
         go-version-file: go.mod
         check-latest: true
         cache-dependency-path: "**/go.sum"
@@ -18,6 +22,7 @@ runs:
       shell: bash
     - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: cache-toolchain
+      if: ${{ inputs.use-cache == 'true' }}
       with:
         path: |
           /usr/local/kubebuilder/bin

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/install-deps
+        with:
+          use-cache: false
       - run: |
           git config user.name "APICodeGen"
           git config user.email "APICodeGen@users.noreply.github.com"

--- a/.github/workflows/dryrun-gen.yaml
+++ b/.github/workflows/dryrun-gen.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/install-deps
+        with:
+          use-cache: false
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: 'arn:aws:iam::${{ vars.READONLY_ACCOUNT_ID }}:role/${{ vars.READONLY_ROLE_NAME }}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
           prerelease: false
       - uses: ./.github/actions/install-deps
+        with:
+          use-cache: false
       - uses: ./.github/actions/e2e/install-helm
         with:
           version: v3.12.3 # Pinned to this version since v3.13.0 has issues with pushing to public ECR: https://github.com/helm/helm/issues/12442

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -16,6 +16,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/install-deps
+        with:
+          use-cache: false
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: 'arn:aws:iam::${{ vars.SNAPSHOT_ACCOUNT_ID }}:role/${{ vars.SNAPSHOT_ROLE_NAME }}'


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Avoid using the install-deps cache on workflows on main that have access to the `id-token` permission

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.