### PR TITLE
feat: add validation refresh annotation

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -150,6 +150,7 @@ var (
 	AnnotationEC2NodeClassHashVersion        = apis.Group + "/ec2nodeclass-hash-version"
 	AnnotationInstanceTagged                 = apis.Group + "/tagged"
 	AnnotationInstanceProfile                = apis.Group + "/instance-profile-name"
+	AnnotationValidationRefresh              = apis.Group + "/validation-refresh"
 
 	NodeClaimTagKey          = coreapis.Group + "/nodeclaim"
 	NameTagKey               = "Name"

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -46,7 +46,7 @@ const (
 	// if it is not updated by a node creation event or refreshed during controller reconciliation
 	DiscoveredCapacityCacheTTL = 60 * 24 * time.Hour
 	// ValidationTTL is time to check authorization errors with validation controller
-	ValidationTTL = 10 * time.Minute
+	ValidationTTL = 30 * time.Minute
 	// RecreationTTL is the duration to suppress instance profile recreation for the same role to avoid duplicates
 	RecreationTTL = 1 * time.Minute
 	// ProtectedProfilesTTL is the duration to keep profiles as protected before nodeclass garbagecollector considers deletion

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -380,6 +380,22 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 			})
 		})
 	})
+	It("should not skip validation when refesh annotation is added", func() {
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(awsEnv.ValidationCache.Items()).To(HaveLen(1))
+		nodeClass.SetAnnotations(map[string]string{v1.AnnotationValidationRefresh: "refresh"})
+		ExpectApplied(ctx, env.Client, nodeClass)
+
+		awsEnv.EC2API.Reset()
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+
+		Expect(nodeClass.Annotations).ToNot(HaveKey(v1.AnnotationValidationRefresh))
+		Expect(awsEnv.EC2API.CreateFleetBehavior.Calls()).To(Equal(1))
+		Expect(awsEnv.EC2API.RunInstancesBehavior.Calls()).To(Equal(1))
+	})
 	It("should clear the validation cache when the nodeclass is deleted", func() {
 		controllerutil.AddFinalizer(nodeClass, v1.TerminationFinalizer)
 		nodeClass.Spec.Tags = map[string]string{}


### PR DESCRIPTION
Fixes #N/A

**Description**
* Increase the node class validation requeue time and cache TTL from 10 min to 30 min
* Add an option to trigger reconciliation of validation (and remove old cache entries) by adding `validation-refresh` annotation on the EC2NodeClass.

**How was this change tested?**
* `make presubmit`
* manual testing

**Manual Testing**
Run Karpenter binary and have validation run with a policy that denies `CreateFleet` (so validation will fail). Remove `CreateFleet` deny from policy and add the annotation onto the node class with the following command:

`kubectl annotate ec2nodeclass default karpenter.k8s.aws/validation-refresh="testing"`

Validation succeeds shortly after that. Important to note the change from invalid to valid occurred in a time period much less than the cache TTL of 30 min.

<img width="998" height="228" alt="Screenshot 2025-08-31 at 6 56 29 PM" src="https://github.com/user-attachments/assets/e106696f-9e36-457a-a1b0-511db6bc1b9b" />

We also check the `validation-refresh` annotation to ensure it was removed from the node class after the validation controller reconciled:

<img width="554" height="54" alt="Screenshot 2025-08-31 at 6 56 42 PM" src="https://github.com/user-attachments/assets/8796ba13-30e0-48a3-80a0-4b5bc0b3d9d0" />



**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.