### PR TITLE
chore: Add error logging message when validation fails due to auth

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- with .Values.additionalAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
@@ -221,6 +222,7 @@ func (v *Validation) validateCreateLaunchTemplateAuthorization(
 			// We should only ever receive UnauthorizedOperation so if we receive any other error it would be an unexpected state
 			return nil, reconcile.Result{}, fmt.Errorf("validating ec2:CreateLaunchTemplate authorization, %w", err)
 		}
+		log.FromContext(ctx).Error(err, "unauthorized to call ec2:CreateLaunchTemplate")
 		v.updateCacheOnFailure(nodeClass, tags, ConditionReasonCreateLaunchTemplateAuthFailed)
 		return nil, reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}
@@ -252,6 +254,7 @@ func (v *Validation) validateCreateFleetAuthorization(
 			// it would be an unexpected state
 			return reconcile.Result{}, fmt.Errorf("validating ec2:CreateFleet authorization, %w", err)
 		}
+		log.FromContext(ctx).Error(err, "unauthorized to call ec2:CreateFleet")
 		v.updateCacheOnFailure(nodeClass, tags, ConditionReasonCreateFleetAuthFailed)
 		return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}
@@ -279,6 +282,7 @@ func (v *Validation) validateRunInstancesAuthorization(
 			// it would be an unexpected state
 			return reconcile.Result{}, fmt.Errorf("validating ec2:RunInstances authorization, %w", err)
 		}
+		log.FromContext(ctx).Error(err, "unauthorized to call ec2:RunInstances")
 		v.updateCacheOnFailure(nodeClass, tags, ConditionReasonRunInstancesAuthFailed)
 		return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add error logging messages when getting anauthorized errors from EC2 APIs for improved visibility

**How was this change tested?**

`make presubmit`

#### Example Error Message

```
karpenter-667c975c47-qf427 controller {"level":"ERROR","time":"2025-08-29T20:55:48.007Z","logger":"controller","caller":"nodeclass/validation.go:257","message":"unauthorized to call ec2:CreateFleet","commit":"aceca23-dirty","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"toucannotch-4-2edbxszfct"},"namespace":"","name":"toucannotch-4-2edbxszfct","reconcileID":"c9db8135-bac1-4c08-a5f3-35786cc203d7","aws-error-code":"UnauthorizedOperation","aws-operation-name":"CreateFleet","aws-request-id":"b60e8bad-3d7d-4206-95e9-7af9f28b1d47","aws-service-name":"EC2","aws-status-code":403,"error":"operation error EC2: CreateFleet, https response error StatusCode: 403, RequestID: b60e8bad-3d7d-4206-95e9-7af9f28b1d47, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::330700974597:assumed-role/scale-test-karpenter/1756500455459701167 is not authorized to perform: ec2:CreateFleet on resource: arn:aws:ec2:us-west-2:330700974597:fleet/* with an explicit deny in an identity-based policy. Encoded authorization failure message: RmYG9T32KAq99dNzyTLArnNm7a9Y8ZrEsmEFjmm_p-PhcTFUsz8U8b8_bSU643_AE1iB_7RugRPygMOWuYoz6J1F4MVd5MnycG-xPOQ2mQ8_UYV-T5jC8WQj4PBMGMwn6zqzbhq-wu5mYcqYPh-qN5RURgsF9HMdyUVMdaP9nh_vRaE7AS1iplqlW0XVqyLl8iUD1YXPoRbHw1U2SSxYHavD6tgsV6MJeVlPJ0E513LP67t2DPoNkVWp23FP6LOr22dFGGqsAOhZvqqVBPssyWhaOhTmfulzhzfzCzmdpe-pT49lV5kUSOY95iOFGsdy5SC5RbZycY68BQwClrSWqwRzWoh3ZookQMgcWIxqe9vPvjjtAaltt4q5ASxST7FdiFGmmvgCkxHfjJSUElux-fjOobek6rNN8SeiaNtfPyx9hx7K88lpZbJPEmde_7A6GLkR_JUFtb4GHLU2jxE-7O2qggrXri-hjwsKRr3g2H5Ts3kH5hieqW_CHZkdUoYZ0SYjxAsGWut06xI-DHyQ2soTHS9_E9yTgXuECtp-A0qFOMl8FetcZduvCeQeRAxnClLbaDY5YVkI78uyLsaVMlnO06zYxk7eieT864zHrxu4 (aws-error-code=UnauthorizedOperation, aws-operation-name=CreateFleet, aws-request-id=b60e8bad-3d7d-4206-95e9-7af9f28b1d47, aws-service-name=EC2, aws-status-code=403)"}
karpenter-667c975c47-qf427 controller {"level":"DEBUG","time":"2025-08-29T20:56:02.780Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:265","message":"created launch template","commit":"aceca23-dirty","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"toucannotch-4-2edbxszfct"},"namespace":"","name":"toucannotch-4-2edbxszfct","reconcileID":"04f5cbad-0630-492b-a5d4-0d3205ae4bea","launch-template-name":"karpenter.k8s.aws/1102654762722916350","id":"lt-0abbad7946db2570d"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.