### PR TITLE
ci: Include K8s version 1.33 in docs and testing

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -21,7 +21,7 @@ inputs:
     required: true
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
-    default: "1.32"
+    default: "1.33"
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
   private_cluster:

--- a/.github/actions/e2e/run-tests-private-cluster/action.yaml
+++ b/.github/actions/e2e/run-tests-private-cluster/action.yaml
@@ -33,7 +33,7 @@ inputs:
     required: true
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
-    default: "1.32"
+    default: "1.33"
   private_cluster:
     description: "Whether to create a private cluster which does not add access to the public internet. Valid values are 'true' or 'false'"
     default: 'false'

--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -27,7 +27,7 @@ inputs:
     required: true
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
-    default: "1.32"
+    default: "1.33"
   eksctl_version:
     description: "Version of eksctl to install"
     default: v0.202.0

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -3,7 +3,7 @@ description: 'Installs Go Downloads and installs Karpenter Dependencies'
 inputs:
   k8sVersion:
     description: Kubernetes version to use when installing the toolchain
-    default: "1.32.x"
+    default: "1.33.x"
   use-cache:
     description: 'Whether to cache dependencies'
     default: true

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          k8sVersion: ["1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x"]
+          k8sVersion: ["1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x"]
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - uses: ./.github/actions/install-deps
@@ -23,7 +23,7 @@ jobs:
     - run: K8S_VERSION=${{ matrix.k8sVersion }} make ci-test
     - name: Send coverage
       # should only send converage once https://docs.coveralls.io/parallel-builds
-      if: matrix.k8sVersion == '1.32.x'
+      if: matrix.k8sVersion == '1.33.x'
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: goveralls -coverprofile=coverage.out -service=github

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -7,7 +7,7 @@ on:
         default: "us-east-2"
       k8s_version:
         type: string
-        default: "1.32"
+        default: "1.33"
       cleanup:
         type: boolean
         required: true
@@ -34,14 +34,13 @@ on:
       k8s_version:
         type: choice
         options:
-          - "1.26"
-          - "1.27"
           - "1.28"
           - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
-        default: "1.32"
+          - "1.33"
+        default: "1.33"
       cleanup:
         type: boolean
         required: true

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -16,14 +16,13 @@ on:
       k8s_version:
         type: choice
         options:
-          - "1.26"
-          - "1.27"
           - "1.28"
           - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
-        default: "1.32"
+          - "1.33"
+        default: "1.33"
       cleanup:
         required: true
         default: true
@@ -43,7 +42,7 @@ on:
         default: "us-east-2"
       k8s_version:
         type: string
-        default: "1.32"
+        default: "1.33"
       cleanup:
         required: true
         type: boolean

--- a/.github/workflows/e2e-version-compatibility-trigger.yaml
+++ b/.github/workflows/e2e-version-compatibility-trigger.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: ["1.26", "1.27", "1.28", "1.29", "1.30", "1.31", "1.32"]
+        k8s_version: ["1.28", "1.29", "1.30", "1.31", "1.32", "1.33"]
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       region: ${{ inputs.region || 'eu-west-1' }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,14 +30,13 @@ on:
       k8s_version:
         type: choice
         options:
-          - "1.26"
-          - "1.27"
           - "1.28"
           - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
-        default: "1.32"
+          - "1.33"
+        default: "1.33"
       cluster_name:
         type: string
       cleanup:
@@ -67,7 +66,7 @@ on:
         required: true
       k8s_version:
         type: string
-        default: "1.32"
+        default: "1.33"
       enable_metrics:
         type: boolean
         default: false

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- with .Values.additionalAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-K8S_VERSION="${K8S_VERSION:="1.29.x"}"
+K8S_VERSION="${K8S_VERSION:="1.33.x"}"
 KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:-/usr/local/kubebuilder/bin}"
 
 

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -17,7 +17,6 @@ package cloudprovider_test
 import (
 	"context"
 	"fmt"
-	"net"
 	"strings"
 	"testing"
 	"time"
@@ -108,9 +107,6 @@ var _ = BeforeEach(func() {
 
 	cluster.Reset()
 	awsEnv.Reset()
-
-	awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("10.0.100.10")
-	awsEnv.LaunchTemplateProvider.ClusterEndpoint = "https://test-cluster"
 })
 
 var _ = AfterEach(func() {
@@ -231,9 +227,9 @@ var _ = Describe("CloudProvider", func() {
 		})
 		version := awsEnv.VersionProvider.Get(ctx)
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):       "amd64-ami-id",
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version):   "amd64-nvidia-ami-id",
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version): "arm64-ami-id",
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", version): "amd64-ami-id",
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/nvidia/recommended/image_id", version):   "amd64-nvidia-ami-id",
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id", version):  "arm64-ami-id",
 		}
 	})
 	It("should not proceed with instance creation if NodeClass is unknown", func() {

--- a/pkg/controllers/nodeclass/ami_test.go
+++ b/pkg/controllers/nodeclass/ami_test.go
@@ -23,6 +23,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -231,6 +232,9 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 			Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeAMIsReady)).To(BeTrue())
 		})
 		It("Should resolve all AMIs with correct requirements for AL2", func() {
+			if version.MustParseGeneric(k8sVersion).Minor() > 32 {
+				Skip("AL2 is not supported on versions > 1.32")
+			}
 			awsEnv.SSMAPI.Parameters = map[string]string{
 				fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", k8sVersion):       "ami-amd64-standard",
 				fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", k8sVersion):   "ami-amd64-nvidia",

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/awslabs/operatorpkg/object"
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -129,6 +130,9 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 		DescribeTable(
 			"shouldn't resolve cluster CIDR for non-AL2023 NodeClasses",
 			func(family string, terms []v1.AMISelectorTerm) {
+				if version.MustParseGeneric(awsEnv.VersionProvider.Get(ctx)).Minor() > 32 {
+					Skip("AL2 is not supported on versions > 1.32")
+				}
 				nodeClass.Spec.AMIFamily = lo.ToPtr(family)
 				nodeClass.Spec.AMISelectorTerms = terms
 				ExpectApplied(ctx, env.Client, nodeClass)
@@ -263,7 +267,6 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 		)
 		Context("Instance Type Prioritization Validation", func() {
 			BeforeEach(func() {
-				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 				awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{
 					Images: []ec2types.Image{
 						{
@@ -291,9 +294,9 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 				})
 				version := awsEnv.VersionProvider.Get(ctx)
 				awsEnv.SSMAPI.Parameters = map[string]string{
-					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):       "amd64-ami-id",
-					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version):   "amd64-nvidia-ami-id",
-					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version): "arm64-ami-id",
+					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", version): "amd64-ami-id",
+					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/nvidia/recommended/image_id", version):   "amd64-nvidia-ami-id",
+					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id", version):  "arm64-ami-id",
 				}
 				Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypes(ctx)).To(Succeed())
 				Expect(awsEnv.InstanceTypesProvider.UpdateInstanceTypeOfferings(ctx)).To(Succeed())

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"net"
 	"reflect"
 	"sort"
 	"strings"
@@ -102,8 +101,6 @@ var _ = BeforeEach(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cluster.Reset()
 	awsEnv.Reset()
-	awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("10.0.100.10")
-	awsEnv.LaunchTemplateProvider.ClusterEndpoint = "https://test-cluster"
 })
 
 var _ = AfterEach(func() {
@@ -2469,8 +2466,6 @@ var _ = Describe("InstanceTypeProvider", func() {
 		})
 		It("should default to EBS defaults when volumeSize is not defined in blockDeviceMappings for AL2023 Root volume", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
-			awsEnv.LaunchTemplateProvider.CABundle = lo.ToPtr("Y2EtYnVuZGxlCg==")
-			awsEnv.LaunchTemplateProvider.ClusterCIDR.Store(lo.ToPtr("10.100.0.0/16"))
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -118,10 +118,6 @@ var _ = BeforeEach(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cluster.Reset()
 	awsEnv.Reset()
-
-	awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("10.0.100.10")
-	awsEnv.LaunchTemplateProvider.ClusterEndpoint = "https://test-cluster"
-	awsEnv.LaunchTemplateProvider.CABundle = lo.ToPtr("ca-bundle")
 })
 
 var _ = AfterEach(func() {
@@ -648,8 +644,6 @@ var _ = Describe("LaunchTemplate Provider", func() {
 		})
 		It("should default AL2023 block device mappings", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
-			awsEnv.LaunchTemplateProvider.CABundle = lo.ToPtr("Y2EtYnVuZGxlCg==")
-			awsEnv.LaunchTemplateProvider.ClusterCIDR.Store(lo.ToPtr("10.100.0.0/16"))
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
@@ -1147,6 +1141,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 	})
 	Context("User Data", func() {
 		It("should specify --use-max-pods=false when using ENI-based pod density", func() {
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
@@ -1154,6 +1149,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectLaunchTemplatesCreatedWithUserDataContaining("--use-max-pods false")
 		})
 		It("should specify --use-max-pods=false and --max-pods user value when user specifies maxPods in NodePool", func() {
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{MaxPods: aws.Int32(10)}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
@@ -1161,7 +1157,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			ExpectLaunchTemplatesCreatedWithUserDataContaining("--use-max-pods false", "--max-pods=10")
 		})
-		It("should generate different launch templates for different --max-pods values when specifying kubelet configuration", func() {
+		It("should generate different launch templates for different maxPods values when specifying kubelet configuration", func() {
 			// We validate that we no longer combine instance types into the same launch template with the same --max-pods values
 			// that shouldn't have been combined but were combined due to a pointer error
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
@@ -1174,7 +1170,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			// We expect to generate 5 launch templates for our image/max-pods combination where we were only generating 2 before
 			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
 		})
-		It("should specify --system-reserved when overriding system reserved values", func() {
+		It("should specify systemReserved when overriding system reserved values", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				SystemReserved: map[string]string{
 					string(corev1.ResourceCPU):              "500m",
@@ -1187,21 +1183,16 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
-			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
-				userData, err := base64.StdEncoding.DecodeString(*ltInput.LaunchTemplateData.UserData)
-				Expect(err).To(BeNil())
-
-				// Check whether the arguments are there for --system-reserved
-				arg := "--system-reserved="
-				i := strings.Index(string(userData), arg)
-				rem := string(userData)[(i + len(arg)):]
-				i = strings.Index(rem, "'")
-				for k, v := range nodeClass.Spec.Kubelet.SystemReserved {
-					Expect(rem[:i]).To(ContainSubstring(fmt.Sprintf("%v=%v", k, v)))
-				}
-			})
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				systemReserved := ExpectParseNodeConfigKubeletField[corev1.ResourceList](userData, "systemReserved")
+				ExpectResources(corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("500m"),
+					corev1.ResourceMemory:           resource.MustParse("1Gi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+				}, systemReserved)
+			}
 		})
-		It("should specify --kube-reserved when overriding system reserved values", func() {
+		It("should specify kubeReserved when overriding system reserved values", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				KubeReserved: map[string]string{
 					string(corev1.ResourceCPU):              "500m",
@@ -1214,21 +1205,16 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
-			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
-				userData, err := base64.StdEncoding.DecodeString(*ltInput.LaunchTemplateData.UserData)
-				Expect(err).To(BeNil())
-
-				// Check whether the arguments are there for --kube-reserved
-				arg := "--kube-reserved="
-				i := strings.Index(string(userData), arg)
-				rem := string(userData)[(i + len(arg)):]
-				i = strings.Index(rem, "'")
-				for k, v := range nodeClass.Spec.Kubelet.KubeReserved {
-					Expect(rem[:i]).To(ContainSubstring(fmt.Sprintf("%v=%v", k, v)))
-				}
-			})
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				kubeReserved := ExpectParseNodeConfigKubeletField[corev1.ResourceList](userData, "kubeReserved")
+				ExpectResources(corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("500m"),
+					corev1.ResourceMemory:           resource.MustParse("1Gi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+				}, kubeReserved)
+			}
 		})
-		It("should pass eviction hard threshold values when specified", func() {
+		It("should pass evictionHard threshold values when specified", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				EvictionHard: map[string]string{
 					"memory.available":  "10%",
@@ -1241,21 +1227,14 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
-			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
-				userData, err := base64.StdEncoding.DecodeString(*ltInput.LaunchTemplateData.UserData)
-				Expect(err).To(BeNil())
-
-				// Check whether the arguments are there for --kube-reserved
-				arg := "--eviction-hard="
-				i := strings.Index(string(userData), arg)
-				rem := string(userData)[(i + len(arg)):]
-				i = strings.Index(rem, "'")
-				for k, v := range nodeClass.Spec.Kubelet.EvictionHard {
-					Expect(rem[:i]).To(ContainSubstring(fmt.Sprintf("%v<%v", k, v)))
-				}
-			})
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				evictionHard := ExpectParseNodeConfigKubeletField[map[string]string](userData, "evictionHard")
+				Expect(evictionHard).To(HaveKeyWithValue("memory.available", "10%"))
+				Expect(evictionHard).To(HaveKeyWithValue("nodefs.available", "15%"))
+				Expect(evictionHard).To(HaveKeyWithValue("nodefs.inodesFree", "5%"))
+			}
 		})
-		It("should pass eviction soft threshold values when specified", func() {
+		It("should pass evictionSoft threshold values when specified", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				EvictionSoft: map[string]string{
 					"memory.available":  "10%",
@@ -1273,21 +1252,14 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
-			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
-				userData, err := base64.StdEncoding.DecodeString(*ltInput.LaunchTemplateData.UserData)
-				Expect(err).To(BeNil())
-
-				// Check whether the arguments are there for --kube-reserved
-				arg := "--eviction-soft="
-				i := strings.Index(string(userData), arg)
-				rem := string(userData)[(i + len(arg)):]
-				i = strings.Index(rem, "'")
-				for k, v := range nodeClass.Spec.Kubelet.EvictionSoft {
-					Expect(rem[:i]).To(ContainSubstring(fmt.Sprintf("%v<%v", k, v)))
-				}
-			})
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				evictionSoft := ExpectParseNodeConfigKubeletField[map[string]string](userData, "evictionSoft")
+				Expect(evictionSoft).To(HaveKeyWithValue("memory.available", "10%"))
+				Expect(evictionSoft).To(HaveKeyWithValue("nodefs.available", "15%"))
+				Expect(evictionSoft).To(HaveKeyWithValue("nodefs.inodesFree", "5%"))
+			}
 		})
-		It("should pass eviction soft grace period values when specified", func() {
+		It("should pass evictionSoftGracePeriod values when specified", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				EvictionSoftGracePeriod: map[string]metav1.Duration{
 					"memory.available":  {Duration: time.Minute},
@@ -1305,21 +1277,14 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
-			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
-				userData, err := base64.StdEncoding.DecodeString(*ltInput.LaunchTemplateData.UserData)
-				Expect(err).To(BeNil())
-
-				// Check whether the arguments are there for --kube-reserved
-				arg := "--eviction-soft-grace-period="
-				i := strings.Index(string(userData), arg)
-				rem := string(userData)[(i + len(arg)):]
-				i = strings.Index(rem, "'")
-				for k, v := range nodeClass.Spec.Kubelet.EvictionSoftGracePeriod {
-					Expect(rem[:i]).To(ContainSubstring(fmt.Sprintf("%v=%v", k, v.Duration.String())))
-				}
-			})
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				evictionSoftGracePeriod := ExpectParseNodeConfigKubeletField[map[string]string](userData, "evictionSoftGracePeriod")
+				Expect(evictionSoftGracePeriod).To(HaveKeyWithValue("memory.available", "1m0s"))
+				Expect(evictionSoftGracePeriod).To(HaveKeyWithValue("nodefs.available", "3m0s"))
+				Expect(evictionSoftGracePeriod).To(HaveKeyWithValue("nodefs.inodesFree", "5m0s"))
+			}
 		})
-		It("should pass eviction max pod grace period when specified", func() {
+		It("should pass evictionMaxPodGracePeriod when specified", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				EvictionMaxPodGracePeriod: aws.Int32(300),
 			}
@@ -1327,9 +1292,12 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining(fmt.Sprintf("--eviction-max-pod-grace-period=%d", 300))
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				evictionMaxPodGracePeriod := ExpectParseNodeConfigKubeletField[int64](userData, "evictionMaxPodGracePeriod")
+				Expect(evictionMaxPodGracePeriod).To(BeNumerically("==", 300))
+			}
 		})
-		It("should specify --pods-per-core", func() {
+		It("should specify podsPerCore", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				PodsPerCore: aws.Int32(2),
 			}
@@ -1337,9 +1305,12 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining(fmt.Sprintf("--pods-per-core=%d", 2))
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				podsPerCore := ExpectParseNodeConfigKubeletField[int64](userData, "podsPerCore")
+				Expect(podsPerCore).To(BeNumerically("==", 2))
+			}
 		})
-		It("should specify --pods-per-core with --max-pods enabled", func() {
+		It("should specify podsPerCore with maxPods enabled", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				PodsPerCore: aws.Int32(2),
 				MaxPods:     aws.Int32(100),
@@ -1348,23 +1319,35 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining(fmt.Sprintf("--pods-per-core=%d", 2), fmt.Sprintf("--max-pods=%d", 100))
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				podsPerCore := ExpectParseNodeConfigKubeletField[int64](userData, "podsPerCore")
+				Expect(podsPerCore).To(BeNumerically("==", 2))
+				maxPods := ExpectParseNodeConfigKubeletField[int64](userData, "maxPods")
+				Expect(maxPods).To(BeNumerically("==", 100))
+			}
 		})
-		It("should specify --dns-cluster-ip and --ip-family when running in an ipv6 cluster", func() {
+		It("should specify clusterDNS when running in an ipv6 cluster", func() {
 			awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("fd4b:121b:812b::a")
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining("--dns-cluster-ip 'fd4b:121b:812b::a'")
-			ExpectLaunchTemplatesCreatedWithUserDataContaining("--ip-family ipv6")
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				clusterDNS := ExpectParseNodeConfigKubeletField[[]string](userData, "clusterDNS")
+				Expect(clusterDNS).To(HaveLen(1))
+				Expect(clusterDNS[0]).To(Equal("fd4b:121b:812b::a"))
+			}
 		})
-		It("should specify --dns-cluster-ip when running in an ipv4 cluster", func() {
+		It("should specify clusterDNS when running in an ipv4 cluster", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining("--dns-cluster-ip '10.0.100.10'")
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				clusterDNS := ExpectParseNodeConfigKubeletField[[]string](userData, "clusterDNS")
+				Expect(clusterDNS).To(HaveLen(1))
+				Expect(clusterDNS[0]).To(Equal("10.0.100.10"))
+			}
 		})
 		It("should pass ImageGCHighThresholdPercent when specified", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
@@ -1374,7 +1357,10 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining("--image-gc-high-threshold=50")
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				imageGCHighThresholdPercent := ExpectParseNodeConfigKubeletField[int64](userData, "imageGCHighThresholdPercent")
+				Expect(imageGCHighThresholdPercent).To(BeNumerically("==", 50))
+			}
 		})
 		It("should pass ImageGCLowThresholdPercent when specified", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
@@ -1384,9 +1370,12 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining("--image-gc-low-threshold=50")
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				imageGCLowThresholdPercent := ExpectParseNodeConfigKubeletField[int64](userData, "imageGCLowThresholdPercent")
+				Expect(imageGCLowThresholdPercent).To(BeNumerically("==", 50))
+			}
 		})
-		It("should pass --cpu-fs-quota when specified", func() {
+		It("should pass cpuCFSQuota when specified", func() {
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				CPUCFSQuota: aws.Bool(false),
 			}
@@ -1394,7 +1383,10 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			ExpectLaunchTemplatesCreatedWithUserDataContaining("--cpu-cfs-quota=false")
+			for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
+				cpuCFSQuota := ExpectParseNodeConfigKubeletField[bool](userData, "cpuCFSQuota")
+				Expect(cpuCFSQuota).To(BeFalse())
+			}
 		})
 		It("should not pass any labels prefixed with the node-restriction.kubernetes.io domain", func() {
 			nodePool.Spec.Template.Labels = lo.Assign(nodePool.Spec.Template.Labels, map[string]string{
@@ -1418,6 +1410,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectLaunchTemplatesCreatedWithUserDataNotContaining(corev1.LabelNamespaceNodeRestriction)
 		})
 		It("should specify --local-disks raid0 when instance-store policy is set on AL2", func() {
+			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 			nodeClass.Spec.InstanceStorePolicy = lo.ToPtr(v1.InstanceStorePolicyRAID0)
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
@@ -1607,7 +1600,7 @@ essential = true
 				ExpectLaunchTemplatesCreatedWithUserDataContaining(`
 [settings.kubernetes]
 api-server = 'https://test-cluster'
-cluster-certificate = 'ca-bundle'
+cluster-certificate = 'Y2EtYnVuZGxlCg=='
 cluster-name = 'test-cluster'
 cluster-dns-ip = '10.0.100.10'
 max-pods = 35
@@ -1779,6 +1772,7 @@ eviction-max-pod-grace-period = 10
 		Context("AL2 Custom UserData", func() {
 			BeforeEach(func() {
 				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{MaxPods: lo.ToPtr[int32](110)}
+				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 			})
 			It("should merge in custom user data", func() {
 				content, err := os.ReadFile("testdata/al2_userdata_input.golden")
@@ -1834,10 +1828,6 @@ eviction-max-pod-grace-period = 10
 		Context("AL2023", func() {
 			BeforeEach(func() {
 				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
-
-				// base64 encoded version of "ca-bundle" to ensure the nodeadm bootstrap provider can decode successfully
-				awsEnv.LaunchTemplateProvider.CABundle = lo.ToPtr("Y2EtYnVuZGxlCg==")
-				awsEnv.LaunchTemplateProvider.ClusterCIDR.Store(lo.ToPtr("10.100.0.0/16"))
 			})
 			Context("Kubelet", func() {
 				It("should specify taints in the KubeletConfiguration when specified in NodePool", func() {
@@ -1861,7 +1851,7 @@ eviction-max-pod-grace-period = 10
 					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 					ExpectScheduled(ctx, env.Client, pod)
 					for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
-						configs := ExpectUserDataCreatedWithNodeConfigs(userData)
+						configs := ExpectParseNodeConfigs(userData)
 						Expect(len(configs)).To(Equal(1))
 						taintsRaw, ok := configs[0].Spec.Kubelet.Config["registerWithTaints"]
 						Expect(ok).To(BeTrue())
@@ -1885,7 +1875,7 @@ eviction-max-pod-grace-period = 10
 					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 					ExpectScheduled(ctx, env.Client, pod)
 					for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
-						configs := ExpectUserDataCreatedWithNodeConfigs(userData)
+						configs := ExpectParseNodeConfigs(userData)
 						Expect(len(configs)).To(Equal(1))
 						labelFlag, ok := lo.Find(configs[0].Spec.Kubelet.Flags, func(flag string) bool {
 							return strings.HasPrefix(flag, "--node-labels")
@@ -1916,7 +1906,7 @@ eviction-max-pod-grace-period = 10
 					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 					ExpectScheduled(ctx, env.Client, pod)
 					for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
-						configs := ExpectUserDataCreatedWithNodeConfigs(userData)
+						configs := ExpectParseNodeConfigs(userData)
 						Expect(len(configs)).To(Equal(1))
 						labelFlag, ok := lo.Find(configs[0].Spec.Kubelet.Flags, func(flag string) bool {
 							return strings.HasPrefix(flag, "--node-labels")
@@ -1949,7 +1939,7 @@ eviction-max-pod-grace-period = 10
 							})
 						}()
 						for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
-							configs := ExpectUserDataCreatedWithNodeConfigs(userData)
+							configs := ExpectParseNodeConfigs(userData)
 							Expect(len(configs)).To(Equal(1))
 							Expect(configs[0].Spec.Kubelet.Config[field]).To(Equal(inlineConfig[field]))
 						}
@@ -2026,7 +2016,7 @@ eviction-max-pod-grace-period = 10
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				ExpectScheduled(ctx, env.Client, pod)
 				for _, userData := range ExpectUserDataExistsFromCreatedLaunchTemplates() {
-					configs := ExpectUserDataCreatedWithNodeConfigs(userData)
+					configs := ExpectParseNodeConfigs(userData)
 					Expect(len(configs)).To(Equal(1))
 					Expect(configs[0].Spec.Instance.LocalStorage.Strategy).To(Equal(admv1alpha1.LocalStorageRAID0))
 				}
@@ -2298,16 +2288,6 @@ eviction-max-pod-grace-period = 10
 				Entry("AssociatePublicIPAddress is false (EFA)", false, false, true),
 			)
 		})
-		Context("Kubelet Args", func() {
-			It("should specify the --dns-cluster-ip flag when clusterDNSIP is set", func() {
-				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{ClusterDNS: []string{"10.0.10.100"}}
-				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-				pod := coretest.UnschedulablePod()
-				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-				ExpectScheduled(ctx, env.Client, pod)
-				ExpectLaunchTemplatesCreatedWithUserDataContaining("--dns-cluster-ip '10.0.10.100'")
-			})
-		})
 		Context("Windows Custom UserData", func() {
 			BeforeEach(func() {
 				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelOSStable, Operator: corev1.NodeSelectorOpIn, Values: []string{string(corev1.Windows)}}}}
@@ -2425,7 +2405,6 @@ eviction-max-pod-grace-period = 10
 			DescribeTable(
 				"should set Primary IPv6 as true and provision a IPv6 address",
 				func(isPublicAddressSet, isPublic, isEFA bool) {
-					awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("fd4b:121b:812b::a")
 					awsEnv.LaunchTemplateProvider.ClusterIPFamily = corev1.IPv6Protocol
 					if isPublicAddressSet {
 						nodeClass.Spec.AssociatePublicIPAddress = lo.ToPtr(isPublic)
@@ -2649,7 +2628,7 @@ func ExpectUserDataExistsFromCreatedLaunchTemplates() []string {
 	return userDatas
 }
 
-func ExpectUserDataCreatedWithNodeConfigs(userData string) []admv1alpha1.NodeConfig {
+func ExpectParseNodeConfigs(userData string) []admv1alpha1.NodeConfig {
 	GinkgoHelper()
 	archive, err := mime.NewArchive(userData)
 	Expect(err).To(BeNil())
@@ -2664,4 +2643,14 @@ func ExpectUserDataCreatedWithNodeConfigs(userData string) []admv1alpha1.NodeCon
 	})
 	Expect(len(nodeConfigs)).To(BeNumerically(">=", 1))
 	return nodeConfigs
+}
+
+func ExpectParseNodeConfigKubeletField[T any](userData, fieldName string) T {
+	GinkgoHelper()
+	configs := ExpectParseNodeConfigs(userData)
+	Expect(len(configs)).To(Equal(1))
+	var ret T
+	raw := configs[0].Spec.Kubelet.Config[fieldName]
+	Expect(yaml.Unmarshal(raw.Raw, &ret)).To(Succeed())
+	return ret
 }

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
@@ -12,7 +12,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
+/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'Y2EtYnVuZGxlCg==' \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
 --kubelet-extra-args '--node-labels="karpenter.k8s.aws/ec2nodeclass=%s,karpenter.sh/capacity-type=on-demand,karpenter.sh/do-not-sync-taints=true,%s=%s,testing/cluster=unspecified" --register-with-taints="karpenter.sh/unregistered:NoExecute" --max-pods=110'

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
+/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'Y2EtYnVuZGxlCg==' \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
 --kubelet-extra-args '--node-labels="karpenter.k8s.aws/ec2nodeclass=%s,karpenter.sh/capacity-type=on-demand,karpenter.sh/do-not-sync-taints=true,%s=%s,testing/cluster=unspecified" --register-with-taints="karpenter.sh/unregistered:NoExecute" --max-pods=110'

--- a/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
@@ -2,7 +2,7 @@
 [settings.kubernetes]
 api-server = 'https://test-cluster'
 cloud-provider = 'external'
-cluster-certificate = 'ca-bundle'
+cluster-certificate = 'Y2EtYnVuZGxlCg=='
 cluster-name = 'test-cluster'
 cluster-dns-ip = '10.0.100.10'
 max-pods = 110

--- a/pkg/providers/launchtemplate/testdata/br_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_unmerged.golden
@@ -1,7 +1,7 @@
 [settings]
 [settings.kubernetes]
 api-server = 'https://test-cluster'
-cluster-certificate = 'ca-bundle'
+cluster-certificate = 'Y2EtYnVuZGxlCg=='
 cluster-name = 'test-cluster'
 cluster-dns-ip = '10.0.100.10'
 max-pods = 110

--- a/pkg/providers/launchtemplate/testdata/windows_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/windows_userdata_merged.golden
@@ -2,5 +2,5 @@
 Write-Host "Running custom user data script"
 Write-Host "Finished running custom user data script"
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.k8s.aws/ec2nodeclass=%s,karpenter.sh/capacity-type=spot,karpenter.sh/do-not-sync-taints=true,%s=%s,testing/cluster=unspecified" --register-with-taints="karpenter.sh/unregistered:NoExecute" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'Y2EtYnVuZGxlCg==' -KubeletExtraArgs '--node-labels="karpenter.k8s.aws/ec2nodeclass=%s,karpenter.sh/capacity-type=spot,karpenter.sh/do-not-sync-taints=true,%s=%s,testing/cluster=unspecified" --register-with-taints="karpenter.sh/unregistered:NoExecute" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>

--- a/pkg/providers/launchtemplate/testdata/windows_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/windows_userdata_unmerged.golden
@@ -1,4 +1,4 @@
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.k8s.aws/ec2nodeclass=%s,karpenter.sh/capacity-type=spot,karpenter.sh/do-not-sync-taints=true,%s=%s,testing/cluster=unspecified" --register-with-taints="karpenter.sh/unregistered:NoExecute" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'Y2EtYnVuZGxlCg==' -KubeletExtraArgs '--node-labels="karpenter.k8s.aws/ec2nodeclass=%s,karpenter.sh/capacity-type=spot,karpenter.sh/do-not-sync-taints=true,%s=%s,testing/cluster=unspecified" --register-with-taints="karpenter.sh/unregistered:NoExecute" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -168,6 +168,10 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		net.ParseIP("10.0.100.10"),
 		"https://test-cluster",
 	)
+	launchTemplateProvider.CABundle = lo.ToPtr("Y2EtYnVuZGxlCg==")
+	launchTemplateProvider.ClusterCIDR.Store(lo.ToPtr("10.100.0.0/16"))
+	launchTemplateProvider.KubeDNSIP = net.ParseIP("10.0.100.10")
+	launchTemplateProvider.ClusterEndpoint = "https://test-cluster"
 	instanceProvider := instance.NewDefaultProvider(
 		ctx,
 		"",
@@ -263,6 +267,10 @@ func (env *Environment) Reset() {
 			}
 		}
 	}
+	env.LaunchTemplateProvider.CABundle = lo.ToPtr("Y2EtYnVuZGxlCg==")
+	env.LaunchTemplateProvider.ClusterCIDR.Store(lo.ToPtr("10.100.0.0/16"))
+	env.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("10.0.100.10")
+	env.LaunchTemplateProvider.ClusterEndpoint = "https://test-cluster"
 }
 
 func NodeInstanceIDFieldIndexer(ctx context.Context) func(ctrlcache.Cache) error {

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -34,7 +34,7 @@ func EC2NodeClass(overrides ...v1.EC2NodeClass) *v1.EC2NodeClass {
 		}
 	}
 	if len(options.Spec.AMISelectorTerms) == 0 {
-		options.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
+		options.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2023@latest"}}
 		options.Status.AMIs = []v1.AMI{
 			{
 				ID: "ami-test1",

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -220,6 +220,9 @@ var _ = Describe("AMI", func() {
 		DescribeTable(
 			"should provision a node using an alias",
 			func(alias string) {
+				if strings.Contains(alias, "al2") && env.K8sMinorVersion() > 32 {
+					Skip("AL2 is not supported on versions > 1.32")
+				}
 				pod := coretest.Pod()
 				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
 				env.ExpectCreated(nodeClass, nodePool, pod)
@@ -293,6 +296,9 @@ var _ = Describe("AMI", func() {
 
 	Context("UserData", func() {
 		It("should merge UserData contents for AL2 AMIFamily", func() {
+			if env.K8sMinorVersion() > 32 {
+				Skip("AL2 is not supported on versions > 1.32")
+			}
 			content, err := os.ReadFile("testdata/al2_userdata_input.sh")
 			Expect(err).ToNot(HaveOccurred())
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
@@ -315,6 +321,9 @@ var _ = Describe("AMI", func() {
 			Expect(string(actualUserData)).To(ContainSubstring("karpenter.sh/do-not-sync-taints=true"))
 		})
 		It("should merge non-MIME UserData contents for AL2 AMIFamily", func() {
+			if env.K8sMinorVersion() > 32 {
+				Skip("AL2 is not supported on versions > 1.32")
+			}
 			content, err := os.ReadFile("testdata/al2_no_mime_userdata_input.sh")
 			Expect(err).ToNot(HaveOccurred())
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}

--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -124,8 +124,6 @@ var _ = Describe("Extended Resources", func() {
 	})
 	It("should provision nodes for a deployment that requests aws.amazon.com/neuron", func() {
 		ExpectNeuronDevicePluginCreated()
-		// TODO: jmdeal@ remove AL2 pin once AL2023 accelerated AMIs are available
-		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 		numPods := 1
 		dep := test.Deployment(test.DeploymentOptions{
 			Replicas: int32(numPods),
@@ -166,8 +164,6 @@ var _ = Describe("Extended Resources", func() {
 	})
 	It("should provision nodes for a deployment that requests aws.amazon.com/neuroncore", func() {
 		ExpectNeuronDevicePluginCreated()
-		// TODO: jmdeal@ remove AL2 pin once AL2023 accelerated AMIs are available
-		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 		numPods := 1
 		dep := test.Deployment(test.DeploymentOptions{
 			Replicas: int32(numPods),
@@ -293,7 +289,7 @@ var _ = Describe("Extended Resources", func() {
 		Skip("skipping test on an exotic instance type")
 		ExpectHabanaDevicePluginCreated()
 
-		nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2)
+		nodeClass.Spec.AMIFamily = lo.ToPtr(v1.AMIFamilyAL2023)
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{
 			{
 				ID: "ami-0fae925f94979981f",

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -258,8 +258,6 @@ var _ = DescribeTableSubtree("Scheduling", Ordered, ContinueOnFailure, func(minV
 				NodePreferences:  requirements,
 				NodeRequirements: requirements,
 			}})
-			// Use AL2 AMIs instead of AL2023 since accelerated AMIs aren't yet available
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 			env.ExpectCreated(nodeClass, nodePool, deployment)
 			env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
 			env.ExpectCreatedNodeCount("==", 1)
@@ -279,8 +277,6 @@ var _ = DescribeTableSubtree("Scheduling", Ordered, ContinueOnFailure, func(minV
 				NodePreferences:  requirements,
 				NodeRequirements: requirements,
 			}})
-			// Use AL2 AMIs instead of AL2023 since accelerated AMIs aren't yet available
-			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 			env.ExpectCreated(nodeClass, nodePool, deployment)
 			env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
 			env.ExpectCreatedNodeCount("==", 1)

--- a/test/suites/storage/suite_test.go
+++ b/test/suites/storage/suite_test.go
@@ -374,6 +374,9 @@ var _ = Describe("Stateful workloads", func() {
 
 var _ = Describe("Ephemeral Storage", func() {
 	DescribeTable("should run a pod with instance-store ephemeral storage that exceeds EBS root block device mappings", func(alias string) {
+		if strings.Contains(alias, "al2") && env.K8sMinorVersion() > 32 {
+			Skip("AL2 is not supported on versions > 1.32")
+		}
 		nodeClass.Spec.InstanceStorePolicy = lo.ToPtr(v1.InstanceStorePolicyRAID0)
 		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{
 			{

--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -759,7 +759,7 @@ The following commands can be used to determine the versions availble for an ali
 {{< tabpane text=true right=false >}}
   {{% tab "AL2023" %}}
   ```bash
-  export K8S_VERSION="1.32"
+  export K8S_VERSION="1.33"
   aws ssm get-parameters-by-path --path "/aws/service/eks/optimized-ami/$K8S_VERSION/amazon-linux-2023/" --recursive | jq -cr '.Parameters[].Name' | grep -v "recommended" | awk -F '/' '{print $10}' | sed -r 's/.*(v[[:digit:]]+)$/\1/' | sort | uniq
   ```
   {{% /tab %}}
@@ -771,7 +771,7 @@ The following commands can be used to determine the versions availble for an ali
   {{% /tab %}}
   {{% tab "Bottlerocket" %}}
   ```bash
-  export K8S_VERSION="1.32"
+  export K8S_VERSION="1.33"
   aws ssm get-parameters-by-path --path "/aws/service/bottlerocket/aws-k8s-$K8S_VERSION" --recursive | jq -cr '.Parameters[].Name' | grep -v "latest" | awk -F '/' '{print $7}' | sort | uniq
   ```
   {{% /tab %}}

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
@@ -49,7 +49,7 @@ After setting up the tools, set the Karpenter and Kubernetes version:
 ```bash
 export KARPENTER_NAMESPACE="kube-system"
 export KARPENTER_VERSION="1.6.3"
-export K8S_VERSION="1.32"
+export K8S_VERSION="1.33"
 ```
 
 Then set the following environment variable:

--- a/website/content/en/v1.5/concepts/nodeclasses.md
+++ b/website/content/en/v1.5/concepts/nodeclasses.md
@@ -755,7 +755,7 @@ The following commands can be used to determine the versions availble for an ali
 {{< tabpane text=true right=false >}}
   {{% tab "AL2023" %}}
   ```bash
-  export K8S_VERSION="1.32"
+  export K8S_VERSION="1.33"
   aws ssm get-parameters-by-path --path "/aws/service/eks/optimized-ami/$K8S_VERSION/amazon-linux-2023/" --recursive | jq -cr '.Parameters[].Name' | grep -v "recommended" | awk -F '/' '{print $10}' | sed -r 's/.*(v[[:digit:]]+)$/\1/' | sort | uniq
   ```
   {{% /tab %}}
@@ -767,7 +767,7 @@ The following commands can be used to determine the versions availble for an ali
   {{% /tab %}}
   {{% tab "Bottlerocket" %}}
   ```bash
-  export K8S_VERSION="1.32"
+  export K8S_VERSION="1.33"
   aws ssm get-parameters-by-path --path "/aws/service/bottlerocket/aws-k8s-$K8S_VERSION" --recursive | jq -cr '.Parameters[].Name' | grep -v "latest" | awk -F '/' '{print $7}' | sort | uniq
   ```
   {{% /tab %}}

--- a/website/content/en/v1.5/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.5/getting-started/getting-started-with-karpenter/_index.md
@@ -49,7 +49,7 @@ After setting up the tools, set the Karpenter and Kubernetes version:
 ```bash
 export KARPENTER_NAMESPACE="kube-system"
 export KARPENTER_VERSION="1.5.4"
-export K8S_VERSION="1.32"
+export K8S_VERSION="1.33"
 ```
 
 Then set the following environment variable:

--- a/website/content/en/v1.6/concepts/nodeclasses.md
+++ b/website/content/en/v1.6/concepts/nodeclasses.md
@@ -759,7 +759,7 @@ The following commands can be used to determine the versions availble for an ali
 {{< tabpane text=true right=false >}}
   {{% tab "AL2023" %}}
   ```bash
-  export K8S_VERSION="1.32"
+  export K8S_VERSION="1.33"
   aws ssm get-parameters-by-path --path "/aws/service/eks/optimized-ami/$K8S_VERSION/amazon-linux-2023/" --recursive | jq -cr '.Parameters[].Name' | grep -v "recommended" | awk -F '/' '{print $10}' | sed -r 's/.*(v[[:digit:]]+)$/\1/' | sort | uniq
   ```
   {{% /tab %}}
@@ -771,7 +771,7 @@ The following commands can be used to determine the versions availble for an ali
   {{% /tab %}}
   {{% tab "Bottlerocket" %}}
   ```bash
-  export K8S_VERSION="1.32"
+  export K8S_VERSION="1.33"
   aws ssm get-parameters-by-path --path "/aws/service/bottlerocket/aws-k8s-$K8S_VERSION" --recursive | jq -cr '.Parameters[].Name' | grep -v "latest" | awk -F '/' '{print $7}' | sort | uniq
   ```
   {{% /tab %}}

--- a/website/content/en/v1.6/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.6/getting-started/getting-started-with-karpenter/_index.md
@@ -49,7 +49,7 @@ After setting up the tools, set the Karpenter and Kubernetes version:
 ```bash
 export KARPENTER_NAMESPACE="kube-system"
 export KARPENTER_VERSION="1.6.3"
-export K8S_VERSION="1.32"
+export K8S_VERSION="1.33"
 ```
 
 Then set the following environment variable:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Include K8s version 1.33 in testing for unit testing and E2E testing.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.