### PR TITLE
fix: capacitycache UT failing

### DIFF
--- a/pkg/controllers/providers/instancetype/capacity/suite_test.go
+++ b/pkg/controllers/providers/instancetype/capacity/suite_test.go
@@ -158,6 +158,7 @@ var _ = Describe("CapacityCache", func() {
 			Capacity: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dMi", 3840)),
 			},
+			ProviderID: fake.ProviderID(fake.InstanceID()),
 		})
 		ExpectApplied(ctx, env.Client, node)
 
@@ -174,8 +175,9 @@ var _ = Describe("CapacityCache", func() {
 				Requirements: make([]karpv1.NodeSelectorRequirementWithMinValues, 0),
 			},
 			Status: karpv1.NodeClaimStatus{
-				NodeName: node.Name,
-				ImageID:  nodeClass.Status.AMIs[0].ID,
+				NodeName:   node.Name,
+				ImageID:    nodeClass.Status.AMIs[0].ID,
+				ProviderID: node.Spec.ProviderID,
 			},
 		}
 		ExpectApplied(ctx, env.Client, nodeClaim)


### PR DESCRIPTION
UTs are failing after merging - https://github.com/kubernetes-sigs/karpenter/pull/2507

```
[FAILED] Expected capacity to match discovered node capacity
  Expected
      <int64>: 7945060352
  to equal
      <int64>: 4026531840
  In [It] at: /Users/rsumukha/workspace/karpenter/karpenter-provider-aws/pkg/controllers/providers/instancetype/capacity/suite_test.go:192
```

This fixes the UT. 

**Description**

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.