### PR TITLE
docs: change preview url link

### DIFF
--- a/website/content/en/docs/contributing/documentation-updates.md
+++ b/website/content/en/docs/contributing/documentation-updates.md
@@ -8,4 +8,4 @@ description: >
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
 - Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
-- Previews for your changes are built and available a few minutes after you push. Look for the "netlify Deploy Preview" link in a comment in your PR.
+- Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.

--- a/website/content/en/preview/contributing/documentation-updates.md
+++ b/website/content/en/preview/contributing/documentation-updates.md
@@ -8,4 +8,4 @@ description: >
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
 - Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
-- Previews for your changes are built and available a few minutes after you push. Look for the "netlify Deploy Preview" link in a comment in your PR.
+- Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.

--- a/website/content/en/v1.0/contributing/documentation-updates.md
+++ b/website/content/en/v1.0/contributing/documentation-updates.md
@@ -8,4 +8,4 @@ description: >
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
 - Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
-- Previews for your changes are built and available a few minutes after you push. Look for the "netlify Deploy Preview" link in a comment in your PR.
+- Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.

--- a/website/content/en/v1.6/contributing/documentation-updates.md
+++ b/website/content/en/v1.6/contributing/documentation-updates.md
@@ -8,4 +8,4 @@ description: >
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
 - Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
-- Previews for your changes are built and available a few minutes after you push. Look for the "netlify Deploy Preview" link in a comment in your PR.
+- Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.

--- a/website/content/en/v1.7/contributing/documentation-updates.md
+++ b/website/content/en/v1.7/contributing/documentation-updates.md
@@ -8,4 +8,4 @@ description: >
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
 - Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
-- Previews for your changes are built and available a few minutes after you push. Look for the "netlify Deploy Preview" link in a comment in your PR.
+- Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.

--- a/website/content/en/v1.8/contributing/documentation-updates.md
+++ b/website/content/en/v1.8/contributing/documentation-updates.md
@@ -8,4 +8,4 @@ description: >
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
 - Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
-- Previews for your changes are built and available a few minutes after you push. Look for the "netlify Deploy Preview" link in a comment in your PR.
+- Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
* change preview link description from `netlify Deploy Preview` to `Amplify Preview URL` in development docs

**How was this change tested?**
* see preview website url

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.