### PR TITLE
docs: Add the dropped metrics back

### DIFF
--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -8,6 +8,329 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen_docs.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)
+
+### `karpenter_ignored_pod_count`
+Number of pods ignored during scheduling by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_build_info`
+A metric with a constant '1' value labeled by version from which karpenter was built.
+- Stability Level: STABLE
+
+## Nodeclaims Metrics
+
+### `karpenter_nodeclaims_termination_duration_seconds`
+Duration of NodeClaim termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_terminated_total`
+Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodeclaims_instance_termination_duration_seconds`
+Duration of CloudProvider Instance termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_disrupted_total`
+Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_created_total`
+Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created and the owning nodepool.
+- Stability Level: STABLE
+
+### `operator_nodeclaim_status_condition_transitions_total`
+The count of transitions of a nodeclaim, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_count`
+The number of a condition for a nodeclaim, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_current_time_seconds`
+The current amount of time in seconds that a nodeclaim has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_duration_seconds`
+The amount of time taken by a nodeclaim to terminate completely.
+- Stability Level: BETA
+
+## Nodes Metrics
+
+### `karpenter_nodes_total_pod_requests`
+Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_pod_limits`
+Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_requests`
+Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_limits`
+Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Stability Level: BETA
+
+### `karpenter_nodes_termination_duration_seconds`
+The time taken between a node's deletion request and the removal of its finalizer
+- Stability Level: BETA
+
+### `karpenter_nodes_terminated_total`
+Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_system_overhead`
+Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Stability Level: BETA
+
+### `karpenter_nodes_lifetime_duration_seconds`
+The lifetime duration of the nodes since creation.
+- Stability Level: ALPHA
+
+### `karpenter_nodes_eviction_requests_total`
+The total number of eviction requests made by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_drained_total`
+The total number of nodes drained by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_current_lifetime_seconds`
+Node age in seconds
+- Stability Level: ALPHA
+
+### `karpenter_nodes_created_total`
+Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_allocatable`
+Node allocatable are the resources allocatable by nodes.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transitions_total`
+The count of transitions of a node, type and status.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_node_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_node_status_condition_count`
+The number of a condition for a node, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_node_termination_current_time_seconds`
+The current amount of time in seconds that a node has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_node_termination_duration_seconds`
+The amount of time taken by a node to terminate completely.
+- Stability Level: BETA
+
+### `operator_node_event_count`
+The number of a events for a node.
+- Stability Level: BETA
+
+## Pods Metrics
+
+### `karpenter_pods_state`
+Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type and pod phase.
+- Stability Level: BETA
+
+### `karpenter_pods_startup_duration_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: STABLE
+
+## Termination Metrics
+
+### `operator_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: DEPRECATED
+
+### `operator_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: DEPRECATED
+
+## Voluntary Disruption Metrics
+
+### `karpenter_voluntary_disruption_queue_failures_total`
+The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_eligible_nodes`
+Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_decisions_total`
+Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
+Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_consolidation_timeouts_total`
+Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Stability Level: BETA
+
+## Scheduler Metrics
+
+### `karpenter_scheduler_scheduling_duration_seconds`
+Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Stability Level: STABLE
+
+### `karpenter_scheduler_queue_depth`
+The number of pods currently waiting to be scheduled.
+- Stability Level: BETA
+
+## Nodepools Metrics
+
+### `karpenter_nodepools_usage`
+The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_limit`
+Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_allowed_disruptions`
+The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Stability Level: ALPHA
+
+### `operator_nodepool_status_condition_transitions_total`
+The count of transitions of a nodepool, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_count`
+The number of an condition for a nodepool, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_current_time_seconds`
+The current amount of time in seconds that a nodepool has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_duration_seconds`
+Duration of NodePool termination in seconds.
+- Stability Level: BETA
+
+## EC2NodeClass Metrics
+
+### `operator_ec2nodeclass_status_condition_transitions_total`
+The count of transitions of a ec2nodeclass, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_count`
+The number of an condition for an ec2nodeclass, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_current_time_seconds`
+The current amount of time in seconds that an ec2nodeclass has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_duration_seconds`
+Duration of ec2nodeclass termination in seconds.
+- Stability Level: BETA
+
+## Interruption Metrics
+
+### `karpenter_interruption_received_messages_total`
+Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Stability Level: STABLE
+
+### `karpenter_interruption_message_queue_duration_seconds`
+Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Stability Level: STABLE
+
+### `karpenter_interruption_deleted_messages_total`
+Count of messages deleted from the SQS queue.
+- Stability Level: STABLE
+
+## Cluster Metrics
+
+### `karpenter_cluster_utilization_percent`
+Utilization of allocatable resources by pod requests
+- Stability Level: ALPHA
+
+## Cluster State Metrics
+
+### `karpenter_cluster_state_unsynced_time_seconds`
+The time for which cluster state is not synced
+- Stability Level: ALPHA
+
+### `karpenter_cluster_state_synced`
+Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_node_count`
+Current count of nodes in cluster state
+- Stability Level: STABLE
+
+## Cloudprovider Metrics
+
+### `karpenter_cloudprovider_instance_type_offering_price_estimate`
+Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_offering_available`
+Instance type offering availability, based on instance type, capacity type, and zone
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_memory_bytes`
+Memory, in bytes, for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_cpu_cores`
+VCPUs cores for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_errors_total`
+Total number of errors returned from CloudProvider calls.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_duration_seconds`
+Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Stability Level: BETA
+
+## Cloudprovider Batcher Metrics
+
+### `karpenter_cloudprovider_batcher_batch_time_seconds`
+Duration of the batching window per batcher
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_batcher_batch_size`
+Size of the request batch per batcher
+- Stability Level: BETA
+
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
@@ -72,6 +395,34 @@ Current depth of workqueue by workqueue and priority
 Total number of adds handled by workqueue
 - Stability Level: STABLE
 
+## Status Condition Metrics
+
+### `operator_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_count`
+The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: DEPRECATED
+
+## Client Go Metrics
+
+### `client_go_request_total`
+Number of HTTP requests, partitioned by status code and method.
+- Stability Level: STABLE
+
+### `client_go_request_duration_seconds`
+Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
+- Stability Level: STABLE
+
 ## AWS SDK Go Metrics
 
 ### `aws_sdk_go_request_total`
@@ -103,4 +454,3 @@ Total number of slow path exercised in renewing leader leases. 'name' is the str
 ### `leader_election_master_status`
 Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.
 - Stability Level: STABLE
-

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -8,6 +8,329 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen_docs.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)
+
+### `karpenter_ignored_pod_count`
+Number of pods ignored during scheduling by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_build_info`
+A metric with a constant '1' value labeled by version from which karpenter was built.
+- Stability Level: STABLE
+
+## Nodeclaims Metrics
+
+### `karpenter_nodeclaims_termination_duration_seconds`
+Duration of NodeClaim termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_terminated_total`
+Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodeclaims_instance_termination_duration_seconds`
+Duration of CloudProvider Instance termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_disrupted_total`
+Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_created_total`
+Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created and the owning nodepool.
+- Stability Level: STABLE
+
+### `operator_nodeclaim_status_condition_transitions_total`
+The count of transitions of a nodeclaim, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_count`
+The number of a condition for a nodeclaim, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_current_time_seconds`
+The current amount of time in seconds that a nodeclaim has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_duration_seconds`
+The amount of time taken by a nodeclaim to terminate completely.
+- Stability Level: BETA
+
+## Nodes Metrics
+
+### `karpenter_nodes_total_pod_requests`
+Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_pod_limits`
+Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_requests`
+Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_limits`
+Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Stability Level: BETA
+
+### `karpenter_nodes_termination_duration_seconds`
+The time taken between a node's deletion request and the removal of its finalizer
+- Stability Level: BETA
+
+### `karpenter_nodes_terminated_total`
+Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_system_overhead`
+Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Stability Level: BETA
+
+### `karpenter_nodes_lifetime_duration_seconds`
+The lifetime duration of the nodes since creation.
+- Stability Level: ALPHA
+
+### `karpenter_nodes_eviction_requests_total`
+The total number of eviction requests made by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_drained_total`
+The total number of nodes drained by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_current_lifetime_seconds`
+Node age in seconds
+- Stability Level: ALPHA
+
+### `karpenter_nodes_created_total`
+Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_allocatable`
+Node allocatable are the resources allocatable by nodes.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transitions_total`
+The count of transitions of a node, type and status.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_node_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_node_status_condition_count`
+The number of a condition for a node, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_node_termination_current_time_seconds`
+The current amount of time in seconds that a node has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_node_termination_duration_seconds`
+The amount of time taken by a node to terminate completely.
+- Stability Level: BETA
+
+### `operator_node_event_count`
+The number of a events for a node.
+- Stability Level: BETA
+
+## Pods Metrics
+
+### `karpenter_pods_state`
+Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type and pod phase.
+- Stability Level: BETA
+
+### `karpenter_pods_startup_duration_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: STABLE
+
+## Termination Metrics
+
+### `operator_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: DEPRECATED
+
+### `operator_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: DEPRECATED
+
+## Voluntary Disruption Metrics
+
+### `karpenter_voluntary_disruption_queue_failures_total`
+The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_eligible_nodes`
+Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_decisions_total`
+Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
+Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_consolidation_timeouts_total`
+Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Stability Level: BETA
+
+## Scheduler Metrics
+
+### `karpenter_scheduler_scheduling_duration_seconds`
+Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Stability Level: STABLE
+
+### `karpenter_scheduler_queue_depth`
+The number of pods currently waiting to be scheduled.
+- Stability Level: BETA
+
+## Nodepools Metrics
+
+### `karpenter_nodepools_usage`
+The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_limit`
+Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_allowed_disruptions`
+The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Stability Level: ALPHA
+
+### `operator_nodepool_status_condition_transitions_total`
+The count of transitions of a nodepool, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_count`
+The number of an condition for a nodepool, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_current_time_seconds`
+The current amount of time in seconds that a nodepool has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_duration_seconds`
+Duration of NodePool termination in seconds.
+- Stability Level: BETA
+
+## EC2NodeClass Metrics
+
+### `operator_ec2nodeclass_status_condition_transitions_total`
+The count of transitions of a ec2nodeclass, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_count`
+The number of an condition for an ec2nodeclass, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_current_time_seconds`
+The current amount of time in seconds that an ec2nodeclass has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_duration_seconds`
+Duration of ec2nodeclass termination in seconds.
+- Stability Level: BETA
+
+## Interruption Metrics
+
+### `karpenter_interruption_received_messages_total`
+Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Stability Level: STABLE
+
+### `karpenter_interruption_message_queue_duration_seconds`
+Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Stability Level: STABLE
+
+### `karpenter_interruption_deleted_messages_total`
+Count of messages deleted from the SQS queue.
+- Stability Level: STABLE
+
+## Cluster Metrics
+
+### `karpenter_cluster_utilization_percent`
+Utilization of allocatable resources by pod requests
+- Stability Level: ALPHA
+
+## Cluster State Metrics
+
+### `karpenter_cluster_state_unsynced_time_seconds`
+The time for which cluster state is not synced
+- Stability Level: ALPHA
+
+### `karpenter_cluster_state_synced`
+Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_node_count`
+Current count of nodes in cluster state
+- Stability Level: STABLE
+
+## Cloudprovider Metrics
+
+### `karpenter_cloudprovider_instance_type_offering_price_estimate`
+Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_offering_available`
+Instance type offering availability, based on instance type, capacity type, and zone
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_memory_bytes`
+Memory, in bytes, for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_cpu_cores`
+VCPUs cores for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_errors_total`
+Total number of errors returned from CloudProvider calls.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_duration_seconds`
+Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Stability Level: BETA
+
+## Cloudprovider Batcher Metrics
+
+### `karpenter_cloudprovider_batcher_batch_time_seconds`
+Duration of the batching window per batcher
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_batcher_batch_size`
+Size of the request batch per batcher
+- Stability Level: BETA
+
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
@@ -72,6 +395,34 @@ Current depth of workqueue by workqueue and priority
 Total number of adds handled by workqueue
 - Stability Level: STABLE
 
+## Status Condition Metrics
+
+### `operator_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_count`
+The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: DEPRECATED
+
+## Client Go Metrics
+
+### `client_go_request_total`
+Number of HTTP requests, partitioned by status code and method.
+- Stability Level: STABLE
+
+### `client_go_request_duration_seconds`
+Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
+- Stability Level: STABLE
+
 ## AWS SDK Go Metrics
 
 ### `aws_sdk_go_request_total`
@@ -103,4 +454,3 @@ Total number of slow path exercised in renewing leader leases. 'name' is the str
 ### `leader_election_master_status`
 Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.
 - Stability Level: STABLE
-

--- a/website/content/en/v1.8/reference/metrics.md
+++ b/website/content/en/v1.8/reference/metrics.md
@@ -8,6 +8,329 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen_docs.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)
+
+### `karpenter_ignored_pod_count`
+Number of pods ignored during scheduling by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_build_info`
+A metric with a constant '1' value labeled by version from which karpenter was built.
+- Stability Level: STABLE
+
+## Nodeclaims Metrics
+
+### `karpenter_nodeclaims_termination_duration_seconds`
+Duration of NodeClaim termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_terminated_total`
+Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodeclaims_instance_termination_duration_seconds`
+Duration of CloudProvider Instance termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_disrupted_total`
+Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_created_total`
+Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created and the owning nodepool.
+- Stability Level: STABLE
+
+### `operator_nodeclaim_status_condition_transitions_total`
+The count of transitions of a nodeclaim, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_count`
+The number of a condition for a nodeclaim, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_current_time_seconds`
+The current amount of time in seconds that a nodeclaim has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_duration_seconds`
+The amount of time taken by a nodeclaim to terminate completely.
+- Stability Level: BETA
+
+## Nodes Metrics
+
+### `karpenter_nodes_total_pod_requests`
+Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_pod_limits`
+Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_requests`
+Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_limits`
+Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Stability Level: BETA
+
+### `karpenter_nodes_termination_duration_seconds`
+The time taken between a node's deletion request and the removal of its finalizer
+- Stability Level: BETA
+
+### `karpenter_nodes_terminated_total`
+Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_system_overhead`
+Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Stability Level: BETA
+
+### `karpenter_nodes_lifetime_duration_seconds`
+The lifetime duration of the nodes since creation.
+- Stability Level: ALPHA
+
+### `karpenter_nodes_eviction_requests_total`
+The total number of eviction requests made by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_drained_total`
+The total number of nodes drained by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_current_lifetime_seconds`
+Node age in seconds
+- Stability Level: ALPHA
+
+### `karpenter_nodes_created_total`
+Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_allocatable`
+Node allocatable are the resources allocatable by nodes.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transitions_total`
+The count of transitions of a node, type and status.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_node_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_node_status_condition_count`
+The number of a condition for a node, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_node_termination_current_time_seconds`
+The current amount of time in seconds that a node has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_node_termination_duration_seconds`
+The amount of time taken by a node to terminate completely.
+- Stability Level: BETA
+
+### `operator_node_event_count`
+The number of a events for a node.
+- Stability Level: BETA
+
+## Pods Metrics
+
+### `karpenter_pods_state`
+Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type and pod phase.
+- Stability Level: BETA
+
+### `karpenter_pods_startup_duration_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: STABLE
+
+## Termination Metrics
+
+### `operator_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: DEPRECATED
+
+### `operator_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: DEPRECATED
+
+## Voluntary Disruption Metrics
+
+### `karpenter_voluntary_disruption_queue_failures_total`
+The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_eligible_nodes`
+Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_decisions_total`
+Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
+Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_consolidation_timeouts_total`
+Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Stability Level: BETA
+
+## Scheduler Metrics
+
+### `karpenter_scheduler_scheduling_duration_seconds`
+Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Stability Level: STABLE
+
+### `karpenter_scheduler_queue_depth`
+The number of pods currently waiting to be scheduled.
+- Stability Level: BETA
+
+## Nodepools Metrics
+
+### `karpenter_nodepools_usage`
+The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_limit`
+Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_allowed_disruptions`
+The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Stability Level: ALPHA
+
+### `operator_nodepool_status_condition_transitions_total`
+The count of transitions of a nodepool, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_count`
+The number of an condition for a nodepool, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_current_time_seconds`
+The current amount of time in seconds that a nodepool has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_duration_seconds`
+Duration of NodePool termination in seconds.
+- Stability Level: BETA
+
+## EC2NodeClass Metrics
+
+### `operator_ec2nodeclass_status_condition_transitions_total`
+The count of transitions of a ec2nodeclass, type and status. Labeled by the type, reason, and status.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_count`
+The number of an condition for an ec2nodeclass, type and status. Labeled by the name, namespace, type, status, and reason.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_current_time_seconds`
+The current amount of time in seconds that an ec2nodeclass has been in terminating state. Labeled by name, and namespace.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_duration_seconds`
+Duration of ec2nodeclass termination in seconds.
+- Stability Level: BETA
+
+## Interruption Metrics
+
+### `karpenter_interruption_received_messages_total`
+Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Stability Level: STABLE
+
+### `karpenter_interruption_message_queue_duration_seconds`
+Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Stability Level: STABLE
+
+### `karpenter_interruption_deleted_messages_total`
+Count of messages deleted from the SQS queue.
+- Stability Level: STABLE
+
+## Cluster Metrics
+
+### `karpenter_cluster_utilization_percent`
+Utilization of allocatable resources by pod requests
+- Stability Level: ALPHA
+
+## Cluster State Metrics
+
+### `karpenter_cluster_state_unsynced_time_seconds`
+The time for which cluster state is not synced
+- Stability Level: ALPHA
+
+### `karpenter_cluster_state_synced`
+Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_node_count`
+Current count of nodes in cluster state
+- Stability Level: STABLE
+
+## Cloudprovider Metrics
+
+### `karpenter_cloudprovider_instance_type_offering_price_estimate`
+Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_offering_available`
+Instance type offering availability, based on instance type, capacity type, and zone
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_memory_bytes`
+Memory, in bytes, for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_cpu_cores`
+VCPUs cores for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_errors_total`
+Total number of errors returned from CloudProvider calls.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_duration_seconds`
+Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Stability Level: BETA
+
+## Cloudprovider Batcher Metrics
+
+### `karpenter_cloudprovider_batcher_batch_time_seconds`
+Duration of the batching window per batcher
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_batcher_batch_size`
+Size of the request batch per batcher
+- Stability Level: BETA
+
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
@@ -72,6 +395,34 @@ Current depth of workqueue by workqueue and priority
 Total number of adds handled by workqueue
 - Stability Level: STABLE
 
+## Status Condition Metrics
+
+### `operator_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_count`
+The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: DEPRECATED
+
+## Client Go Metrics
+
+### `client_go_request_total`
+Number of HTTP requests, partitioned by status code and method.
+- Stability Level: STABLE
+
+### `client_go_request_duration_seconds`
+Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
+- Stability Level: STABLE
+
 ## AWS SDK Go Metrics
 
 ### `aws_sdk_go_request_total`
@@ -103,4 +454,3 @@ Total number of slow path exercised in renewing leader leases. 'name' is the str
 ### `leader_election_master_status`
 Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.
 - Stability Level: STABLE
-


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes <https://github.com/aws/karpenter-provider-aws/issues/8606>

**Description**
Add metrics back that got dropped by the auto-generated PR - https://github.com/aws/karpenter-provider-aws/pull/8583.
We should have all the metrics that are present in 1.7 docs alongwith the new `controller_runtime_conversion_webhook_panics_total` metric.

**How was this change tested?**
Netlify

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.