### PR TITLE
fix: failing install_karpenter.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ run: ## Run Karpenter controller binary against your local cluster
 		DISABLE_LEADER_ELECTION=true \
 		CLUSTER_NAME=${CLUSTER_NAME} \
 		INTERRUPTION_QUEUE=${CLUSTER_NAME} \
-		FEATURE_GATES="SpotToSpotConsolidation=true,NodeOverlay=true" \
+		FEATURE_GATES="SpotToSpotConsolidation=true,NodeOverlay=true,StaticCapacity=true" \
 		LOG_LEVEL="debug" \
 		go run ./cmd/controller/main.go
 

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -222,3 +222,6 @@ settings:
     # -- spotToSpotConsolidation is ALPHA and is disabled by default.
     # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
     spotToSpotConsolidation: false
+     # -- staticCapacity is ALPHA and is disabled by default.
+    # Setting this to true will enable static capacity provisioning.
+    StaticCapacity: false

--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -20,6 +20,7 @@ helm upgrade --install karpenter "${CHART}" \
   --set settings.featureGates.nodeRepair=true \
   --set settings.featureGates.reservedCapacity=true \
   --set settings.featureGates.nodeOverlay=true \
+  --set settings.featureGates.staticCapacity=true \
   --set controller.resources.requests.cpu=5 \
   --set controller.resources.requests.memory=3Gi \
   --set controller.resources.limits.cpu=5 \


### PR DESCRIPTION
Currently the CI fails - https://github.com/aws/karpenter-provider-aws/actions/runs/18264656746/job/52179554355


Fixes 



**How was this change tested?**
make presubmit and will run CI 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.