### PR TITLE
fix(chart): conditionally add CPU_REQUESTS env var

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -113,12 +113,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if and .Values.controller.resources.requests .Values.controller.resources.requests.cpu }}
             - name: CPU_REQUESTS
               valueFrom:
                 resourceFieldRef:
                   containerName: {{ include "karpenter.controller.containerName" . }}
                   divisor: 1m
                   resource: requests.cpu
+          {{- end }}
             - name: MEMORY_LIMIT
               valueFrom:
                 resourceFieldRef:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #8495 <!-- issue number -->

**Description**
Adds conditional logic to the helm chart to only specify the `CPU_REQUESTS` env var if the user has set cpu resource requests on their helm chart to a non-zero value. `CPU_REQUESTS` is used as a proxy to scale concurrency throughout the codebase - if unspecified we'll default to 1000m.

Alternatively, we could specify defaults for `resources.requests.cpu`, but helm best practices are to not default these values.  

**How was this change tested?**
Manual testing

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.