### PR TITLE
ci: pull public ECR images to private ECR in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,9 @@ jobs:
           role-to-assume: 'arn:aws:iam::${{ vars.RELEASE_ACCOUNT_ID }}:role/${{ vars.RELEASE_ROLE_NAME }}'
           aws-region: ${{ vars.RELEASE_REGION }}
       - run: make release
+        env:
+          RELEASE_ACCOUNT_ID: ${{ vars.RELEASE_ACCOUNT_ID }}
+          CACHED_ECR_NAME: ${{ vars.CACHED_ECR_NAME }}
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: 'arn:aws:iam::${{ vars.READONLY_ACCOUNT_ID }}:role/${{ vars.READONLY_ROLE_NAME }}'

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -7,6 +7,9 @@ RELEASE_REPO_ECR="${RELEASE_REPO_ECR:-public.ecr.aws/${ECR_GALLERY_NAME}/}"
 SNAPSHOT_ECR="021119463062.dkr.ecr.us-east-1.amazonaws.com"
 SNAPSHOT_REPO_ECR="${SNAPSHOT_REPO_ECR:-${SNAPSHOT_ECR}/karpenter/snapshot/}"
 
+CACHED_REPO_ECR="${RELEASE_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com"
+CACHED_REPO_NAME="${CACHED_ECR_NAME}"
+
 CURRENT_MAJOR_VERSION="0"
 
 snapshot() {
@@ -40,7 +43,7 @@ Helm Chart Version ${helm_chart_version}"
   authenticate
   build "${RELEASE_REPO_ECR}" "${version}" "${helm_chart_version}" "${commit_sha}"
 
-  authenticatePrivateRepo
+  authenticateCachedRepo
   pullImages "${version}"
 }
 
@@ -48,8 +51,8 @@ authenticate() {
   aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${RELEASE_REPO_ECR}"
 }
 
-authenticatePrivateRepo() {
-  aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${PRIVATE_REPO_ECR}"
+authenticateCachedRepo() {
+  aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${CACHED_REPO_ECR}"
 }
 
 authenticateSnapshotRepo() {
@@ -145,7 +148,7 @@ pullImages() {
   local repos=("controller" "karpenter" "karpenter-crd")
 
   for repo in "${repos[@]}"; do
-    docker pull "${PRIVATE_REPO_ECR}".dkr.ecr.us-east-1.amazonaws.com/"${PRIVATE_REPO_NAME}"/"${repo}":"${tag}"
+    docker pull "${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/"${repo}":"${tag}"
   done
 }
 

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -145,11 +145,10 @@ buildDate() {
 
 pullImages() {
   local tag="${1}"
-  local repos=("controller" "karpenter" "karpenter-crd")
 
-  for repo in "${repos[@]}"; do
-    docker pull "${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/"${repo}":"${tag}"
-  done
+  docker pull "${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/controller:"${tag}"
+  helm pull oci://"${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/karpenter --version "${tag}"
+  helm pull oci://"${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/karpenter-crd --version "${tag}"
 }
 
 prepareWebsite() {


### PR DESCRIPTION
Fixes #N/A

**Description**
* add additional `pull` commands in the `make release` workflow to pull public ECR images just created by the workflow into a private ECR repo

**How was this change tested?**
* `make presubmit`
* created a separate branch [link](https://github.com/ryan-mist/karpenter-provider-aws/compare/main...ryan-mist:karpenter-provider-aws:mirror-public-ecr-test?expand=1) with similar changes but allows testing with a new PR opening to that branch
  * note: tests only on `authenticateCachedRepo` and `pullImages "${version}"` part of the workflow
  * see here for an example run: https://github.com/ryan-mist/karpenter-provider-aws/actions/runs/17419752109/job/49455656788?pr=52

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.