### PR TITLE
fix: make toolchain failing due to deletion of asciicheck for v1.6.x

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,4 @@
-# See https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
+version: "2"
 run:
   tests: true
   timeout: 5m
@@ -6,66 +6,89 @@ linters:
   enable:
     - asciicheck
     - bidichk
-    - errorlint
     - copyloopvar
+    - errorlint
+    - gocyclo
+    - goheader
     - gosec
+    - misspell
+    - nilerr
     - revive
-    - stylecheck
+    - staticcheck
     - tparallel
     - unconvert
     - unparam
-    - gocyclo
-    - govet
-    - goimports
-    - goheader
-    - misspell
-    - nilerr
   disable:
     - prealloc
-linters-settings:
-  gocyclo:
-    min-complexity: 11
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  revive:
+  settings:
+    gocyclo:
+      min-complexity: 11
+    goheader:
+      template: |-
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-    - name: dot-imports
-      disabled: true
-  stylecheck:
-    dot-import-whitelist:
-      - "github.com/onsi/ginkgo/v2"
-      - "github.com/onsi/gomega"
-  misspell:
-    locale: US
-    ignore-words: []
-  goimports:
-    local-prefixes: github.com/aws/karpenter-provider-aws
-  goheader:
-    template: |-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-      
-          http://www.apache.org/licenses/LICENSE-2.0
-      
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
+      - linters:
+          - goheader
+        path: zz_(.+)\.go
+      - path: (.+)\.go$
+        text: declaration of "(err|ctx)" shadows declaration at
+    paths:
+      - tools
+      - website
+      - hack
+      - charts
+      - designs
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   fix: true
-  exclude: ['declaration of "(err|ctx)" shadows declaration at']
-  exclude-dirs:
-    - tools
-    - website
-    - hack
-    - charts
-    - designs
-  exclude-rules:
-  - linters:
-    - goheader
-    path: 'zz_(.+)\.go' 
-    
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/aws/karpenter-provider-aws
+  exclusions:
+    generated: lax
+    paths:
+      - tools
+      - website
+      - hack
+      - charts
+      - designs
+      - third_party$
+      - builtin$
+      - examples$

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -12,7 +12,10 @@ main() {
 
 tools() {
     go install github.com/google/go-licenses@latest
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    # asciicheck is a dependency of golangci-lint that got removed so golangci changed their go.mod to use the forked version
+    # fix - https://github.com/golangci/golangci-lint/issues/6017
+    # change to latest once golangci releases new version with the fix
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@main
     go install github.com/google/ko@latest
     go install github.com/mikefarah/yq/v4@latest
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -309,7 +309,7 @@ var _ = Describe("CloudProvider", func() {
 		cloudProviderNodeClaim, err := cloudProvider.Create(ctx, nodeClaim)
 		Expect(err).To(BeNil())
 		Expect(cloudProviderNodeClaim).ToNot(BeNil())
-		_, ok := cloudProviderNodeClaim.ObjectMeta.Annotations[v1.AnnotationEC2NodeClassHash]
+		_, ok := cloudProviderNodeClaim.Annotations[v1.AnnotationEC2NodeClassHash]
 		Expect(ok).To(BeTrue())
 	})
 	It("should return NodeClass Hash Version on the nodeClaim", func() {
@@ -317,7 +317,7 @@ var _ = Describe("CloudProvider", func() {
 		cloudProviderNodeClaim, err := cloudProvider.Create(ctx, nodeClaim)
 		Expect(err).To(BeNil())
 		Expect(cloudProviderNodeClaim).ToNot(BeNil())
-		v, ok := cloudProviderNodeClaim.ObjectMeta.Annotations[v1.AnnotationEC2NodeClassHashVersion]
+		v, ok := cloudProviderNodeClaim.Annotations[v1.AnnotationEC2NodeClassHashVersion]
 		Expect(ok).To(BeTrue())
 		Expect(v).To(Equal(v1.EC2NodeClassHashVersion))
 	})
@@ -1154,11 +1154,11 @@ var _ = Describe("CloudProvider", func() {
 				Expect(isDrifted).To(BeEmpty())
 			})
 			It("should not return drifted if the NodeClaim's karpenter.k8s.aws/ec2nodeclass-hash-version annotation does not match the EC2NodeClass's", func() {
-				nodeClass.ObjectMeta.Annotations = map[string]string{
+				nodeClass.Annotations = map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "test-hash-111111",
 					v1.AnnotationEC2NodeClassHashVersion: "test-hash-version-1",
 				}
-				nodeClaim.ObjectMeta.Annotations = map[string]string{
+				nodeClaim.Annotations = map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "test-hash-222222",
 					v1.AnnotationEC2NodeClassHashVersion: "test-hash-version-2",
 				}
@@ -1168,10 +1168,10 @@ var _ = Describe("CloudProvider", func() {
 				Expect(isDrifted).To(BeEmpty())
 			})
 			It("should not return drifted if karpenter.k8s.aws/ec2nodeclass-hash-version annotation is not present on the NodeClass", func() {
-				nodeClass.ObjectMeta.Annotations = map[string]string{
+				nodeClass.Annotations = map[string]string{
 					v1.AnnotationEC2NodeClassHash: "test-hash-111111",
 				}
-				nodeClaim.ObjectMeta.Annotations = map[string]string{
+				nodeClaim.Annotations = map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "test-hash-222222",
 					v1.AnnotationEC2NodeClassHashVersion: "test-hash-version-2",
 				}
@@ -1185,11 +1185,11 @@ var _ = Describe("CloudProvider", func() {
 				Expect(isDrifted).To(BeEmpty())
 			})
 			It("should not return drifted if karpenter.k8s.aws/ec2nodeclass-hash-version annotation is not present on the NodeClaim", func() {
-				nodeClass.ObjectMeta.Annotations = map[string]string{
+				nodeClass.Annotations = map[string]string{
 					v1.AnnotationEC2NodeClassHash:        "test-hash-111111",
 					v1.AnnotationEC2NodeClassHashVersion: "test-hash-version-1",
 				}
-				nodeClaim.ObjectMeta.Annotations = map[string]string{
+				nodeClaim.Annotations = map[string]string{
 					v1.AnnotationEC2NodeClassHash: "test-hash-222222",
 				}
 				// should trigger drift

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -142,7 +142,7 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 	nodeClaim := &karpv1.NodeClaim{
 		Spec: karpv1.NodeClaimSpec{
 			NodeClassRef: &karpv1.NodeClassReference{
-				Name: nodeClass.ObjectMeta.Name,
+				Name: nodeClass.Name,
 			},
 		},
 	}
@@ -454,8 +454,8 @@ func (v *Validation) getInstanceTypesForNodeClass(ctx context.Context, nodeClass
 	names := sets.New[string]()
 	for _, np := range nodePools {
 		reqs := scheduling.NewNodeSelectorRequirementsWithMinValues(np.Spec.Template.Spec.Requirements...)
-		if np.Spec.Template.ObjectMeta.Labels != nil {
-			reqs.Add(lo.Values(scheduling.NewLabelRequirements(np.Spec.Template.ObjectMeta.Labels))...)
+		if np.Spec.Template.Labels != nil {
+			reqs.Add(lo.Values(scheduling.NewLabelRequirements(np.Spec.Template.Labels))...)
 		}
 		for _, it := range instanceTypes {
 			if it.Requirements.Intersects(reqs) != nil {

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -91,8 +91,8 @@ func (a AL2) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k
 func (a AL2) UserData(kubeletConfig *v1.KubeletConfiguration, taints []corev1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string, instanceStorePolicy *v1.InstanceStorePolicy) bootstrap.Bootstrapper {
 	return bootstrap.EKS{
 		Options: bootstrap.Options{
-			ClusterName:         a.Options.ClusterName,
-			ClusterEndpoint:     a.Options.ClusterEndpoint,
+			ClusterName:         a.ClusterName,
+			ClusterEndpoint:     a.ClusterEndpoint,
 			KubeletConfig:       kubeletConfig,
 			Taints:              taints,
 			Labels:              labels,

--- a/pkg/providers/amifamily/al2023.go
+++ b/pkg/providers/amifamily/al2023.go
@@ -82,9 +82,9 @@ func (a AL2023) resolvePath(architecture, variant, k8sVersion, amiVersion string
 func (a AL2023) UserData(kubeletConfig *v1.KubeletConfiguration, taints []corev1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string, instanceStorePolicy *v1.InstanceStorePolicy) bootstrap.Bootstrapper {
 	return bootstrap.Nodeadm{
 		Options: bootstrap.Options{
-			ClusterName:         a.Options.ClusterName,
-			ClusterEndpoint:     a.Options.ClusterEndpoint,
-			ClusterCIDR:         a.Options.ClusterCIDR,
+			ClusterName:         a.ClusterName,
+			ClusterEndpoint:     a.ClusterEndpoint,
+			ClusterCIDR:         a.ClusterCIDR,
 			KubeletConfig:       kubeletConfig,
 			Taints:              taints,
 			Labels:              labels,

--- a/pkg/providers/amifamily/bootstrap/custom.go
+++ b/pkg/providers/amifamily/bootstrap/custom.go
@@ -25,5 +25,5 @@ type Custom struct {
 }
 
 func (e Custom) Script() (string, error) {
-	return base64.StdEncoding.EncodeToString([]byte(aws.ToString(e.Options.CustomUserData))), nil
+	return base64.StdEncoding.EncodeToString([]byte(aws.ToString(e.CustomUserData))), nil
 }

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -79,8 +79,8 @@ func (b Bottlerocket) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Pr
 func (b Bottlerocket) UserData(kubeletConfig *v1.KubeletConfiguration, taints []corev1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string, instanceStorePolicy *v1.InstanceStorePolicy) bootstrap.Bootstrapper {
 	return bootstrap.Bottlerocket{
 		Options: bootstrap.Options{
-			ClusterName:         b.Options.ClusterName,
-			ClusterEndpoint:     b.Options.ClusterEndpoint,
+			ClusterName:         b.ClusterName,
+			ClusterEndpoint:     b.ClusterEndpoint,
 			KubeletConfig:       kubeletConfig,
 			Taints:              taints,
 			Labels:              labels,

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -73,8 +73,8 @@ func (w Windows) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provide
 func (w Windows) UserData(kubeletConfig *v1.KubeletConfiguration, taints []corev1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string, _ *v1.InstanceStorePolicy) bootstrap.Bootstrapper {
 	return bootstrap.Windows{
 		Options: bootstrap.Options{
-			ClusterName:     w.Options.ClusterName,
-			ClusterEndpoint: w.Options.ClusterEndpoint,
+			ClusterName:     w.ClusterName,
+			ClusterEndpoint: w.ClusterEndpoint,
 			KubeletConfig:   kubeletConfig,
 			Taints:          taints,
 			Labels:          labels,

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2631,8 +2631,8 @@ func ExpectLaunchTemplatesCreatedWithUserData(expected string) {
 		userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
 		ExpectWithOffset(2, err).To(BeNil())
 		// Newlines are always added for missing TOML fields, so strip them out before comparisons.
-		actualUserData := strings.Replace(string(userData), "\n", "", -1)
-		expectedUserData := strings.Replace(expected, "\n", "", -1)
+		actualUserData := strings.ReplaceAll(string(userData), "\n", "")
+		expectedUserData := strings.ReplaceAll(expected, "\n", "")
 		ExpectWithOffset(2, actualUserData).To(Equal(expectedUserData))
 	})
 }

--- a/test/pkg/debug/node.go
+++ b/test/pkg/debug/node.go
@@ -49,11 +49,11 @@ func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (
 	n := &corev1.Node{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, n); err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Printf("[DELETED %s] NODE %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+			fmt.Printf("[DELETED %s] NODE %s\n", time.Now().Format(time.RFC3339), req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	fmt.Printf("[CREATED/UPDATED %s] NODE %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.Name, c.GetInfo(ctx, n))
+	fmt.Printf("[CREATED/UPDATED %s] NODE %s %s\n", time.Now().Format(time.RFC3339), req.Name, c.GetInfo(ctx, n))
 	return reconcile.Result{}, nil
 }
 

--- a/test/pkg/debug/nodeclaim.go
+++ b/test/pkg/debug/nodeclaim.go
@@ -46,11 +46,11 @@ func (c *NodeClaimController) Reconcile(ctx context.Context, req reconcile.Reque
 	nc := &karpv1.NodeClaim{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, nc); err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Printf("[DELETED %s] NODECLAIM %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+			fmt.Printf("[DELETED %s] NODECLAIM %s\n", time.Now().Format(time.RFC3339), req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	fmt.Printf("[CREATED/UPDATED %s] NODECLAIM %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.Name, c.GetInfo(nc))
+	fmt.Printf("[CREATED/UPDATED %s] NODECLAIM %s %s\n", time.Now().Format(time.RFC3339), req.Name, c.GetInfo(nc))
 	return reconcile.Result{}, nil
 }
 

--- a/test/pkg/debug/pod.go
+++ b/test/pkg/debug/pod.go
@@ -48,11 +48,11 @@ func (c *PodController) Reconcile(ctx context.Context, req reconcile.Request) (r
 	p := &corev1.Pod{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, p); err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Printf("[DELETED %s] POD %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+			fmt.Printf("[DELETED %s] POD %s\n", time.Now().Format(time.RFC3339), req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	fmt.Printf("[CREATED/UPDATED %s] POD %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String(), c.GetInfo(p))
+	fmt.Printf("[CREATED/UPDATED %s] POD %s %s\n", time.Now().Format(time.RFC3339), req.String(), c.GetInfo(p))
 	return reconcile.Result{}, nil
 }
 

--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -147,13 +147,13 @@ func (env *Environment) GetInstanceProfileName(nodeClass *v1.EC2NodeClass) strin
 }
 
 func (env *Environment) GetInstance(nodeName string) ec2types.Instance {
-	node := env.Environment.GetNode(nodeName)
+	node := env.GetNode(nodeName)
 	return env.GetInstanceByID(env.ExpectParsedProviderID(node.Spec.ProviderID))
 }
 
 func (env *Environment) ExpectInstanceStopped(nodeName string) {
 	GinkgoHelper()
-	node := env.Environment.GetNode(nodeName)
+	node := env.GetNode(nodeName)
 	_, err := env.EC2API.StopInstances(env.Context, &ec2.StopInstancesInput{
 		Force:       aws.Bool(true),
 		InstanceIds: []string{env.ExpectParsedProviderID(node.Spec.ProviderID)},
@@ -163,7 +163,7 @@ func (env *Environment) ExpectInstanceStopped(nodeName string) {
 
 func (env *Environment) ExpectInstanceTerminated(nodeName string) {
 	GinkgoHelper()
-	node := env.Environment.GetNode(nodeName)
+	node := env.GetNode(nodeName)
 	_, err := env.EC2API.TerminateInstances(env.Context, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{env.ExpectParsedProviderID(node.Spec.ProviderID)},
 	})

--- a/test/pkg/environment/aws/metrics.go
+++ b/test/pkg/environment/aws/metrics.go
@@ -80,7 +80,7 @@ func (env *Environment) MeasureDurationFor(f func(), eventType EventType, dimens
 	start := time.Now()
 	f()
 	gitRef := "n/a"
-	if env.Context.Value(common.GitRefContextKey) != nil {
+	if env.Value(common.GitRefContextKey) != nil {
 		gitRef = env.Value(common.GitRefContextKey).(string)
 	}
 

--- a/test/pkg/environment/aws/setup.go
+++ b/test/pkg/environment/aws/setup.go
@@ -36,7 +36,7 @@ func (env *Environment) BeforeEach() {
 
 func (env *Environment) Cleanup() {
 	env.Environment.Cleanup()
-	env.Environment.CleanupObjects(CleanableObjects...)
+	env.CleanupObjects(CleanableObjects...)
 }
 
 func (env *Environment) AfterEach() {

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
-	. "sigs.k8s.io/karpenter/pkg/utils/testing" //nolint:stylecheck
+	. "sigs.k8s.io/karpenter/pkg/utils/testing" //nolint:stylecheck,staticcheck
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -143,7 +143,7 @@ var _ = DescribeTableSubtree("Scheduling", Ordered, ContinueOnFailure, func(minV
 					{
 						Key:      v1.LabelTopologyZoneID,
 						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{env.GetSubnetInfo(map[string]string{"karpenter.sh/discovery": env.ClusterName})[0].ZoneInfo.ZoneID},
+						Values:   []string{env.GetSubnetInfo(map[string]string{"karpenter.sh/discovery": env.ClusterName})[0].ZoneID},
 					},
 				},
 			}})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Ran presubmit to auto lints/corrects based on golangci-lint v2
Currently make toolchain fails with
```
/Users/rsumukha/go/pkg/mod/github.com/golangci/golangci-lint@v1.64.8/pkg/golinters/asciicheck/asciicheck.go:4:2: reading github.com/tdakkota/asciicheck/go.mod at revision v0.4.1: git ls-remote -q origin in /Users/rsumukha/go/pkg/mod/cache/vcs/e91413ff76cb95901df8e2d834855d07c617befa58b5014bc6cd6fd1148034dd: exit status 128:
	remote: Repository not found.
	fatal: repository 'https://github.com/tdakkota/asciicheck/' not found
make: *** [toolchain] Error 1
```

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.