### PR TITLE
fix(chart): Fix staticCapacity feature gate case mismatch

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -226,6 +226,6 @@ settings:
     # -- spotToSpotConsolidation is ALPHA and is disabled by default.
     # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
     spotToSpotConsolidation: false
-     # -- staticCapacity is ALPHA and is disabled by default.
+    # -- staticCapacity is ALPHA and is disabled by default.
     # Setting this to true will enable static capacity provisioning.
-    StaticCapacity: false
+    staticCapacity: false


### PR DESCRIPTION
## Problem

The Helm chart has a case mismatch between the values.yaml definition and the deployment template reference for the `staticCapacity` feature gate, causing Karpenter to crash on startup.

**values.yaml (line 231):**
```yaml
StaticCapacity: false  # PascalCase
```

**deployment.yaml (line 129):**
```yaml
value: "...StaticCapacity={{ .Values.settings.featureGates.staticCapacity }}"
                                                             ^^^^^^^^^^^^^^^
                                                             camelCase reference
```

When the template tries to access `.Values.settings.featureGates.staticCapacity` (camelCase), it gets an undefined value which renders as an empty string, resulting in:
```
FEATURE_GATES: "...StaticCapacity="
                                  ^ empty value
```

This causes Karpenter to panic on startup:
```
panic: parsing feature gates, invalid value of StaticCapacity: , 
err: strconv.ParseBool: parsing "": invalid syntax

goroutine 1 [running]:
github.com/samber/lo.must({0x1b154c0, 0xc000017f20}, {0x0, 0x0, 0x0})
	github.com/samber/lo@v1.51.0/errors.go:55 +0x1df
```

## Solution

Change `StaticCapacity` to `staticCapacity` in values.yaml to match:
1. The template reference in deployment.yaml
2. All other feature gate naming conventions:
   - `reservedCapacity` (not ReservedCapacity)
   - `spotToSpotConsolidation` (not SpotToSpotConsolidation)
   - `nodeRepair` (not NodeRepair)
   - `nodeOverlay` (not NodeOverlay)
3. Standard Go/Kubernetes camelCase convention for YAML keys

## Testing

Verified the fix with helm template:
```bash
helm template test-release charts/karpenter --set settings.clusterName=test-cluster | grep FEATURE_GATES
```

**Before fix:**
```yaml
value: "ReservedCapacity=true,SpotToSpotConsolidation=false,NodeRepair=false,NodeOverlay=false,StaticCapacity="
```

**After fix:**
```yaml
value: "ReservedCapacity=true,SpotToSpotConsolidation=false,NodeRepair=false,NodeOverlay=false,StaticCapacity=false"
```

## Impact

- **Versions affected:** v1.8.0 (when StaticCapacity was added with incorrect casing)
- **Severity:** Critical - causes crash loop on startup for users upgrading to 1.8.0+
- **Workaround:** Users must explicitly set `settings.featureGates.staticCapacity: false` in their values overrides

## Additional Changes

Also fixed extra leading whitespace in the staticCapacity comment (line 229).

Fixes #TBD