### PR TITLE
Add kubelet log level for Bottlerocket

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -87,6 +87,7 @@ type BottlerocketKubernetes struct {
 	ContainerLogMaxWorkers             *int                                      `toml:"container-log-max-workers,omitempty"`
 	ContainerLogMonitorInterval        *string                                   `toml:"container-log-monitor-interval,omitempty"`
 	HostnameOverrideSource             *string                                   `toml:"hostname-override-source,omitempty"`
+	LogLevel                           *int                                      `toml:"log-level,omitempty"`
 }
 type BottlerocketStaticPod struct {
 	Enabled  *bool   `toml:"enabled,omitempty"`


### PR DESCRIPTION
- **Added settings.kubernetes.hostname-override-source to bottlerocketsettings.go**
- **Enabled pass-through of kubelet log level for debugging purposes**
