### PR TITLE
docs: Remove `OR` comment in the Node Overlay docs

### DIFF
--- a/website/content/en/preview/concepts/nodeoverlays.md
+++ b/website/content/en/preview/concepts/nodeoverlays.md
@@ -32,11 +32,9 @@ spec:
     - key: node.kubernetes.io/instance-type
       operator: In
       values: ["m5.large", "m5.xlarge"]
-    # or 
     - key: karpenter.sh/capacity-type  
       operator: In
       values: ["spot"]
-    # or 
     - key: karpenter.k8s.aws/instance-cpu 
       operator: Gt
       values: ["32"]

--- a/website/content/en/v1.7/concepts/nodeoverlays.md
+++ b/website/content/en/v1.7/concepts/nodeoverlays.md
@@ -32,11 +32,9 @@ spec:
     - key: node.kubernetes.io/instance-type
       operator: In
       values: ["m5.large", "m5.xlarge"]
-    # or 
     - key: karpenter.sh/capacity-type  
       operator: In
       values: ["spot"]
-    # or 
     - key: karpenter.k8s.aws/instance-cpu 
       operator: Gt
       values: ["32"]


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- There looks to be confusion over the semantic meaning of the `or` comment in the requirements for Node Overlay. 
- Removing them for now the show the illustrate the `and` semantic meaning for Node Overlay requirements  

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.