### PR TITLE
ci: remove image pulls of karpenter & karpenter-crd in release workflow

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -147,8 +147,6 @@ pullImages() {
   local tag="${1}"
 
   docker pull "${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/controller:"${tag}"
-  helm pull oci://"${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/karpenter --version "${tag}"
-  helm pull oci://"${CACHED_REPO_ECR}"/"${CACHED_REPO_NAME}"/karpenter-crd --version "${tag}"
 }
 
 prepareWebsite() {


### PR DESCRIPTION
Fixes #N/A

**Description**
* remove additional pull commands from karpenter-crd and karpenter in the make release workflow (which pulls public ECR images just created by the workflow into a private ECR repo)

**How was this change tested?**
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.