### PR TITLE
bottlerocket: use default ephemeral storage bind command

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/bootstrap.go
@@ -38,6 +38,7 @@ type Options struct {
 	ContainerRuntime    *string
 	CustomUserData      *string
 	InstanceStorePolicy *v1.InstanceStorePolicy
+	AMIVersion          string
 }
 
 func (o Options) kubeletExtraArgs() (args []string) {

--- a/pkg/providers/amifamily/bootstrap/bottlerocket_test.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket_test.go
@@ -1,0 +1,39 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBootstrap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bootstrap")
+}
+
+var _ = Describe("Bottlerocket", func() {
+	Describe("EnableDefaultMountPaths", func() {
+		It("should use the configured flag value", func() {
+			bottlerocket := Bottlerocket{EnableDefaultMountPaths: true}
+			Expect(bottlerocket.EnableDefaultMountPaths).To(BeTrue())
+
+			bottlerocket = Bottlerocket{EnableDefaultMountPaths: false}
+			Expect(bottlerocket.EnableDefaultMountPaths).To(BeFalse())
+		})
+	})
+})

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily/bootstrap"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/ssm"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
@@ -88,7 +89,94 @@ func (b Bottlerocket) UserData(kubeletConfig *v1.KubeletConfiguration, taints []
 			CustomUserData:      customUserData,
 			InstanceStorePolicy: instanceStorePolicy,
 		},
+		EnableDefaultMountPaths: version.SupportsDefaultBind(b.resolveAMIVersion()),
 	}
+}
+
+// resolveAMIVersion extracts AMI version from selector terms
+func (b Bottlerocket) resolveAMIVersion() string {
+	if version := b.getVersionFromAlias(); version != "" {
+		return version
+	}
+	if version := b.getVersionFromName(); version != "" {
+		return version
+	}
+	if version := b.getVersionFromID(); version != "" {
+		return version
+	}
+	if version := b.getVersionFromResolvedAMIs(); version != "" {
+		return version
+	}
+	return ""
+}
+
+func (b Bottlerocket) getVersionFromAlias() string {
+	for _, term := range b.AMISelectorTerms {
+		if term.Alias == "" {
+			continue
+		}
+		parts := strings.Split(term.Alias, "@")
+		if len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	return ""
+}
+
+func (b Bottlerocket) getVersionFromName() string {
+	for _, term := range b.AMISelectorTerms {
+		if term.Name == "" {
+			continue
+		}
+		if version := b.extractVersionFromName(term.Name); version != "" {
+			return version
+		}
+	}
+	return ""
+}
+
+func (b Bottlerocket) getVersionFromID() string {
+	for _, term := range b.AMISelectorTerms {
+		if term.ID == "" {
+			continue
+		}
+		if version := b.findVersionByID(term.ID); version != "" {
+			return version
+		}
+	}
+	return ""
+}
+
+func (b Bottlerocket) findVersionByID(id string) string {
+	for _, ami := range b.AMIs {
+		if ami.ID == id && ami.Name != "" && strings.Contains(ami.Name, "bottlerocket") {
+			return b.extractVersionFromName(ami.Name)
+		}
+	}
+	return ""
+}
+
+func (b Bottlerocket) getVersionFromResolvedAMIs() string {
+	for _, ami := range b.AMIs {
+		if ami.Name == "" || !strings.Contains(ami.Name, "bottlerocket") {
+			continue
+		}
+		if version := b.extractVersionFromName(ami.Name); version != "" {
+			return version
+		}
+	}
+	return ""
+}
+
+func (b Bottlerocket) extractVersionFromName(name string) string {
+	// Bottlerocket pattern: bottlerocket-aws-k8s-1.33-x86_64-v1.46.0-431fe75a
+	parts := strings.SplitSeq(name, "-")
+	for part := range parts {
+		if strings.HasPrefix(part, "v") && strings.Contains(part, ".") {
+			return part
+		}
+	}
+	return ""
 }
 
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family

--- a/pkg/providers/amifamily/bottlerocket_test.go
+++ b/pkg/providers/amifamily/bottlerocket_test.go
@@ -1,0 +1,104 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amifamily
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+)
+
+var _ = Describe("Bottlerocket", func() {
+	Describe("resolveAMIVersion", func() {
+		It("should resolve version from alias", func() {
+			b := Bottlerocket{
+				Options: &Options{
+					AMISelectorTerms: []v1.AMISelectorTerm{
+						{Alias: "bottlerocket@v1.46.0"},
+					},
+				},
+			}
+			result := b.resolveAMIVersion()
+			Expect(result).To(Equal("v1.46.0"))
+		})
+
+		It("should resolve latest from alias", func() {
+			b := Bottlerocket{
+				Options: &Options{
+					AMISelectorTerms: []v1.AMISelectorTerm{
+						{Alias: "bottlerocket@latest"},
+					},
+				},
+			}
+			result := b.resolveAMIVersion()
+			Expect(result).To(Equal("latest"))
+		})
+
+		It("should resolve version from name", func() {
+			b := Bottlerocket{
+				Options: &Options{
+					AMISelectorTerms: []v1.AMISelectorTerm{
+						{Name: "bottlerocket-aws-k8s-1.33-x86_64-v1.46.0-431fe75a"},
+					},
+				},
+			}
+			result := b.resolveAMIVersion()
+			Expect(result).To(Equal("v1.46.0"))
+		})
+
+		It("should resolve version from ID with resolved AMI", func() {
+			b := Bottlerocket{
+				Options: &Options{
+					AMISelectorTerms: []v1.AMISelectorTerm{
+						{ID: "ami-12345"},
+					},
+					AMIs: []v1.AMI{
+						{ID: "ami-12345", Name: "bottlerocket-aws-k8s-1.33-x86_64-v1.47.0-abc123"},
+					},
+				},
+			}
+			result := b.resolveAMIVersion()
+			Expect(result).To(Equal("v1.47.0"))
+		})
+
+		It("should resolve version from resolved AMI fallback", func() {
+			b := Bottlerocket{
+				Options: &Options{
+					AMISelectorTerms: []v1.AMISelectorTerm{
+						{Tags: map[string]string{"Environment": "prod"}},
+					},
+					AMIs: []v1.AMI{
+						{ID: "ami-67890", Name: "bottlerocket-aws-k8s-1.30-arm64-v2.0.1-def456"},
+					},
+				},
+			}
+			result := b.resolveAMIVersion()
+			Expect(result).To(Equal("v2.0.1"))
+		})
+
+		It("should return empty when no version found", func() {
+			b := Bottlerocket{
+				Options: &Options{
+					AMISelectorTerms: []v1.AMISelectorTerm{
+						{Name: "some-other-ami"},
+					},
+				},
+			}
+			result := b.resolveAMIVersion()
+			Expect(result).To(Equal(""))
+		})
+	})
+})

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -60,6 +60,8 @@ type Options struct {
 	InstanceProfile     string
 	CABundle            *string `hash:"ignore"`
 	InstanceStorePolicy *v1.InstanceStorePolicy
+	AMISelectorTerms    []v1.AMISelectorTerm `hash:"ignore"` // For Bottlerocket version resolution
+	AMIs                []v1.AMI             `hash:"ignore"` // Resolved AMIs for version extraction
 	// Level-triggered fields that may change out of sync.
 	SecurityGroups           []v1.SecurityGroup
 	Tags                     map[string]string

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -209,6 +209,8 @@ func (p *DefaultProvider) CreateAMIOptions(ctx context.Context, nodeClass *v1.EC
 		ClusterCIDR:              p.ClusterCIDR.Load(),
 		InstanceProfile:          nodeClass.Status.InstanceProfile,
 		InstanceStorePolicy:      nodeClass.Spec.InstanceStorePolicy,
+		AMISelectorTerms:         nodeClass.Spec.AMISelectorTerms,
+		AMIs:                     nodeClass.Status.AMIs,
 		SecurityGroups:           nodeClass.Status.SecurityGroups,
 		Tags:                     tags,
 		Labels:                   labels,

--- a/pkg/providers/version/version.go
+++ b/pkg/providers/version/version.go
@@ -145,3 +145,34 @@ func (p *DefaultProvider) getK8sVersion() (string, error) {
 	}
 	return fmt.Sprintf("%s.%s", output.Major, strings.TrimSuffix(output.Minor, "+")), err
 }
+
+// SupportsDefaultBind checks if the Bottlerocket AMI version supports default bind (>= 1.46.0)
+// This function is used to determine whether to use the new default bind command or the legacy
+// command with explicit directory paths for ephemeral storage binding.
+func SupportsDefaultBind(amiVersion string) bool {
+	if amiVersion == "" {
+		return false
+	}
+
+	// Handle @latest - assume it's the newest version
+	if amiVersion == "latest" {
+		return true
+	}
+
+	version := strings.TrimLeft(amiVersion, "v")
+	parts := strings.Split(version, ".")
+	if len(parts) < 3 {
+		return false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+
+	return major > 1 || (major == 1 && minor >= 46)
+}

--- a/pkg/providers/version/version_test.go
+++ b/pkg/providers/version/version_test.go
@@ -1,0 +1,44 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
+)
+
+var _ = Describe("SupportsDefaultBind", func() {
+	DescribeTable("should return correct result for version",
+		func(versionStr string, expected bool) {
+			result := version.SupportsDefaultBind(versionStr)
+			Expect(result).To(Equal(expected))
+		},
+		Entry("1.45.0", "1.45.0", false),
+		Entry("1.46.0", "1.46.0", true),
+		Entry("1.47.0", "1.47.0", true),
+		Entry("2.0.0", "2.0.0", true),
+		Entry("v1.45.0", "v1.45.0", false),
+		Entry("v1.46.0", "v1.46.0", true),
+		Entry("1.9.0", "1.9.0", false),
+		Entry("latest", "latest", true),
+		Entry("invalid", "invalid", false),
+		Entry("1", "1", false),
+		Entry("empty", "", false),
+		Entry("1.46", "1.46", false),
+		Entry("abc.def.ghi", "abc.def.ghi", false),
+	)
+})


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #8393 

**Description**

Bottlerocket v1.46.0 released with default behavior for the ephemeral-storage bind command. When no arguments are specified, all allowlisted directories for a detected Bottlerocket variant are bind-mounted. This prevents having to consistently update the list of dirs passed as arguments to this command as more are added.

**How was this change tested?**

```
make run
```

Apply nodeclass:

<details>

```
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: default
spec:
  role: "KarpenterNodeRole-fedora-karpenter-demo" # replace with your cluster name
  amiFamily: Bottlerocket
  amiSelectorTerms:
    - alias: bottlerocket@v1.46.0
  instanceStorePolicy: RAID0
  subnetSelectorTerms:
    - tags:
        karpenter.sh/discovery: "fedora-karpenter-demo" # replace with your cluster name
  securityGroupSelectorTerms:
    - tags:
        karpenter.sh/discovery: "fedora-karpenter-demo" # replace with your cluster name
```
</details>

apply nodepool:

<details>

```
apiVersion: karpenter.sh/v1
kind: NodePool
metadata:
  name: default
spec:
  template:
    spec:
      requirements:
        - key: kubernetes.io/arch
          operator: In
          values: ["amd64"]
        - key: kubernetes.io/os
          operator: In
          values: ["linux"]
        - key: karpenter.sh/capacity-type
          operator: In
          values: ["on-demand"]
        - key: karpenter.k8s.aws/instance-category
          operator: In
          values: ["i"]
        - key: karpenter.k8s.aws/instance-family
          operator: In
          values: ["i7ie"]
        - key: karpenter.k8s.aws/instance-generation
          operator: In
          values: ["7"]
      nodeClassRef:
        group: karpenter.k8s.aws
        kind: EC2NodeClass
        name: default
      expireAfter: 720h # 30 * 24h = 720h
  limits:
    cpu: 1000
  disruption:
    consolidationPolicy: WhenEmptyOrUnderutilized
    consolidateAfter: 1m
```

</details>

Apply deployment:

<details>

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: inflate
spec:
  replicas: 0
  selector:
    matchLabels:
      app: inflate
  template:
    metadata:
      labels:
        app: inflate
    spec:
      terminationGracePeriodSeconds: 0
      securityContext:
        runAsUser: 1000
        runAsGroup: 3000
        fsGroup: 2000
      containers:
      - name: inflate
        image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
        resources:
          requests:
            cpu: 1
        securityContext:
          allowPrivilegeEscalation: false
```

</details>

Observe mounted dirs on provisioned node via `lsblk`:

```
`-nvme0n1p13 259:15   0    1M  0 part
nvme2n1      259:1    0  1.1T  0 disk /var/log/pods
                                      /var/lib/kubelet
                                      /var/lib/containerd
                                      /var/lib/host-containerd
                                      /var/lib/soci-snapshotter
                                      /mnt/.ephemeral
```

repeated above for following `amiSelectorTerms`:

```
  amiSelectorTerms:
    - alias: bottlerocket@v1.45.0
    # - alias: bottlerocket@v1.46.0
    # - alias: bottlerocket@latest
    # - id: ami-045211d4043c5881c # -> bottlerocket-aws-k8s-1.33-x86_64-v1.46.0-431fe75a
    # - id: ami-02fea268d7a3212fd # -> bottlerocket-aws-k8s-1.33-x86_64-v1.45.0-2f4223e5
    # - name: bottlerocket-aws-k8s-1.33-x86_64-v1.46.0-431fe75a
    # - name: bottlerocket-aws-k8s-1.33-x86_64-v1.45.0-2f4223e5
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.