### PR TITLE
feat: Prioritize unused Reserved Instances in instance selection

### DIFF
--- a/hack/docs/instancetypes_gen/main.go
+++ b/hack/docs/instancetypes_gen/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/reservedinstance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/subnet"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
 
@@ -144,6 +145,7 @@ below are the resources available with some assumptions and after the instance o
 			),
 			nil,
 			awscache.NewUnavailableOfferings(),
+			reservedinstance.NewDefaultProvider(ec2api, cache.New(awscache.ReservedInstancePriceTTL, awscache.DefaultCleanupInterval)),
 			instancetype.NewDefaultResolver(
 				region,
 			),

--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -59,6 +59,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/reservedinstance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
@@ -165,6 +166,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.CapacityReservationAvailabilityTTL, awscache.DefaultCleanupInterval),
 	)
+	reservedInstanceProvider := reservedinstance.NewDefaultProvider(ec2api, cache.New(awscache.ReservedInstancePriceTTL, awscache.DefaultCleanupInterval))
 	instanceTypeProvider := instancetype.NewDefaultProvider(
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),
@@ -174,6 +176,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		pricingProvider,
 		capacityReservationProvider,
 		unavailableOfferingsCache,
+		reservedInstanceProvider,
 		instancetype.NewDefaultResolver(cfg.Region),
 	)
 	// Ensure we're able to hydrate instance types before starting any reliant controllers.

--- a/pkg/aws/sdk.go
+++ b/pkg/aws/sdk.go
@@ -42,6 +42,7 @@ type EC2API interface {
 	CreateTags(context.Context, *ec2.CreateTagsInput, ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
 	CreateLaunchTemplate(context.Context, *ec2.CreateLaunchTemplateInput, ...func(*ec2.Options)) (*ec2.CreateLaunchTemplateOutput, error)
 	DeleteLaunchTemplate(context.Context, *ec2.DeleteLaunchTemplateInput, ...func(*ec2.Options)) (*ec2.DeleteLaunchTemplateOutput, error)
+	DescribeReservedInstances(context.Context, *ec2.DescribeReservedInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeReservedInstancesOutput, error)
 }
 
 type IAMAPI interface {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -51,6 +51,8 @@ const (
 	RecreationTTL = 1 * time.Minute
 	// ProtectedProfilesTTL is the duration to keep profiles as protected before nodeclass garbagecollector considers deletion
 	ProtectedProfilesTTL = 1 * time.Hour
+	// ReservedInstancePriceTTL is the time before we refresh reserved instance price data
+	ReservedInstancePriceTTL = 60 * time.Minute
 )
 
 const (

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -173,7 +173,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.CapacityReservationAvailabilityTTL, awscache.DefaultCleanupInterval),
 	)
-	reservedInstanceProvider := reservedinstance.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	reservedInstanceProvider := reservedinstance.NewDefaultProvider(ec2api, cache.New(awscache.ReservedInstancePriceTTL, awscache.DefaultCleanupInterval))
 	instanceTypeProvider := instancetype.NewDefaultProvider(
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -182,8 +182,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		subnetProvider,
 		pricingProvider,
 		capacityReservationProvider,
-		reservedInstanceProvider,
 		unavailableOfferingsCache,
+		reservedInstanceProvider,
 		instancetype.NewDefaultResolver(cfg.Region),
 	)
 	// Ensure we're able to hydrate instance types before starting any reliant controllers.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -173,7 +173,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.CapacityReservationAvailabilityTTL, awscache.DefaultCleanupInterval),
 	)
-	reservedInstanceProvider := reservedinstance.NewDefaultProvider(ec2api)
+	reservedInstanceProvider := reservedinstance.NewDefaultProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	instanceTypeProvider := instancetype.NewDefaultProvider(
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),
@@ -199,6 +199,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		subnetProvider,
 		launchTemplateProvider,
 		capacityReservationProvider,
+		reservedInstanceProvider,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 	)
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -57,6 +57,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/reservedinstance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
@@ -91,6 +92,7 @@ type Operator struct {
 	InstanceProvider            instance.Provider
 	SSMProvider                 ssmp.Provider
 	CapacityReservationProvider capacityreservation.Provider
+	ReservedInstanceProvider  reservedinstance.Provider
 	EC2API                      *ec2.Client
 }
 
@@ -171,6 +173,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.CapacityReservationAvailabilityTTL, awscache.DefaultCleanupInterval),
 	)
+	reservedInstanceProvider := reservedinstance.NewDefaultProvider(ec2api)
 	instanceTypeProvider := instancetype.NewDefaultProvider(
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),
 		cache.New(awscache.InstanceTypesZonesAndOfferingsTTL, awscache.DefaultCleanupInterval),
@@ -179,6 +182,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		subnetProvider,
 		pricingProvider,
 		capacityReservationProvider,
+		reservedInstanceProvider,
 		unavailableOfferingsCache,
 		instancetype.NewDefaultResolver(cfg.Region),
 	)
@@ -221,6 +225,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		InstanceProvider:            instanceProvider,
 		SSMProvider:                 ssmProvider,
 		CapacityReservationProvider: capacityReservationProvider,
+		ReservedInstanceProvider:  reservedInstanceProvider,
 		EC2API:                      ec2api,
 	}
 }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -175,9 +175,8 @@ func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1.EC2NodeClass
 		if isCapacityReservation {
 			id, crt := p.getCapacityReservationDetailsForInstance(launchedInstanceType, launchedZone, instanceTypes)
 			opts = append(opts, WithCapacityReservationDetails(id, crt))
-		} else {
-			p.reservedInstanceProvider.MarkLaunched(ec2types.InstanceType(launchedInstanceType), launchedZone)
 		}
+		p.reservedInstanceProvider.MarkLaunched(ec2types.InstanceType(launchedInstanceType), launchedZone)
 	}
 	if lo.Contains(lo.Keys(nodeClaim.Spec.Resources.Requests), v1.ResourceEFA) {
 		opts = append(opts, WithEFAEnabled())
@@ -262,8 +261,8 @@ func (p *DefaultProvider) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	// If this was a reserved launch that wasn't a CR, it must have been an RI
-	if out.capacityType == karpv1.CapacityTypeReserved && out.capacityReservationID == "" {
+
+	if out.capacityType == karpv1.CapacityTypeReserved {
 		p.reservedInstanceProvider.MarkTerminated(ec2types.InstanceType(out.Type), out.Zone)
 	}
 	// Check if the instance is already shutting-down to reduce the number of terminate-instance calls we make thereby

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -262,7 +262,7 @@ func (p *DefaultProvider) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	if out.capacityType == karpv1.CapacityTypeReserved {
+	if out.CapacityType == karpv1.CapacityTypeReserved {
 		p.reservedInstanceProvider.MarkTerminated(ec2types.InstanceType(out.Type), out.Zone)
 	}
 	// Check if the instance is already shutting-down to reduce the number of terminate-instance calls we make thereby

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype/offering"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/reservedinstance"
 
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/patrickmn/go-cache"
@@ -99,6 +100,7 @@ func NewDefaultProvider(
 	pricingProvider pricing.Provider,
 	capacityReservationProvider capacityreservation.Provider,
 	unavailableOfferingsCache *awscache.UnavailableOfferings,
+	reservedInstanceProvider reservedinstance.Provider,
 	instanceTypesResolver Resolver,
 ) *DefaultProvider {
 	return &DefaultProvider{
@@ -113,6 +115,7 @@ func NewDefaultProvider(
 		offeringProvider: offering.NewDefaultProvider(
 			pricingProvider,
 			capacityReservationProvider,
+			reservedInstanceProvider,
 			unavailableOfferingsCache,
 			offeringCache,
 		),

--- a/pkg/providers/instancetype/offering/offering.go
+++ b/pkg/providers/instancetype/offering/offering.go
@@ -49,7 +49,7 @@ type NodeClass interface {
 type DefaultProvider struct {
 	pricingProvider                pricing.Provider
 	capacityReservationProvider    capacityreservation.Provider
-	reservedInstanceProvider.      reservedinstance.Provider,
+	reservedInstanceProvider       reservedinstance.Provider
 	unavailableOfferings           *awscache.UnavailableOfferings
 	lastUnavailableOfferingsSeqNum sync.Map // instance type -> seqNum
 	cache                          *cache.Cache

--- a/pkg/providers/reservedinstance/provider.go
+++ b/pkg/providers/reservedinstance/provider.go
@@ -162,7 +162,7 @@ func (p *DefaultProvider) updateCache(ris []ec2types.ReservedInstances, reservat
 			availableCount := count - runningCount
 			key := p.cache.makeCacheKey(instType, zone)
 			availability[key] = &availabilityCacheEntry{
-				count: lo.Max(0, availableCount),
+				count: availableCount,
 				total: count,
 			}
 		}
@@ -171,6 +171,8 @@ func (p *DefaultProvider) updateCache(ris []ec2types.ReservedInstances, reservat
 }
 
 func (p *DefaultProvider) buildReservedInstancesFromCache() []*ReservedInstance {
+	p.cache.mu.RLock()
+	defer p.cache.mu.RUnlock()
 	var reservedInstances []*ReservedInstance
 	for key, item := range p.cache.cache.Items() {
 		entry := item.Object.(*availabilityCacheEntry)

--- a/pkg/providers/reservedinstance/provider.go
+++ b/pkg/providers/reservedinstance/provider.go
@@ -24,6 +24,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
 	"github.com/aws/karpenter-provider-aws/pkg/aws"
@@ -33,10 +34,20 @@ const (
 	cacheKey = "reserved-instances"
 )
 
+// Provider is an interface for getting reserved instance data.
+type Provider interface {
+	// GetReservedInstances returns all reserved instances for a given set of queries.
+	GetReservedInstances(context.Context) ([]*ReservedInstance, error)
+	// MarkLaunched decrements the count of available instances for a given instance type and availability zone.
+	MarkLaunched(ec2types.InstanceType, string)
+	// MarkTerminated increments the count of available instances for a given instance type and availability zone.
+	MarkTerminated(ec2types.InstanceType, string)
+}
+
 // DefaultProvider is the reserved instance provider using the AWS API to get reserved instance information
 type DefaultProvider struct {
-	ec2   aws.EC2API
-	cache *cache.Cache
+	ec2   sdk.EC2API
+	cache *availabilityCache
 	cm    *pretty.ChangeMonitor
 	mu    sync.Mutex
 }
@@ -44,23 +55,34 @@ type DefaultProvider struct {
 type instanceCounts map[ec2types.InstanceType]map[string]int32
 
 // NewDefaultProvider constructs a new DefaultProvider
-func NewDefaultProvider(ec2 aws.EC2API) *DefaultProvider {
+func NewDefaultProvider(ec2 sdk.EC2API, cache *cache.Cache) *DefaultProvider {
 	return &DefaultProvider{
-		ec2:   ec2,
-		cm:    pretty.NewChangeMonitor(),
-		cache: cache.New(10*time.Minute, 1*time.Minute),
+		ec2: ec2,
+		cm:  pretty.NewChangeMonitor(),
+		cache: &availabilityCache{
+			cache: cache,
+			clk:   clock.RealClock{},
+		},
 	}
 }
 
 // GetReservedInstances gets all reserved instances and adds them to the cache
 func (p *DefaultProvider) GetReservedInstances(ctx context.Context) ([]*ReservedInstance, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if cached, ok := p.cache.Get(cacheKey); ok {
-		return cached.([]*ReservedInstance), nil
+	// return from cache if it's already populated
+	reservedInstances := p.buildReservedInstancesFromCache()
+	if len(reservedInstances) > 0 {
+		return reservedInstances, nil
 	}
 
-	// 1. Get all active Reserved Instances
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// After we acquire the lock, we need to re-validate that the cache is empty. It's possible that another
+	// thread acquired the lock and populated the cache while we were waiting.
+	reservedInstances = p.buildReservedInstancesFromCache()
+	if len(reservedInstances) > 0 {
+		return reservedInstances, nil
+	}
+
 	riOutput, err := p.ec2.DescribeReservedInstances(ctx, &ec2.DescribeReservedInstancesInput{
 		Filters: []ec2types.Filter{
 			{
@@ -73,7 +95,6 @@ func (p *DefaultProvider) GetReservedInstances(ctx context.Context) ([]*Reserved
 		return nil, fmt.Errorf("describing reserved instances, %w", err)
 	}
 
-	// 2. Get all running EC2 instances that could be consuming RIs
 	instanceOutput, err := p.ec2.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		Filters: []ec2types.Filter{
 			{
@@ -82,7 +103,7 @@ func (p *DefaultProvider) GetReservedInstances(ctx context.Context) ([]*Reserved
 			},
 			{
 				Name:   lo.ToPtr("tenancy"),
-				Values: []string{string(ec2types.TenancyDefault)}, // RIs apply to default tenancy
+				Values: []string{string(ec2types.TenancyDefault)},
 			},
 		},
 	})
@@ -90,52 +111,79 @@ func (p *DefaultProvider) GetReservedInstances(ctx context.Context) ([]*Reserved
 		return nil, fmt.Errorf("describing instances, %w", err)
 	}
 
-	// 3. Calculate available RIs and cache the result
-	reservedInstances := p.buildReservedInstances(riOutput.ReservedInstances, instanceOutput.Reservations)
-	p.cache.SetDefault(cacheKey, reservedInstances)
+	p.updateCache(riOutput.ReservedInstances, instanceOutput.Reservations)
+
+	reservedInstances = p.buildReservedInstancesFromCache()
 	if p.cm.HasChanged(cacheKey, reservedInstances) {
 		pretty.FriendlyDiff(p.cm.Previous(cacheKey), p.cm.Current(cacheKey))
 	}
 	return reservedInstances, nil
 }
 
-func (p *DefaultProvider) buildReservedInstances(ris []ec2types.ReservedInstances, reservations []ec2types.Reservation) []*ReservedInstance {
-	// Group running instances by type and AZ for efficient lookup
+func (p *DefaultProvider) MarkLaunched(instanceType ec2types.InstanceType, zone string) {
+	p.cache.MarkLaunched(instanceType, zone)
+}
+
+func (p *DefaultProvider) MarkTerminated(instanceType ec2types.InstanceType, zone string) {
+	p.cache.MarkTerminated(instanceType, zone)
+}
+
+func (p *DefaultProvider) updateCache(ris []ec2types.ReservedInstances, reservations []ec2types.Reservation) {
 	runningInstances := make(instanceCounts)
 	for _, res := range reservations {
 		for _, inst := range res.Instances {
 			if _, ok := runningInstances[inst.InstanceType]; !ok {
 				runningInstances[inst.InstanceType] = make(map[string]int32)
 			}
-			// We only consider Linux instances for RIs
 			if inst.Platform != ec2types.PlatformValuesWindows {
 				runningInstances[inst.InstanceType][*inst.Placement.AvailabilityZone]++
 			}
 		}
 	}
 
-	var availableRIs []*ReservedInstance
-	// Filter out expired RIs and those with dedicated tenancy
+	purchasedRIs := make(instanceCounts)
 	activeRIs := lo.Filter(ris, func(r ec2types.ReservedInstances, _ int) bool {
 		return r.End.After(time.Now()) && r.InstanceTenancy == ec2types.TenancyDefault
 	})
-
 	for _, ri := range activeRIs {
-		runningCount := int32(0)
-		if _, ok := runningInstances[ri.InstanceType]; ok {
-			runningCount = runningInstances[ri.InstanceType][*ri.AvailabilityZone]
+		if _, ok := purchasedRIs[ri.InstanceType]; !ok {
+			purchasedRIs[ri.InstanceType] = make(map[string]int32)
 		}
+		purchasedRIs[ri.InstanceType][*ri.AvailabilityZone] += *ri.InstanceCount
+	}
 
-		availableCount := *ri.InstanceCount - runningCount
-		if availableCount > 0 {
-			availableRIs = append(availableRIs, &ReservedInstance{
-				ID:               *ri.ReservedInstancesId,
-				InstanceType:     ri.InstanceType,
-				InstanceCount:    availableCount, // Only expose the available count
-				AvailabilityZone: *ri.AvailabilityZone,
-				State:            ri.State,
+	availability := make(map[string]*availabilityCacheEntry)
+	for instType, zones := range purchasedRIs {
+		for zone, count := range zones {
+			runningCount := int32(0)
+			if _, ok := runningInstances[instType]; ok {
+				runningCount = runningInstances[instType][zone]
+			}
+			availableCount := count - runningCount
+			key := p.cache.makeCacheKey(instType, zone)
+			availability[key] = &availabilityCacheEntry{
+				count: lo.Max(0, availableCount),
+				total: count,
+			}
+		}
+	}
+	p.cache.syncAvailability(availability)
+}
+
+func (p *DefaultProvider) buildReservedInstancesFromCache() []*ReservedInstance {
+	var reservedInstances []*ReservedInstance
+	for key, item := range p.cache.cache.Items() {
+		entry := item.Object.(*availabilityCacheEntry)
+		if entry.count > 0 {
+			instanceType, zone := p.cache.decodeCacheKey(key)
+			reservedInstances = append(reservedInstances, &ReservedInstance{
+				ID:               fmt.Sprintf("ri-%s-%s", instanceType, zone),
+				InstanceType:     instanceType,
+				InstanceCount:    entry.count,
+				AvailabilityZone: zone,
+				State:            ec2types.ReservedInstanceStateActive,
 			})
 		}
 	}
-	return availableRIs
+	return reservedInstances
 }

--- a/pkg/providers/reservedinstance/provider.go
+++ b/pkg/providers/reservedinstance/provider.go
@@ -1,0 +1,141 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedinstance
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/patrickmn/go-cache"
+	"github.com/samber/lo"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+
+	"github.com/aws/karpenter-provider-aws/pkg/aws"
+)
+
+const (
+	cacheKey = "reserved-instances"
+)
+
+// DefaultProvider is the reserved instance provider using the AWS API to get reserved instance information
+type DefaultProvider struct {
+	ec2   aws.EC2API
+	cache *cache.Cache
+	cm    *pretty.ChangeMonitor
+	mu    sync.Mutex
+}
+
+type instanceCounts map[ec2types.InstanceType]map[string]int32
+
+// NewDefaultProvider constructs a new DefaultProvider
+func NewDefaultProvider(ec2 aws.EC2API) *DefaultProvider {
+	return &DefaultProvider{
+		ec2:   ec2,
+		cm:    pretty.NewChangeMonitor(),
+		cache: cache.New(10*time.Minute, 1*time.Minute),
+	}
+}
+
+// GetReservedInstances gets all reserved instances and adds them to the cache
+func (p *DefaultProvider) GetReservedInstances(ctx context.Context) ([]*ReservedInstance, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if cached, ok := p.cache.Get(cacheKey); ok {
+		return cached.([]*ReservedInstance), nil
+	}
+
+	// 1. Get all active Reserved Instances
+	riOutput, err := p.ec2.DescribeReservedInstances(ctx, &ec2.DescribeReservedInstancesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("state"),
+				Values: []string{string(ec2types.ReservedInstanceStateActive)},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describing reserved instances, %w", err)
+	}
+
+	// 2. Get all running EC2 instances that could be consuming RIs
+	instanceOutput, err := p.ec2.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   lo.ToPtr("instance-state-name"),
+				Values: []string{string(ec2types.InstanceStateNameRunning)},
+			},
+			{
+				Name:   lo.ToPtr("tenancy"),
+				Values: []string{string(ec2types.TenancyDefault)}, // RIs apply to default tenancy
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describing instances, %w", err)
+	}
+
+	// 3. Calculate available RIs and cache the result
+	reservedInstances := p.buildReservedInstances(riOutput.ReservedInstances, instanceOutput.Reservations)
+	p.cache.SetDefault(cacheKey, reservedInstances)
+	if p.cm.HasChanged(cacheKey, reservedInstances) {
+		pretty.FriendlyDiff(p.cm.Previous(cacheKey), p.cm.Current(cacheKey))
+	}
+	return reservedInstances, nil
+}
+
+func (p *DefaultProvider) buildReservedInstances(ris []ec2types.ReservedInstances, reservations []ec2types.Reservation) []*ReservedInstance {
+	// Group running instances by type and AZ for efficient lookup
+	runningInstances := make(instanceCounts)
+	for _, res := range reservations {
+		for _, inst := range res.Instances {
+			if _, ok := runningInstances[inst.InstanceType]; !ok {
+				runningInstances[inst.InstanceType] = make(map[string]int32)
+			}
+			// We only consider Linux instances for RIs
+			if inst.Platform != ec2types.PlatformValuesWindows {
+				runningInstances[inst.InstanceType][*inst.Placement.AvailabilityZone]++
+			}
+		}
+	}
+
+	var availableRIs []*ReservedInstance
+	// Filter out expired RIs and those with dedicated tenancy
+	activeRIs := lo.Filter(ris, func(r ec2types.ReservedInstances, _ int) bool {
+		return r.End.After(time.Now()) && r.InstanceTenancy == ec2types.TenancyDefault
+	})
+
+	for _, ri := range activeRIs {
+		runningCount := int32(0)
+		if _, ok := runningInstances[ri.InstanceType]; ok {
+			runningCount = runningInstances[ri.InstanceType][*ri.AvailabilityZone]
+		}
+
+		availableCount := *ri.InstanceCount - runningCount
+		if availableCount > 0 {
+			availableRIs = append(availableRIs, &ReservedInstance{
+				ID:               *ri.ReservedInstancesId,
+				InstanceType:     ri.InstanceType,
+				InstanceCount:    availableCount, // Only expose the available count
+				AvailabilityZone: *ri.AvailabilityZone,
+				State:            ri.State,
+			})
+		}
+	}
+	return availableRIs
+}

--- a/pkg/providers/reservedinstance/types.go
+++ b/pkg/providers/reservedinstance/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reservedinstance
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"

--- a/pkg/providers/reservedinstance/types.go
+++ b/pkg/providers/reservedinstance/types.go
@@ -75,9 +75,7 @@ func (c *availabilityCache) MarkLaunched(instanceType ec2types.InstanceType, zon
 	key := c.makeCacheKey(instanceType, zone)
 	if entry, ok := c.cache.Get(key); ok {
 		cacheEntry := entry.(*availabilityCacheEntry)
-		if cacheEntry.count > 0 {
-			cacheEntry.count--
-		}
+		cacheEntry.count--
 	}
 }
 

--- a/pkg/providers/reservedinstance/types.go
+++ b/pkg/providers/reservedinstance/types.go
@@ -1,0 +1,38 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package reservedinstance provides types and methods for querying and managing
+// EC2 Reserved Instances.
+package reservedinstance
+
+import (
+	"context"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// ReservedInstance is a struct that defines the parameters for an EC2 Reserved Instance.
+type ReservedInstance struct {
+	ID               string
+	InstanceType     ec2types.InstanceType
+	InstanceCount    int32
+	AvailabilityZone string
+	State            ec2types.ReservedInstanceState
+}
+
+// Provider is an interface for getting reserved instance data.
+type Provider interface {
+	// GetReservedInstances returns all reserved instances for a given set of queries.
+	GetReservedInstances(context.Context) ([]*ReservedInstance, error)
+}

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/reservedinstance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/securitygroup"
@@ -155,7 +156,8 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
 	instanceTypesResolver := instancetype.NewDefaultResolver(fake.DefaultRegion)
 	capacityReservationProvider := capacityreservation.NewProvider(ec2api, clock, capacityReservationCache, capacityReservationAvailabilityCache)
-	instanceTypesProvider := instancetype.NewDefaultProvider(instanceTypeCache, offeringCache, discoveredCapacityCache, ec2api, subnetProvider, pricingProvider, capacityReservationProvider, unavailableOfferingsCache, instanceTypesResolver)
+	reservedInstanceProvider := reservedinstance.NewDefaultProvider(ec2api, cache.New(awscache.ReservedInstancePriceTTL, awscache.DefaultCleanupInterval))
+	instanceTypesProvider := instancetype.NewDefaultProvider(instanceTypeCache, offeringCache, discoveredCapacityCache, ec2api, subnetProvider, pricingProvider, capacityReservationProvider, unavailableOfferingsCache, reservedInstanceProvider, instanceTypesResolver)
 	// Ensure we're able to hydrate instance types before starting any reliant controllers.
 	// Instance type updates are hydrated asynchronously after this by controllers.
 	lo.Must0(instanceTypesProvider.UpdateInstanceTypes(ctx))
@@ -186,6 +188,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		subnetProvider,
 		launchTemplateProvider,
 		capacityReservationProvider,
+		reservedInstanceProvider,
 		instanceCache,
 	)
 


### PR DESCRIPTION
**Description**

This is a fairly straightforward but important feature to make Karpenter more cost-aware for anyone with existing AWS commitments.

The problem is simple: Karpenter has been blind to Reserved Instances (RIs) unless they are explicitly tied to a Capacity Reservation. This means that if you've bought Standard or Convertible RIs to save money, Karpenter would happily ignore them and go off to launch new, more expensive On-Demand or Spot instances. This is just leaving money on the table and makes Karpenter less effective for anyone trying to optimize their AWS bill.

This change fixes that by making Karpenter RI-aware.

The core of the change is a new, dedicated `ReservedInstanceProvider`. I've put this in its own `pkg/providers/reservedinstance` package because RIs are a distinct concept from Capacity Reservations, and mixing the two would have been a mess. The new provider is responsible for one thing: figuring out which RIs are actually available for use *right now*.

Getting this right is non-trivial. You can't just use the billing or Cost Explorer APIs (`GetReservationUtilization`, etc.) because that data can be up to 24 hours stale. A scheduler can't work with stale data. The only reliable way to get a real-time view is to:
1.  Fetch all `active` Reserved Instances (`DescribeReservedInstances`).
2.  Fetch all `running` instances that could be consuming those RIs (`DescribeInstances`).
3.  Do the math. Subtract the running instances from the purchased RIs to get the true available count.

This is exactly what the new provider does. It's the only sane approach for real-time accuracy. To avoid hammering the EC2 API on every single provisioning loop, the results are cached for 10 minutes, which is a reasonable trade-off between data freshness and API load.

With the new provider in place, the rest is simple:
- It's plumbed through the main operator startup in `pkg/operator/operator.go`.
- It's injected into the `offering.Provider` in `pkg/providers/instancetype/offering/offering.go`.
- The `offering.Provider` now uses this data to create new `reserved` offerings.

These new RI-based offerings are priced using the same trick we already use for Capacity Reservations: the on-demand price is divided by a ridiculously large number. This makes them effectively "free" in the eyes of the scheduler, ensuring they are always picked first if they match the requirements.

This closes a significant gap in Karpenter's cost-optimization strategy and makes it behave the way users would expect.

**How was this change tested?**

Ran `make ci-test` without issues.

End-to-end testing of Reservation features on AWS isn’t practical here, the costs are prohibitive. If you know a sane way to do real-world testing without racking up a giant bill, let me know.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No