### PR TITLE
feat: add support for InstanceMatchCriteria in CapacityReservationSelectorTerms

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -265,6 +265,12 @@ spec:
                         description: ID is the capacity reservation id in EC2
                         pattern: ^cr-[0-9a-z]+$
                         type: string
+                      instanceMatchCriteria:
+                        description: InstanceMatchCriteria specifies how instances are matched to capacity reservations.
+                        enum:
+                          - open
+                          - targeted
+                        type: string
                       ownerID:
                         description: Owner is the owner id for the ami.
                         pattern: ^[0-9]{12}$
@@ -284,10 +290,10 @@ spec:
                   maxItems: 30
                   type: array
                   x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id']
-                      rule: self.all(x, has(x.tags) || has(x.id))
-                    - message: '''id'' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term'
-                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))'
+                    - message: expected at least one, got none, ['tags', 'id', 'instanceMatchCriteria']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.instanceMatchCriteria))
+                    - message: '''id'' is mutually exclusive, cannot be set along with other fields in a capacity reservation selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID) || has(x.instanceMatchCriteria)))'
                 context:
                   description: |-
                     Context is a Reserved field in EC2 APIs

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -262,6 +262,12 @@ spec:
                         description: ID is the capacity reservation id in EC2
                         pattern: ^cr-[0-9a-z]+$
                         type: string
+                      instanceMatchCriteria:
+                        description: InstanceMatchCriteria specifies how instances are matched to capacity reservations.
+                        enum:
+                          - open
+                          - targeted
+                        type: string
                       ownerID:
                         description: Owner is the owner id for the ami.
                         pattern: ^[0-9]{12}$
@@ -281,10 +287,10 @@ spec:
                   maxItems: 30
                   type: array
                   x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id']
-                      rule: self.all(x, has(x.tags) || has(x.id))
-                    - message: '''id'' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term'
-                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))'
+                    - message: expected at least one, got none, ['tags', 'id', 'instanceMatchCriteria']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.instanceMatchCriteria))
+                    - message: '''id'' is mutually exclusive, cannot be set along with other fields in a capacity reservation selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID) || has(x.instanceMatchCriteria)))'
                 context:
                   description: |-
                     Context is a Reserved field in EC2 APIs

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -47,8 +47,8 @@ type EC2NodeClassSpec struct {
 	SecurityGroupSelectorTerms []SecurityGroupSelectorTerm `json:"securityGroupSelectorTerms" hash:"ignore"`
 	// CapacityReservationSelectorTerms is a list of capacity reservation selector terms. Each term is ORed together to
 	// determine the set of eligible capacity reservations.
-	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id']",rule="self.all(x, has(x.tags) || has(x.id))"
-	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term",rule="!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))"
+	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'instanceMatchCriteria']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.instanceMatchCriteria))"
+	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set along with other fields in a capacity reservation selector term",rule="!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID) || has(x.instanceMatchCriteria)))"
 	// +kubebuilder:validation:MaxItems:=30
 	// +optional
 	CapacityReservationSelectorTerms []CapacityReservationSelectorTerm `json:"capacityReservationSelectorTerms" hash:"ignore"`
@@ -193,6 +193,10 @@ type CapacityReservationSelectorTerm struct {
 	// +kubebuilder:validation:Pattern:="^[0-9]{12}$"
 	// +optional
 	OwnerID string `json:"ownerID,omitempty"`
+	// InstanceMatchCriteria specifies how instances are matched to capacity reservations.
+	// +kubebuilder:validation:Enum:={open,targeted}
+	// +optional
+	InstanceMatchCriteria string `json:"instanceMatchCriteria,omitempty"`
 }
 
 // AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.

--- a/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
@@ -548,6 +548,50 @@ var _ = Describe("CEL/Validation", func() {
 			}}
 			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
 		})
+		It("should succeed with a valid instanceMatchCriteria 'open'", func() {
+			nc.Spec.CapacityReservationSelectorTerms = []v1.CapacityReservationSelectorTerm{{
+				InstanceMatchCriteria: "open",
+			}}
+			Expect(env.Client.Create(ctx, nc)).To(Succeed())
+		})
+		It("should succeed with a valid instanceMatchCriteria 'targeted'", func() {
+			nc.Spec.CapacityReservationSelectorTerms = []v1.CapacityReservationSelectorTerm{{
+				InstanceMatchCriteria: "targeted",
+			}}
+			Expect(env.Client.Create(ctx, nc)).To(Succeed())
+		})
+		It("should succeed with instanceMatchCriteria combined with tags", func() {
+			nc.Spec.CapacityReservationSelectorTerms = []v1.CapacityReservationSelectorTerm{{
+				InstanceMatchCriteria: "open",
+				Tags: map[string]string{
+					"test": "testvalue",
+				},
+			}}
+			Expect(env.Client.Create(ctx, nc)).To(Succeed())
+		})
+		It("should succeed with instanceMatchCriteria combined with ownerID and tags", func() {
+			nc.Spec.CapacityReservationSelectorTerms = []v1.CapacityReservationSelectorTerm{{
+				InstanceMatchCriteria: "targeted",
+				OwnerID:               "012345678901",
+				Tags: map[string]string{
+					"test": "testvalue",
+				},
+			}}
+			Expect(env.Client.Create(ctx, nc)).To(Succeed())
+		})
+		It("should fail with invalid instanceMatchCriteria value", func() {
+			nc.Spec.CapacityReservationSelectorTerms = []v1.CapacityReservationSelectorTerm{{
+				InstanceMatchCriteria: "invalid",
+			}}
+			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
+		})
+		It("should fail when specifying id with instanceMatchCriteria", func() {
+			nc.Spec.CapacityReservationSelectorTerms = []v1.CapacityReservationSelectorTerm{{
+				ID:                    "cr-12345749",
+				InstanceMatchCriteria: "open",
+			}}
+			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
+		})
 	})
 	Context("AMISelectorTerms", func() {
 		It("should succeed with a valid ami selector on alias", func() {

--- a/pkg/controllers/nodeclass/capacityreservation_test.go
+++ b/pkg/controllers/nodeclass/capacityreservation_test.go
@@ -99,6 +99,16 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 					State:                  ec2types.CapacityReservationStateActive,
 					ReservationType:        ec2types.CapacityReservationTypeDefault,
 				},
+				{
+					AvailabilityZone:       lo.ToPtr("test-zone-1a"),
+					InstanceType:           lo.ToPtr("m5.large"),
+					OwnerId:                lo.ToPtr(selfOwnerID),
+					InstanceMatchCriteria:  ec2types.InstanceMatchCriteriaOpen,
+					CapacityReservationId:  lo.ToPtr("cr-m5.large-1a-3"),
+					AvailableInstanceCount: lo.ToPtr[int32](5),
+					State:                  ec2types.CapacityReservationStateActive,
+					ReservationType:        ec2types.CapacityReservationTypeDefault,
+				},
 			},
 		})
 	})
@@ -149,6 +159,66 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 		Expect(lo.Map(nodeClass.Status.CapacityReservations, func(cr v1.CapacityReservation, _ int) string {
 			return cr.ID
 		})).To(ContainElements("cr-m5.large-1a-2"))
+	})
+	It("should resolve capacity reservations by instance match criteria 'open'", func() {
+		nodeClass.Spec.CapacityReservationSelectorTerms = append(nodeClass.Spec.CapacityReservationSelectorTerms, v1.CapacityReservationSelectorTerm{
+			InstanceMatchCriteria: "open",
+		})
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(1))
+		Expect(nodeClass.Status.CapacityReservations[0].ID).To(Equal("cr-m5.large-1a-3"))
+		Expect(nodeClass.Status.CapacityReservations[0].InstanceMatchCriteria).To(Equal("open"))
+	})
+	It("should resolve capacity reservations by instance match criteria 'targeted'", func() {
+		nodeClass.Spec.CapacityReservationSelectorTerms = append(nodeClass.Spec.CapacityReservationSelectorTerms, v1.CapacityReservationSelectorTerm{
+			InstanceMatchCriteria: "targeted",
+		})
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(5))
+		Expect(lo.Map(nodeClass.Status.CapacityReservations, func(cr v1.CapacityReservation, _ int) string {
+			return cr.ID
+		})).To(ContainElements("cr-m5.large-1a-1", "cr-m5.large-1a-2", "cr-p5.48xlarge-1a", "cr-m5.large-1b-1", "cr-m5.large-1b-2"))
+		for _, cr := range nodeClass.Status.CapacityReservations {
+			Expect(cr.InstanceMatchCriteria).To(Equal("targeted"))
+		}
+	})
+	It("should resolve capacity reservations by instance match criteria with tags", func() {
+		nodeClass.Spec.CapacityReservationSelectorTerms = append(nodeClass.Spec.CapacityReservationSelectorTerms, v1.CapacityReservationSelectorTerm{
+			InstanceMatchCriteria: "targeted",
+			Tags:                  discoveryTags,
+		})
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(2))
+		Expect(lo.Map(nodeClass.Status.CapacityReservations, func(cr v1.CapacityReservation, _ int) string {
+			return cr.ID
+		})).To(ContainElements("cr-m5.large-1a-2", "cr-m5.large-1b-2"))
+		for _, cr := range nodeClass.Status.CapacityReservations {
+			Expect(cr.InstanceMatchCriteria).To(Equal("targeted"))
+		}
+	})
+	It("should resolve capacity reservations by instance match criteria with tags and owner", func() {
+		nodeClass.Spec.CapacityReservationSelectorTerms = append(nodeClass.Spec.CapacityReservationSelectorTerms, v1.CapacityReservationSelectorTerm{
+			InstanceMatchCriteria: "targeted",
+			Tags:                  discoveryTags,
+			OwnerID:               selfOwnerID,
+		})
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(1))
+		Expect(nodeClass.Status.CapacityReservations[0].ID).To(Equal("cr-m5.large-1a-2"))
+		Expect(nodeClass.Status.CapacityReservations[0].InstanceMatchCriteria).To(Equal("targeted"))
+		Expect(nodeClass.Status.CapacityReservations[0].OwnerID).To(Equal(selfOwnerID))
 	})
 	It("should exclude expired capacity reservations", func() {
 		out := awsEnv.EC2API.DescribeCapacityReservationsOutput.Clone()

--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -106,7 +106,7 @@ func FilterDescribeCapacityReservations(crs []ec2types.CapacityReservation, ids 
 		if len(ids) != 0 && !idSet.Has(*cr.CapacityReservationId) {
 			return false
 		}
-		return Filter(filters, *cr.CapacityReservationId, "", *cr.OwnerId, string(cr.State), cr.Tags)
+		return FilterCapacityReservation(filters, *cr.CapacityReservationId, "", *cr.OwnerId, string(cr.State), string(cr.InstanceMatchCriteria), cr.Tags)
 	})
 }
 
@@ -152,6 +152,15 @@ func Filter(filters []ec2types.Filter, id, name, owner, state string, tags []ec2
 			panic(fmt.Sprintf("Unsupported mock filter %v", filter))
 		}
 		return false
+	})
+}
+
+func FilterCapacityReservation(filters []ec2types.Filter, id, name, owner, state, instanceMatchCriteria string, tags []ec2types.Tag) bool {
+	return lo.EveryBy(filters, func(filter ec2types.Filter) bool {
+		if aws.ToString(filter.Name) == "instance-match-criteria" {
+			return lo.Contains(filter.Values, instanceMatchCriteria)
+		}
+		return Filter([]ec2types.Filter{filter}, id, name, owner, state, tags)
 	})
 }
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -113,6 +113,7 @@ spec:
     - tags:
         karpenter.sh/discovery: ${CLUSTER_NAME}
     - id: cr-123
+    - instanceMatchCriteria: open
 
   # Optional, propagates tags to underlying EC2 resources
   tags:
@@ -878,11 +879,12 @@ When using a custom SSM parameter, you'll need to expand the `ssm:GetParameter` 
 
 Capacity Reservation Selector Terms allow you to select [on-demand capacity reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html) (ODCRs), which will be made available to NodePools which select the given EC2NodeClass.
 Karpenter will prioritize utilizing the capacity in these reservations before falling back to on-demand and spot.
-Capacity reservations can be discovered using ids or tags.
+Capacity reservations can be discovered using ids, tags, or instance match criteria.
 
 This selection logic is modeled as terms.
-A term can specify an ID or a set of tags to select against.
+A term can specify an ID, a set of tags, or instance match criteria to select against.
 When specifying tags, it will select all capacity reservations accessible from the account with matching tags.
+When specifying instance match criteria, it selects reservations by their matching behavior: `open` (matches all compatible instances) or `targeted` (matches only explicitly targeted instances).
 This can be further restricted by specifying an owner ID.
 
 For more information on utilizing ODCRs with Karpenter, refer to the [Utilizing ODCRs Task]({{< relref "../tasks/odcrs" >}}).
@@ -926,6 +928,26 @@ spec:
   - tags:
       key: foo
     ownerID: 012345678901
+```
+
+Select by instance match criteria:
+
+```yaml
+spec:
+  capacityReservationSelectorTerms:
+  # Select all open capacity reservations
+  - instanceMatchCriteria: open
+```
+
+Select by instance match criteria and tags:
+
+```yaml
+spec:
+  capacityReservationSelectorTerms:
+  # Select targeted capacity reservations with matching tags
+  - instanceMatchCriteria: targeted
+    tags:
+      key: foo
 ```
 
 ## spec.tags


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7978 <!-- issue number -->

**Description**
This change adds support for InstanceMatchCriteria in CapacityReservationSelectorTerms, allowing for the selection of Capacity Reservations by their [matching criteria](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/cr-concepts.html#cr-instance-eligibility)—"open" which accept all instances that have matching attributes, and "targeted" which only accept instances that have matching attributes and explicitly target the Capacity Reservation. 

**How was this change tested?**
Updated unit tests, along with manual tests by creating capacity reservations (two `open` and two `targeted`, with one of each having tags and the other having no tags) in my account and selecting them with the NodeClass. 

**Test examples:**

NodeClass configuration:
```yaml
...
capacityReservationSelectorTerms:
    - instanceMatchCriteria: open
...
```
ec2nodeclass:
```yaml
...
capacityReservations:
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-013af37a302c098bd
      instanceMatchCriteria: open
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-0344526b1560a71fe
      instanceMatchCriteria: open
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
...
```
---
NodeClass configuration:
```yaml
...
capacityReservationSelectorTerms:
    - instanceMatchCriteria: targeted
...
```
ec2nodeclass:
```yaml
...
capacityReservations:
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-02a1da099c17921b2
      instanceMatchCriteria: targeted
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-0f67d04a6ca923efe
      instanceMatchCriteria: targeted
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
...
```
---
NodeClass configuration:
```yaml
...
capacityReservationSelectorTerms:
    - tags:
        test: test
      instanceMatchCriteria: open
...
```
ec2nodeclass:
```yaml
...
capacityReservations:
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-013af37a302c098bd
      instanceMatchCriteria: open
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
...
```
---
NodeClass configuration:
```yaml
...
capacityReservationSelectorTerms:
    - tags:
        test: test
    - instanceMatchCriteria: open
...
```
ec2nodeclass:
```yaml
...
capacityReservations:
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-013af37a302c098bd
      instanceMatchCriteria: open
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-0344526b1560a71fe
      instanceMatchCriteria: open
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
    - availabilityZone: us-west-2a
      endTime: "2025-10-03T07:00:00Z"
      id: cr-0f67d04a6ca923efe
      instanceMatchCriteria: targeted
      instanceType: c5.large
      ownerID: "138576548588"
      reservationType: default
      state: active
...
```
---
NodeClass configuration:
```yaml
...
capacityReservationSelectorTerms:
    - instanceMatchCriteria: test
...
```
Terminal:
```
❯ k apply -f imc-test-nc.yaml
The EC2NodeClass "default" is invalid: 
* spec.capacityReservationSelectorTerms[0].instanceMatchCriteria: Unsupported value: "test": supported values: "open", "targeted"
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```

**Does this change impact docs?**
- [ X ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.