### PR TITLE
allow opting in to open capacity reservation matching

### DIFF
--- a/pkg/providers/launchtemplate/types.go
+++ b/pkg/providers/launchtemplate/types.go
@@ -148,7 +148,11 @@ func (b *CreateLaunchTemplateInputBuilder) Build(ctx context.Context) *ec2.Creat
 			CapacityReservationPreference: lo.Ternary(
 				b.options.CapacityType == karpv1.CapacityTypeReserved,
 				ec2types.CapacityReservationPreferenceCapacityReservationsOnly,
-				ec2types.CapacityReservationPreferenceNone,
+				lo.Ternary(
+					b.options.Labels["karpenter.sh/allow-open-matching"] == "true",
+					ec2types.CapacityReservationPreferenceOpen,
+					ec2types.CapacityReservationPreferenceNone,
+				),
 			),
 			CapacityReservationTarget: lo.Ternary(
 				b.options.CapacityType == karpv1.CapacityTypeReserved,


### PR DESCRIPTION
Fixes https://github.com/aws/karpenter-provider-aws/issues/8176

**Description**

normally when turning on the capacity reservation feature suddenly all open reservations can no longer match karpenter nodes
this change allows restoring that behavior, so everything keeps working and selected nodepools can use targeted capacity reservations if they want

**How was this change tested?**

bring up instance with label set and see if it matches an open reservation that it did not target via capacityReservationSelectorTerms

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.