### PR TITLE
fix(kubereserved): allow custom AMI bypass and floor kubeReserved to …

### DIFF
--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -120,6 +120,43 @@ func (d *DefaultResolver) Resolve(ctx context.Context, info ec2types.InstanceTyp
 	)
 }
 
+// effectiveKubeReservedPods picks the pod count to use when deriving kubeReserved.
+// If the AMI family uses ENI-limited memory overhead, we floor by min(pods(), ENILimitedPods()).
+// Otherwise we use pods().
+func effectiveKubeReservedPods(
+	ctx context.Context,
+	info ec2types.InstanceTypeInfo,
+	amiFamily amifamily.AMIFamily, // added prefix amifamily
+	maxPods *int32,
+	podsPerCore *int32,
+) *resource.Quantity {
+	eni := ENILimitedPods(ctx, info, 0)                   // *resource.Quantity
+	p := pods(ctx, info, amiFamily, maxPods, podsPerCore) // *resource.Quantity
+
+	if amiFamily.FeatureFlags().UsesENILimitedMemoryOverhead {
+		switch {
+		case p != nil && eni != nil && p.Value() > 0 && eni.Value() > 0:
+			if p.Cmp(*eni) < 0 {
+				return p
+			}
+			return eni
+		case p != nil && p.Value() > 0:
+			return p
+		default:
+			return eni
+		}
+	}
+	return p
+}
+
+// Conservative bypass: for Custom AMI, if user supplied explicit kubeReserved values,
+// honor those values only (don’t add the 11*pods + 255Mi memory formula).
+func bypassAutoKubeReserved(af amifamily.AMIFamily, kubeReserved map[string]string) bool {
+	// true only if the AMI family is Custom AND user supplied explicit kubeReserved values
+	_, isCustom := af.(*amifamily.Custom)
+	return isCustom && len(kubeReserved) > 0
+}
+
 func NewInstanceType(
 	ctx context.Context,
 	info ec2types.InstanceTypeInfo,
@@ -143,7 +180,18 @@ func NewInstanceType(
 		Requirements: computeRequirements(info, region, offeringZones, subnetZoneInfo, amiFamily, capacityReservations),
 		Capacity:     computeCapacity(ctx, info, amiFamily, blockDeviceMappings, instanceStorePolicy, maxPods, podsPerCore),
 		Overhead: &cloudprovider.InstanceTypeOverhead{
-			KubeReserved:      kubeReservedResources(cpu(info), lo.Ternary(amiFamily.FeatureFlags().UsesENILimitedMemoryOverhead, ENILimitedPods(ctx, info, 0), pods(ctx, info, amiFamily, maxPods, podsPerCore)), kubeReserved),
+			KubeReserved: func() corev1.ResourceList {
+				if bypassAutoKubeReserved(amiFamily, kubeReserved) {
+					// honor only user-provided kubeReserved values (no 11*pods+255 added)
+					out := corev1.ResourceList{}
+					for k, v := range kubeReserved {
+						out[corev1.ResourceName(k)] = resource.MustParse(v)
+					}
+					return out
+				}
+				effPods := effectiveKubeReservedPods(ctx, info, amiFamily, maxPods, podsPerCore)
+				return kubeReservedResources(cpu(info), effPods, kubeReserved)
+			}(),
 			SystemReserved:    systemReservedResources(systemReserved),
 			EvictionThreshold: evictionThreshold(memory(ctx, info), ephemeralStorage(info, amiFamily, blockDeviceMappings, instanceStorePolicy), amiFamily, evictionHard, evictionSoft),
 		},


### PR DESCRIPTION
…min(maxPods, ENI limit) per #8497

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- 8497 -->

**Description**
- Added helper to compute **floor(min(MaxPods, ENI limit))** for kubeReserved calculation.  
- Added option to **bypass kubeReserved auto-calculation** when AMI family is Custom.  
- Updated `NewInstanceType` logic to respect these behaviors for Custom AMIs.  
- Preserves existing behavior for AL2/AL2023 families.
- Previously, kubeReserved used ENI-limited memory overhead unconditionally, causing excessive allocable reduction (~8 GiB for high pod densities).  
This change provides flexibility for Custom AMI users and improves accuracy in allocable estimation when user-defined `maxPods` is lower than the ENI limit.
 -This PR focuses on logic correctness and configurability.  
 -If approved, follow-up PRs can adjust test expectations and documentation for `kubeReserved` behavior in Custom AMI families.
**How was this change tested?**
   Local test suite executed under envtest:
  - **92/98 tests passed** ✅
  - 6 integration tests (expected to fail) assert ENI-based maxPods and overhead — these will need update once the new behavior is accepted.
- Core compilation and unit validation via `go vet` and `go fmt` are clean.
**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.