### PR TITLE
docs: update outdated feature gates table

### DIFF
--- a/website/content/en/docs/reference/settings.md
+++ b/website/content/en/docs/reference/settings.md
@@ -55,7 +55,8 @@ Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line
 | Drift                   | true    | Beta   | v0.33.x | v0.37.x |
 | SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 | NodeRepair              | false   | Alpha  | v1.1.x  |         |
-| ReservedCapacity        | false   | Alpha  | v1.3.x  |         |
+| ReservedCapacity        | false   | Alpha  | v1.3.x  | v1.5.x  |
+| ReservedCapacity        | true    | Beta   | v1.6.x  |         |
 | NodeOverlay             | false   | Alpha  | v1.7.x  |         |
 
 {{% alert title="Note" color="primary" %}}

--- a/website/content/en/preview/reference/settings.md
+++ b/website/content/en/preview/reference/settings.md
@@ -55,8 +55,10 @@ Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line
 | Drift                   | true    | Beta   | v0.33.x | v0.37.x |
 | SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 | NodeRepair              | false   | Alpha  | v1.1.x  |         |
-| ReservedCapacity        | false   | Alpha  | v1.3.x  |         |
+| ReservedCapacity        | false   | Alpha  | v1.3.x  | v1.5.x  |
+| ReservedCapacity        | true    | Beta   | v1.6.x  |         |
 | NodeOverlay             | false   | Alpha  | v1.7.x  |         |
+| StaticCapacity          | false   | Alpha  | v1.8.x  |         |
 
 {{% alert title="Note" color="primary" %}}
 In v1, drift has been promoted to stable and the feature gate removed. Users can continue to control drift by using disruption budgets by reason.

--- a/website/content/en/v1.6/reference/settings.md
+++ b/website/content/en/v1.6/reference/settings.md
@@ -53,7 +53,8 @@ Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line
 | Drift                   | true    | Beta   | v0.33.x | v0.37.x |
 | SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 | NodeRepair              | false   | Alpha  | v1.1.x  |         |
-| ReservedCapacity        | false   | Alpha  | v1.3.x  |         |
+| ReservedCapacity        | false   | Alpha  | v1.3.x  | v1.5.x  |
+| ReservedCapacity        | true    | Beta   | v1.6.x  |         |
 
 {{% alert title="Note" color="primary" %}}
 In v1, drift has been promoted to stable and the feature gate removed. Users can continue to control drift by using disruption budgets by reason.

--- a/website/content/en/v1.7/reference/settings.md
+++ b/website/content/en/v1.7/reference/settings.md
@@ -55,7 +55,8 @@ Karpenter uses [feature gates](https://kubernetes.io/docs/reference/command-line
 | Drift                   | true    | Beta   | v0.33.x | v0.37.x |
 | SpotToSpotConsolidation | false   | Alpha  | v0.34.x |         |
 | NodeRepair              | false   | Alpha  | v1.1.x  |         |
-| ReservedCapacity        | false   | Alpha  | v1.3.x  |         |
+| ReservedCapacity        | false   | Alpha  | v1.3.x  | v1.5.x  |
+| ReservedCapacity        | true    | Beta   | v1.6.x  |         |
 | NodeOverlay             | false   | Alpha  | v1.7.x  |         |
 
 {{% alert title="Note" color="primary" %}}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Updates the feature gate table in settings.md to include static capacity (preview) and the promotion of reserved capacity to beta (1.6, 1.7, docs, preview). 

Note that everywhere else we were already indicating that reserved capacity had been promoted to beta (upgrade guide, default settings, embedded feature gate indicators). This is the only place it needed to be updated.

**How was this change tested?**

Docs preview

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.