### PR TITLE
feat: Allow users to set spec.IpvPrefixCount to pre-warm prefixes

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -311,8 +311,8 @@ spec:
                   enum:
                     - RAID0
                   type: string
-                ipv4PrefixCount:
-                  description: IPv4PrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+                ipPrefixCount:
+                  description: IpPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
                   format: int32
                   type: integer
                 kubelet:

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -312,8 +312,9 @@ spec:
                     - RAID0
                   type: string
                 ipPrefixCount:
-                  description: IpPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+                  description: IPPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
                   format: int32
+                  minimum: 0
                   type: integer
                 kubelet:
                   description: |-

--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -311,6 +311,10 @@ spec:
                   enum:
                     - RAID0
                   type: string
+                ipv4PrefixCount:
+                  description: IPv4PrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+                  format: int32
+                  type: integer
                 kubelet:
                   description: |-
                     Kubelet defines args to be used when configuring kubelet on provisioned nodes.

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -308,6 +308,10 @@ spec:
                   enum:
                     - RAID0
                   type: string
+                ipv4PrefixCount:
+                  description: IPv4PrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+                  format: int32
+                  type: integer
                 kubelet:
                   description: |-
                     Kubelet defines args to be used when configuring kubelet on provisioned nodes.

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -308,8 +308,8 @@ spec:
                   enum:
                     - RAID0
                   type: string
-                ipv4PrefixCount:
-                  description: IPv4PrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+                ipPrefixCount:
+                  description: IpPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
                   format: int32
                   type: integer
                 kubelet:

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -309,8 +309,9 @@ spec:
                     - RAID0
                   type: string
                 ipPrefixCount:
-                  description: IpPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+                  description: IPPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
                   format: int32
+                  minimum: 0
                   type: integer
                 kubelet:
                   description: |-

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -55,6 +55,9 @@ type EC2NodeClassSpec struct {
 	// AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
 	// +optional
 	AssociatePublicIPAddress *bool `json:"associatePublicIPAddress,omitempty"`
+	// IPv4PrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+	// +optional
+	Ipv4PrefixCount *int32 `json:"ipv4PrefixCount,omitempty" hash:"ignore"`
 	// AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
 	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameter']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))"
 	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))"

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -55,9 +55,9 @@ type EC2NodeClassSpec struct {
 	// AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
 	// +optional
 	AssociatePublicIPAddress *bool `json:"associatePublicIPAddress,omitempty"`
-	// IPv4PrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+	// IpPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
 	// +optional
-	Ipv4PrefixCount *int32 `json:"ipv4PrefixCount,omitempty" hash:"ignore"`
+	IpPrefixCount *int32 `json:"ipPrefixCount,omitempty" hash:"ignore"`
 	// AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
 	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameter']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))"
 	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))"

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -55,9 +55,10 @@ type EC2NodeClassSpec struct {
 	// AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
 	// +optional
 	AssociatePublicIPAddress *bool `json:"associatePublicIPAddress,omitempty"`
-	// IpPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+	// IPPrefixCount sets the number of IPv4 prefixes to be automatically assigned to the network interface.
+	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	IpPrefixCount *int32 `json:"ipPrefixCount,omitempty" hash:"ignore"`
+	IPPrefixCount *int32 `json:"ipPrefixCount,omitempty" hash:"ignore"`
 	// AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
 	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameter']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))"
 	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))"

--- a/pkg/apis/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1/zz_generated.deepcopy.go
@@ -298,8 +298,8 @@ func (in *EC2NodeClassSpec) DeepCopyInto(out *EC2NodeClassSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.IpPrefixCount != nil {
-		in, out := &in.IpPrefixCount, &out.IpPrefixCount
+	if in.IPPrefixCount != nil {
+		in, out := &in.IPPrefixCount, &out.IPPrefixCount
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/apis/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1/zz_generated.deepcopy.go
@@ -298,8 +298,8 @@ func (in *EC2NodeClassSpec) DeepCopyInto(out *EC2NodeClassSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.Ipv4PrefixCount != nil {
-		in, out := &in.Ipv4PrefixCount, &out.Ipv4PrefixCount
+	if in.IpPrefixCount != nil {
+		in, out := &in.IpPrefixCount, &out.IpPrefixCount
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/apis/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1/zz_generated.deepcopy.go
@@ -298,6 +298,11 @@ func (in *EC2NodeClassSpec) DeepCopyInto(out *EC2NodeClassSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Ipv4PrefixCount != nil {
+		in, out := &in.Ipv4PrefixCount, &out.Ipv4PrefixCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.AMISelectorTerms != nil {
 		in, out := &in.AMISelectorTerms, &out.AMISelectorTerms
 		*out = make([]AMISelectorTerm, len(*in))

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -66,6 +66,7 @@ type Options struct {
 	Labels                   map[string]string `hash:"ignore"`
 	KubeDNSIP                net.IP
 	AssociatePublicIPAddress *bool
+	Ipv4PrefixCount          *int32
 	NodeClassName            string
 }
 

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -66,7 +66,7 @@ type Options struct {
 	Labels                   map[string]string `hash:"ignore"`
 	KubeDNSIP                net.IP
 	AssociatePublicIPAddress *bool
-	IpPrefixCount            *int32
+	IPPrefixCount            *int32
 	NodeClassName            string
 }
 

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -66,7 +66,7 @@ type Options struct {
 	Labels                   map[string]string `hash:"ignore"`
 	KubeDNSIP                net.IP
 	AssociatePublicIPAddress *bool
-	Ipv4PrefixCount          *int32
+	IpPrefixCount            *int32
 	NodeClassName            string
 }
 

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -274,9 +274,10 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 				//nolint: gosec
 				NetworkCardIndex: lo.ToPtr(int32(i)),
 				// Some networking magic to ensure that one network card has higher priority than all the others (important if an instance needs a public IP w/o adding an EIP to every network card)
-				DeviceIndex:   lo.ToPtr(lo.Ternary[int32](i == 0, 0, 1)),
-				InterfaceType: lo.ToPtr(string(ec2types.NetworkInterfaceTypeEfa)),
-				Groups:        lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID }),
+				DeviceIndex:     lo.ToPtr(lo.Ternary[int32](i == 0, 0, 1)),
+				InterfaceType:   lo.ToPtr(string(ec2types.NetworkInterfaceTypeEfa)),
+				Ipv4PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, aws.Int32(1)),
+				Groups:          lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID }),
 				// Instances launched with multiple pre-configured network interfaces cannot set AssociatePublicIPAddress to true. This is an EC2 limitation. However, this does not apply for instances
 				// with a single EFA network interface, and we should support those use cases. Launch failures with multiple enis should be considered user misconfiguration.
 				AssociatePublicIpAddress: options.AssociatePublicIPAddress,
@@ -290,6 +291,7 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 		{
 			AssociatePublicIpAddress: options.AssociatePublicIPAddress,
 			DeviceIndex:              aws.Int32(0),
+			Ipv4PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, aws.Int32(1)),
 			Groups: lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string {
 				return s.ID
 			}),

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -215,7 +215,7 @@ func (p *DefaultProvider) CreateAMIOptions(ctx context.Context, nodeClass *v1.EC
 		CABundle:                 p.CABundle,
 		KubeDNSIP:                p.KubeDNSIP,
 		AssociatePublicIPAddress: nodeClass.Spec.AssociatePublicIPAddress,
-		Ipv4PrefixCount:          nodeClass.Spec.Ipv4PrefixCount,
+		IpPrefixCount:            nodeClass.Spec.IpPrefixCount,
 		NodeClassName:            nodeClass.Name,
 	}, nil
 }
@@ -277,7 +277,8 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 				// Some networking magic to ensure that one network card has higher priority than all the others (important if an instance needs a public IP w/o adding an EIP to every network card)
 				DeviceIndex:     lo.ToPtr(lo.Ternary[int32](i == 0, 0, 1)),
 				InterfaceType:   lo.ToPtr(string(ec2types.NetworkInterfaceTypeEfa)),
-				Ipv4PrefixCount: options.Ipv4PrefixCount,
+				Ipv4PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, options.IpPrefixCount),
+				Ipv6PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, options.IpPrefixCount, nil),
 				Groups:          lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID }),
 				// Instances launched with multiple pre-configured network interfaces cannot set AssociatePublicIPAddress to true. This is an EC2 limitation. However, this does not apply for instances
 				// with a single EFA network interface, and we should support those use cases. Launch failures with multiple enis should be considered user misconfiguration.
@@ -292,7 +293,8 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 		{
 			AssociatePublicIpAddress: options.AssociatePublicIPAddress,
 			DeviceIndex:              aws.Int32(0),
-			Ipv4PrefixCount:          options.Ipv4PrefixCount,
+			Ipv4PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, options.IpPrefixCount),
+			Ipv6PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, options.IpPrefixCount, nil),
 			Groups: lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string {
 				return s.ID
 			}),

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -215,7 +215,7 @@ func (p *DefaultProvider) CreateAMIOptions(ctx context.Context, nodeClass *v1.EC
 		CABundle:                 p.CABundle,
 		KubeDNSIP:                p.KubeDNSIP,
 		AssociatePublicIPAddress: nodeClass.Spec.AssociatePublicIPAddress,
-		IpPrefixCount:            nodeClass.Spec.IpPrefixCount,
+		IPPrefixCount:            nodeClass.Spec.IPPrefixCount,
 		NodeClassName:            nodeClass.Name,
 	}, nil
 }
@@ -277,8 +277,8 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 				// Some networking magic to ensure that one network card has higher priority than all the others (important if an instance needs a public IP w/o adding an EIP to every network card)
 				DeviceIndex:     lo.ToPtr(lo.Ternary[int32](i == 0, 0, 1)),
 				InterfaceType:   lo.ToPtr(string(ec2types.NetworkInterfaceTypeEfa)),
-				Ipv4PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, options.IpPrefixCount),
-				Ipv6PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, options.IpPrefixCount, nil),
+				Ipv4PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, options.IPPrefixCount),
+				Ipv6PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, options.IPPrefixCount, nil),
 				Groups:          lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID }),
 				// Instances launched with multiple pre-configured network interfaces cannot set AssociatePublicIPAddress to true. This is an EC2 limitation. However, this does not apply for instances
 				// with a single EFA network interface, and we should support those use cases. Launch failures with multiple enis should be considered user misconfiguration.
@@ -293,8 +293,8 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 		{
 			AssociatePublicIpAddress: options.AssociatePublicIPAddress,
 			DeviceIndex:              aws.Int32(0),
-			Ipv4PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, options.IpPrefixCount),
-			Ipv6PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, options.IpPrefixCount, nil),
+			Ipv4PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, options.IPPrefixCount),
+			Ipv6PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, options.IPPrefixCount, nil),
 			Groups: lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string {
 				return s.ID
 			}),

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -215,6 +215,7 @@ func (p *DefaultProvider) CreateAMIOptions(ctx context.Context, nodeClass *v1.EC
 		CABundle:                 p.CABundle,
 		KubeDNSIP:                p.KubeDNSIP,
 		AssociatePublicIPAddress: nodeClass.Spec.AssociatePublicIPAddress,
+		Ipv4PrefixCount:          nodeClass.Spec.Ipv4PrefixCount,
 		NodeClassName:            nodeClass.Name,
 	}, nil
 }
@@ -276,7 +277,7 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 				// Some networking magic to ensure that one network card has higher priority than all the others (important if an instance needs a public IP w/o adding an EIP to every network card)
 				DeviceIndex:     lo.ToPtr(lo.Ternary[int32](i == 0, 0, 1)),
 				InterfaceType:   lo.ToPtr(string(ec2types.NetworkInterfaceTypeEfa)),
-				Ipv4PrefixCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, aws.Int32(1)),
+				Ipv4PrefixCount: options.Ipv4PrefixCount,
 				Groups:          lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID }),
 				// Instances launched with multiple pre-configured network interfaces cannot set AssociatePublicIPAddress to true. This is an EC2 limitation. However, this does not apply for instances
 				// with a single EFA network interface, and we should support those use cases. Launch failures with multiple enis should be considered user misconfiguration.
@@ -291,7 +292,7 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 		{
 			AssociatePublicIpAddress: options.AssociatePublicIPAddress,
 			DeviceIndex:              aws.Int32(0),
-			Ipv4PrefixCount:          lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, nil, aws.Int32(1)),
+			Ipv4PrefixCount:          options.Ipv4PrefixCount,
 			Groups: lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string {
 				return s.ID
 			}),

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2288,11 +2288,12 @@ eviction-max-pod-grace-period = 10
 				Entry("AssociatePublicIPAddress is false (EFA)", false, false, true),
 			)
 		})
-		Context("IPv4 Prefix Delegation", func() {
+		Context("IP Prefix Delegation", func() {
 			DescribeTable(
 				"should set 'IPv4PrefixCount' based on EC2NodeClass",
 				func(setValue int) {
-					nodeClass.Spec.IpPrefixCount = lo.ToPtr(int32(setValue))
+					nodeClass.Spec.IPPrefixCount = lo.ToPtr(int32(setValue))
+					awsEnv.LaunchTemplateProvider.ClusterIPFamily = corev1.IPv4Protocol
 					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 					pod := coretest.UnschedulablePod()
 					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
@@ -2304,6 +2305,23 @@ eviction-max-pod-grace-period = 10
 				Entry("IPv4PrefixCount is 1", 1),
 				Entry("IPv4PrefixCount is 10", 10),
 				Entry("IPv4PrefixCount is 100", 100),
+			)
+			DescribeTable(
+				"should set 'IPv6PrefixCount' based on EC2NodeClass",
+				func(setValue int) {
+					nodeClass.Spec.IPPrefixCount = lo.ToPtr(int32(setValue))
+					awsEnv.LaunchTemplateProvider.ClusterIPFamily = corev1.IPv6Protocol
+					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+					pod := coretest.UnschedulablePod()
+					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+					ExpectScheduled(ctx, env.Client, pod)
+					input := awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Pop()
+					Expect(*input.LaunchTemplateData.NetworkInterfaces[0].Ipv6PrefixCount).To(Equal(int32(setValue)))
+				},
+				Entry("IPv6PrefixCount is 0", 0),
+				Entry("IPv6PrefixCount is 1", 1),
+				Entry("IPv6PrefixCount is 10", 10),
+				Entry("IPv6PrefixCount is 100", 100),
 			)
 		})
 		Context("Windows Custom UserData", func() {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2292,7 +2292,7 @@ eviction-max-pod-grace-period = 10
 			DescribeTable(
 				"should set 'IPv4PrefixCount' based on EC2NodeClass",
 				func(setValue int) {
-					nodeClass.Spec.Ipv4PrefixCount = lo.ToPtr(int32(setValue))
+					nodeClass.Spec.IpPrefixCount = lo.ToPtr(int32(setValue))
 					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 					pod := coretest.UnschedulablePod()
 					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2288,6 +2288,24 @@ eviction-max-pod-grace-period = 10
 				Entry("AssociatePublicIPAddress is false (EFA)", false, false, true),
 			)
 		})
+		Context("IPv4 Prefix Delegation", func() {
+			DescribeTable(
+				"should set 'IPv4PrefixCount' based on EC2NodeClass",
+				func(setValue int) {
+					nodeClass.Spec.Ipv4PrefixCount = lo.ToPtr(int32(setValue))
+					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+					pod := coretest.UnschedulablePod()
+					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+					ExpectScheduled(ctx, env.Client, pod)
+					input := awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Pop()
+					Expect(*input.LaunchTemplateData.NetworkInterfaces[0].Ipv4PrefixCount).To(Equal(int32(setValue)))
+				},
+				Entry("IPv4PrefixCount is 0", 0),
+				Entry("IPv4PrefixCount is 1", 1),
+				Entry("IPv4PrefixCount is 10", 10),
+				Entry("IPv4PrefixCount is 100", 100),
+			)
+		})
 		Context("Windows Custom UserData", func() {
 			BeforeEach(func() {
 				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelOSStable, Operator: corev1.NodeSelectorOpIn, Values: []string{string(corev1.Windows)}}}}

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -1528,9 +1528,9 @@ If a `NodeClaim` requests `vpc.amazonaws.com/efa` resources, `spec.associatePubl
 requires that the field is only set to true when configuring an instance with a single ENI at launch. When using this field, it is advised that users segregate their EFA workload to use a separate `NodePool` / `EC2NodeClass` pair.
 {{% /alert %}}
 
-## spec.ipv4PrefixCount
+## spec.ipPrefixCount
 
-This value is a integer field that controls how many ipv4 prefixes will be assigned to `NodeClaim`. See the [EC2 Launch Template Network Interface Spec](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ec2-launchtemplate-networkinterface.html) for more information
+This value is a integer field that controls how many ip prefixes will be assigned to `NodeClaim`. See the [EC2 Launch Template Network Interface Spec](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ec2-launchtemplate-networkinterface.html) for more information. Sets ipv4PrefixCount if you are using an IPv4 Cluster, or ipv6PrefixCount if you are using IPv6.
 
 ## status.subnets
 [`status.subnets`]({{< ref "#statussubnets" >}}) contains the resolved `id` and `zone` of the subnets that were selected by the [`spec.subnetSelectorTerms`]({{< ref "#specsubnetselectorterms" >}}) for the node class. The subnets will be sorted by the available IP address count in decreasing order.

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -1528,6 +1528,10 @@ If a `NodeClaim` requests `vpc.amazonaws.com/efa` resources, `spec.associatePubl
 requires that the field is only set to true when configuring an instance with a single ENI at launch. When using this field, it is advised that users segregate their EFA workload to use a separate `NodePool` / `EC2NodeClass` pair.
 {{% /alert %}}
 
+## spec.ipv4PrefixCount
+
+This value is a integer field that controls how many ipv4 prefixes will be assigned to `NodeClaim`. See the [EC2 Launch Template Network Interface Spec](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ec2-launchtemplate-networkinterface.html) for more information
+
 ## status.subnets
 [`status.subnets`]({{< ref "#statussubnets" >}}) contains the resolved `id` and `zone` of the subnets that were selected by the [`spec.subnetSelectorTerms`]({{< ref "#specsubnetselectorterms" >}}) for the node class. The subnets will be sorted by the available IP address count in decreasing order.
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change automatically updates the IPv4 prefix count to 1 for ipv4 clusters. This streamlines instance launches.

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.