### PR TITLE
chore: make health check configurations editable from values file

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -49,6 +49,16 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.6.3 \
 | controller.envFrom | list | `[]` |  |
 | controller.extraVolumeMounts | list | `[]` | Additional volumeMounts for the controller container. |
 | controller.healthProbe.port | int | `8081` | The container port to use for http health probe. |
+| controller.healthProbe.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the liveness probe to be considered failed after having succeeded. |
+| controller.healthProbe.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds after the container has started before liveness probes are initiated. |
+| controller.healthProbe.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the liveness probe. |
+| controller.healthProbe.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the liveness probe to be considered successful after having failed. |
+| controller.healthProbe.livenessProbe.timeoutSeconds | int | `30` | Number of seconds after which the liveness probe times out. |
+| controller.healthProbe.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the readiness probe to be considered failed after having succeeded. |
+| controller.healthProbe.readinessProbe.initialDelaySeconds | int | `5` | Number of seconds after the container has started before readiness probes are initiated. |
+| controller.healthProbe.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the readiness probe. |
+| controller.healthProbe.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the readiness probe to be considered successful after having failed. |
+| controller.healthProbe.readinessProbe.timeoutSeconds | int | `30` | Number of seconds after which the readiness probe times out. |
 | controller.image.digest | string | `"sha256:37c761a3a0b485fd34db1390317ef6149141f532c5a699c528b98fb8f9cc722a"` | SHA256 digest of the controller image. |
 | controller.image.repository | string | `"public.ecr.aws/karpenter/controller"` | Repository path to the controller image. |
 | controller.image.tag | string | `"1.6.3"` | Tag of the controller image. |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -192,14 +192,20 @@ spec:
               containerPort: {{ .Values.controller.healthProbe.port }}
               protocol: TCP
           livenessProbe:
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
+            initialDelaySeconds: {{ .Values.controller.healthProbe.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.controller.healthProbe.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.controller.healthProbe.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.controller.healthProbe.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.healthProbe.livenessProbe.failureThreshold }}
             httpGet:
               path: /healthz
               port: http
           readinessProbe:
-            initialDelaySeconds: 5
-            timeoutSeconds: 30
+            initialDelaySeconds: {{ .Values.controller.healthProbe.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.controller.healthProbe.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.controller.healthProbe.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.controller.healthProbe.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.healthProbe.readinessProbe.failureThreshold }}
             httpGet:
               path: /readyz
               port: http

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -163,6 +163,30 @@ controller:
   healthProbe:
     # -- The container port to use for http health probe.
     port: 8081
+    # -- Liveness probe configuration for the controller
+    livenessProbe:
+      # -- Number of seconds after the container has started before liveness probes are initiated.
+      initialDelaySeconds: 30
+      # -- Number of seconds after which the probe times out.
+      timeoutSeconds: 30
+      # -- How often (in seconds) to perform the probe.
+      periodSeconds: 10
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+      successThreshold: 1
+      # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
+      failureThreshold: 3
+    # -- Readiness probe configuration for the controller
+    readinessProbe:
+      # -- Number of seconds after the container has started before readiness probes are initiated.
+      initialDelaySeconds: 5
+      # -- Number of seconds after which the probe times out.
+      timeoutSeconds: 30
+      # -- How often (in seconds) to perform the probe.
+      periodSeconds: 10
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+      successThreshold: 1
+      # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
+      failureThreshold: 3
 # -- Global log level, defaults to 'info'
 logLevel: info
 # -- Log outputPaths - defaults to stdout only


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Helps with this issues #7256 <!-- issue number -->

**Description**
Ran into this issue [#7256](https://github.com/aws/karpenter-provider-aws/issues/7256), when deploying Karpenter in a new cluster, the pods were getting killed before they could start. Had to manually edit the deployment before they could start.


**Changes Made:**
- Configurable settings for liveness and readiness probes added to values.yaml.
- Updated README.md to document the new configuration options

**How was this change tested?**
- Deployed Karpenter with default probe settings and verified pods start successfully
- Tested with custom probe configurations to ensure proper functionality
- Validated that pods no longer get killed during startup phase in new clusters

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.