### PR TITLE
chore: Bump to use go1.25.3 from go1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws
 
-go 1.25.0
+go 1.25.3
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Updating to use go1.25.3 as part of failing go vulnerability checks  
```
=== Symbol Results ===

Vulnerability #1: GO-2025-4013
    Panic when validating certificates with DSA public keys in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4013
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.2
    Example traces found:
Error:       #1: pkg/providers/amifamily/bootstrap/mime/mime.go:67:27: mime.NewArchive calls io.ReadAll, which eventually calls x509.Certificate.Verify

Vulnerability #2: GO-2025-4012
    Lack of limit when parsing cookies can cause memory exhaustion in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-4012
  Standard library
    Found in: net/http@go1.25
    Fixed in: net/http@go1.25.2
    Example traces found:
Error:       #1: pkg/operator/operator.go:287:77: operator.KubeDNSIP calls gentype.Client[*k8s.io/api/core/v1.Service].Get[*k8s.io/api/core/v1.Service], which eventually calls http.Client.Do

Vulnerability #3: GO-2025-4011
    Parsing DER payload can cause memory exhaustion in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2025-4011
  Standard library
    Found in: encoding/asn1@go1.25
    Fixed in: encoding/asn1@go1.25.2
    Example traces found:
Error:       #1: pkg/operator/operator.go:276:33: operator.GetCABundle calls transport.TLSConfigFor, which eventually calls asn1.Unmarshal

Vulnerability #4: GO-2025-4010
    Insufficient validation of bracketed IPv6 hostnames in net/url
  More info: https://pkg.go.dev/vuln/GO-2025-4010
  Standard library
    Found in: net/url@go1.25
    Fixed in: net/url@go1.25.2
    Example traces found:
Error:       #1: pkg/operator/options/options_validation.go:38:28: options.Options.validateEndpoint calls url.Parse
Error:       #2: pkg/operator/operator.go:102:54: operator.NewOperator calls imds.Client.GetRegion, which eventually calls url.ParseRequestURI
Error:       #3: pkg/operator/operator.go:287:77: operator.KubeDNSIP calls gentype.Client[*k8s.io/api/core/v1.Service].Get[*k8s.io/api/core/v1.Service], which eventually calls url.URL.Parse

Vulnerability #5: GO-2025-4009
    Quadratic complexity when parsing some invalid inputs in encoding/pem
  More info: https://pkg.go.dev/vuln/GO-2025-4009
  Standard library
    Found in: encoding/pem@go1.25
    Fixed in: encoding/pem@go1.25.2
    Example traces found:
Error:       #1: pkg/operator/operator.go:276:33: operator.GetCABundle calls transport.TLSConfigFor, which eventually calls pem.Decode

Vulnerability #6: GO-2025-4008
    ALPN negotiation error contains attacker controlled information in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2025-4008
  Standard library
    Found in: crypto/tls@go1.25
    Fixed in: crypto/tls@go1.25.2
    Example traces found:
Error:       #1: pkg/operator/operator.go:287:77: operator.KubeDNSIP calls gentype.Client[*k8s.io/api/core/v1.Service].Get[*k8s.io/api/core/v1.Service], which eventually calls tls.Conn.HandshakeContext
Error:       #2: pkg/providers/amifamily/bootstrap/mime/mime.go:67:27: mime.NewArchive calls io.ReadAll, which eventually calls tls.Conn.Read
Error:       #3: pkg/utils/utils.go:76:15: utils.PrettySlice calls fmt.Fprintf, which calls tls.Conn.Write
Error:       #4: pkg/operator/operator.go:287:77: operator.KubeDNSIP calls gentype.Client[*k8s.io/api/core/v1.Service].Get[*k8s.io/api/core/v1.Service], which eventually calls tls.Dialer.DialContext

Vulnerability #7: GO-2025-4007
    Quadratic complexity when checking name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4007
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.3
    Example traces found:
Error:       #1: pkg/operator/operator.go:276:33: operator.GetCABundle calls transport.TLSConfigFor, which eventually calls x509.CertPool.AppendCertsFromPEM
Error:       #2: pkg/providers/amifamily/bootstrap/mime/mime.go:67:27: mime.NewArchive calls io.ReadAll, which eventually calls x509.Certificate.Verify
Error:       #3: pkg/operator/operator.go:276:33: operator.GetCABundle calls transport.TLSConfigFor, which eventually calls x509.ParseCertificate
Error:       #4: pkg/operator/operator.go:276:33: operator.GetCABundle calls transport.TLSConfigFor, which eventually calls x509.ParseECPrivateKey
Error:       #5: pkg/operator/operator.go:276:33: operator.GetCABundle calls transport.TLSConfigFor, which eventually calls x509.ParsePKCS1PrivateKey
Error:       #6: pkg/operator/operator.go:276:33: operator.GetCABundle calls transport.TLSConfigFor, which eventually calls x509.ParsePKCS8PrivateKey

Your code is affected by 7 vulnerabilities from the Go standard library.
This scan also found 4 vulnerabilities in packages you import and 0
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
make: *** [Makefile:147: vulncheck] Error 3
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.