### PR TITLE
chore: split controller IAM policies

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -24,10 +24,14 @@ Resources:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  KarpenterControllerPolicy:
+  NodeLifecyclePolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
+      ManagedPolicyName: !Sub "KarpenterControllerNodeLifecyclePolicy-${AWS::StackId}"
+      Path: /
+      Tags:
+        - key: "eks:eks-cluster-name"
+          value: !Sub "${ClusterName}"
       # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
       # value in one of its key parameters which isn't natively supported by CloudFormation
       PolicyDocument: !Sub |
@@ -75,8 +79,7 @@ Resources:
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
               ],
               "Action": [
                 "ec2:RunInstances",
@@ -163,50 +166,23 @@ Resources:
                   "aws:ResourceTag/karpenter.sh/nodepool": "*"
                 }
               }
-            },
-            {
-              "Sid": "AllowRegionalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "ec2:DescribeCapacityReservations",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeLaunchTemplates",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSpotPriceHistory",
-                "ec2:DescribeSubnets"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestedRegion": "${AWS::Region}"
-                }
-              }
-            },
-            {
-              "Sid": "AllowSSMReadActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
-              "Action": "ssm:GetParameter"
-            },
-            {
-              "Sid": "AllowPricingReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": "pricing:GetProducts"
-            },
-            {
-              "Sid": "AllowInterruptionQueueActions",
-              "Effect": "Allow",
-              "Resource": "${KarpenterInterruptionQueue.Arn}",
-              "Action": [
-                "sqs:DeleteMessage",
-                "sqs:GetQueueUrl",
-                "sqs:ReceiveMessage"
-              ]
-            },
+            }
+          ]
+        }
+  IAMIntegrationPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "KarpenterControllerIAMIntegrationPolicy-${AWS::StackId}"
+      Path: /
+      Tags:
+        - key: "eks:eks-cluster-name"
+          value: !Sub "${ClusterName}"
+      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+      # value in one of its key parameters which isn't natively supported by CloudFormation
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
             {
               "Sid": "AllowPassingInstanceRole",
               "Effect": "Allow",
@@ -278,12 +254,103 @@ Resources:
                   "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"
                 }
               }
+            }
+          ]
+        }
+  EKSIntegrationPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "KarpenterControllerEKSIntegrationPolicy-${AWS::StackId}"
+      Path: /
+      Tags:
+        - key: "eks:eks-cluster-name"
+          value: !Sub "${ClusterName}"
+      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+      # value in one of its key parameters which isn't natively supported by CloudFormation
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowAPIServerEndpointDiscovery",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Action": "eks:DescribeCluster"
+            }
+          ]
+        }
+  InterruptionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "KarpenterControllerInterruptionPolicy-${AWS::StackId}"
+      Path: /
+      Tags:
+        - key: "eks:eks-cluster-name"
+          value: !Sub "${ClusterName}"
+      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+      # value in one of its key parameters which isn't natively supported by CloudFormation
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowInterruptionQueueActions",
+              "Effect": "Allow",
+              "Resource": "${KarpenterInterruptionQueue.Arn}",
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:GetQueueUrl",
+                "sqs:ReceiveMessage"
+              ]
+            }
+          ]
+        }
+  ResourceDiscoveryPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "KarpenterControllerResourceDiscoveryPolicy-${AWS::StackId}"
+      Path: /
+      Tags:
+        - key: "eks:eks-cluster-name"
+          value: !Sub "${ClusterName}"
+      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+      # value in one of its key parameters which isn't natively supported by CloudFormation
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowRegionalReadActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": [
+                "ec2:DescribeCapacityReservations",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypeOfferings",
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeLaunchTemplates",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeSubnets"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "${AWS::Region}"
+                }
+              }
             },
             {
-              "Sid": "AllowInstanceProfileReadActions",
+              "Sid": "AllowSSMReadActions",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
-              "Action": "iam:GetInstanceProfile"
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": "pricing:GetProducts"
             },
             {
               "Sid": "AllowUnscopedInstanceProfileListAction",
@@ -292,10 +359,10 @@ Resources:
               "Action": "iam:ListInstanceProfiles"
             },
             {
-              "Sid": "AllowAPIServerEndpointDiscovery",
+              "Sid": "AllowInstanceProfileReadActions",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
-              "Action": "eks:DescribeCluster"
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+              "Action": "iam:GetInstanceProfile"
             }
           ]
         }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7874 

**Description**

Splits the Karpenter controller policy into five sub-policies:
- NodeLifecylePolicy
- IAMIntegratioPolicy
- EKSIntegrationPolicy
- InterruptionPolicy
- ResourceDiscoveryPolicy

**How was this change tested?**

Manual testing

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.