### PR TITLE
allow matching open capacity reservations when not requesting reserve…

### DIFF
--- a/pkg/providers/launchtemplate/types.go
+++ b/pkg/providers/launchtemplate/types.go
@@ -148,7 +148,7 @@ func (b *CreateLaunchTemplateInputBuilder) Build(ctx context.Context) *ec2.Creat
 			CapacityReservationPreference: lo.Ternary(
 				b.options.CapacityType == karpv1.CapacityTypeReserved,
 				ec2types.CapacityReservationPreferenceCapacityReservationsOnly,
-				ec2types.CapacityReservationPreferenceNone,
+				ec2types.CapacityReservationPreferenceOpen,
 			),
 			CapacityReservationTarget: lo.Ternary(
 				b.options.CapacityType == karpv1.CapacityTypeReserved,


### PR DESCRIPTION
…d capacity

Fixes https://github.com/aws/karpenter-provider-aws/issues/8176

**Description**

normally when turning on the capacity reservation feature suddenly all open reservations can no longer match karpenter nodes
this change restores that behavior, so everything keeps working and selected nodepools can use targeted capacity reservations if they want

**How was this change tested?**

bring up instance and see if it matches an open reservation that it did not target via capacityReservationSelectorTerms

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [X] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.