### PR TITLE
fix: use only evictionHard for allocatable capacity calculation

### DIFF
--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1492,7 +1492,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				Expect(it.Overhead.EvictionThreshold.StorageEphemeral().AsApproximateFloat64()).To(BeNumerically("~", resources.Quantity("2Gi").AsApproximateFloat64()))
 			})
-			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
+			It("should use only evictionHard for overhead, ignoring evictionSoft", func() {
 				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 					SystemReserved: map[string]string{
 						string(corev1.ResourceMemory): "20Gi",
@@ -1523,9 +1523,10 @@ var _ = Describe("InstanceTypeProvider", func() {
 					nodeClass.AMIFamily(),
 					nil,
 				)
-				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("3Gi"))
+				// Should use evictionHard (1Gi), not evictionSoft (3Gi)
+				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("1Gi"))
 			})
-			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
+			It("should use only evictionHard percentage for overhead, ignoring evictionSoft", func() {
 				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 					SystemReserved: map[string]string{
 						string(corev1.ResourceMemory): "20Gi",
@@ -1556,9 +1557,10 @@ var _ = Describe("InstanceTypeProvider", func() {
 					nodeClass.AMIFamily(),
 					nil,
 				)
+				// Should use evictionHard (5%), not evictionSoft (2%)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.05, 10))
 			})
-			It("should take the greater of evictionHard and evictionSoft for overhead with mixed percentage/value", func() {
+			It("should use only evictionHard value with mixed percentage/value types", func() {
 				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 					SystemReserved: map[string]string{
 						string(corev1.ResourceMemory): "20Gi",
@@ -1589,7 +1591,8 @@ var _ = Describe("InstanceTypeProvider", func() {
 					nodeClass.AMIFamily(),
 					nil,
 				)
-				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
+				// Should use evictionHard (1Gi), not evictionSoft (10%)
+				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("1Gi"))
 			})
 		})
 		It("should default max pods based off of network interfaces", func() {

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -535,24 +535,19 @@ func evictionThreshold(memory *resource.Quantity, storage *resource.Quantity, am
 	}
 
 	override := corev1.ResourceList{}
-	var evictionSignals []map[string]string
+	// Only use evictionHard for allocatable memory calculation
+	// evictionSoft should not impact allocatable capacity as it's only a warning threshold
+	// See: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds
 	if evictionHard != nil {
-		evictionSignals = append(evictionSignals, evictionHard)
-	}
-	if evictionSoft != nil && amiFamily.FeatureFlags().EvictionSoftEnabled {
-		evictionSignals = append(evictionSignals, evictionSoft)
-	}
-
-	for _, m := range evictionSignals {
-		temp := corev1.ResourceList{}
-		if v, ok := m[MemoryAvailable]; ok {
-			temp[corev1.ResourceMemory] = computeEvictionSignal(*memory, v)
+		if v, ok := evictionHard[MemoryAvailable]; ok {
+			override[corev1.ResourceMemory] = computeEvictionSignal(*memory, v)
 		}
-		if v, ok := m[NodeFSAvailable]; ok {
-			temp[corev1.ResourceEphemeralStorage] = computeEvictionSignal(*storage, v)
+		if v, ok := evictionHard[NodeFSAvailable]; ok {
+			override[corev1.ResourceEphemeralStorage] = computeEvictionSignal(*storage, v)
 		}
-		override = resources.MaxResources(override, temp)
 	}
+	// Note: evictionSoft is intentionally ignored for allocatable capacity calculation
+	// as per Kubernetes specification and Issue #8407 fix
 	// Assign merges maps from left to right so overrides will always be taken last
 	return lo.Assign(overhead, override)
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #8407

**Description**

This PR fixes the incorrect eviction threshold calculation in Karpenter's allocatable memory computation. Previously, Karpenter used `max(evictionSoft, evictionHard)` to determine how much memory to reserve for eviction thresholds, but this is inconsistent with kubelet behavior.

According to the Kubernetes documentation, only `evictionHard` thresholds should impact allocatable capacity, while `evictionSoft` thresholds are warning-only and should not reserve memory.

**Changes:**
- Modified `evictionThreshold()` function in `pkg/providers/instancetype/types.go` to use only `evictionHard` values
- Updated test cases to expect `evictionHard` values instead of the maximum of both thresholds
- Added clear comments explaining the change and referencing the Kubernetes specification

**Example:**
- Before: `evictionSoft: 1Gi, evictionHard: 500Mi` → reserves 1Gi (incorrect)
- After: `evictionSoft: 1Gi, evictionHard: 500Mi` → reserves 500Mi (matches kubelet)

**How was this change tested?**
- Updated existing unit tests to verify the new behavior
- Modified test expectations for the three affected test cases that were checking `max(evictionSoft, evictionHard)` logic
- Verified that the code compiles successfully with the changes
- All tests now validate that only `evictionHard` values are used for allocatable capacity calculation

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.