### PR TITLE
fix: ensure filtered offering is available for capacity blocks

### DIFF
--- a/pkg/providers/instance/filter/filter.go
+++ b/pkg/providers/instance/filter/filter.go
@@ -170,6 +170,7 @@ type capacityBlockFilter struct {
 	requirements scheduling.Requirements
 }
 
+//nolint:gocyclo
 func (f capacityBlockFilter) FilterReject(instanceTypes []*cloudprovider.InstanceType) ([]*cloudprovider.InstanceType, []*cloudprovider.InstanceType) {
 	if !f.shouldFilter(instanceTypes) {
 		return instanceTypes, nil
@@ -179,6 +180,9 @@ func (f capacityBlockFilter) FilterReject(instanceTypes []*cloudprovider.Instanc
 		var selectedOffering *cloudprovider.Offering
 		for _, o := range it.Offerings {
 			if o.CapacityType() != karpv1.CapacityTypeReserved {
+				continue
+			}
+			if !o.Available || !f.requirements.IsCompatible(o.Requirements, scheduling.AllowUndefinedWellKnownLabels) {
 				continue
 			}
 			if o.Requirements.Get(v1.LabelCapacityReservationType).Any() != string(v1.CapacityReservationTypeCapacityBlock) {


### PR DESCRIPTION
Cherry pick of #8508

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Cherry picks #8508

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.