### PR TITLE
chore: Add spot offering filter

### DIFF
--- a/.github/actions/e2e/run-tests-private-cluster/action.yaml
+++ b/.github/actions/e2e/run-tests-private-cluster/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: "Account ID to access AWS"
     required: true
   suite:
-    type: string
+    description: "Test suite to run"
     required: true
   ecr_account_id:
     description: "Account ID to access ECR Repository"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/pkg/providers/instance/filter/filter.go
+++ b/pkg/providers/instance/filter/filter.go
@@ -325,22 +325,21 @@ func (exoticInstanceFilter) Name() string {
 	return "exotic-instance-filter"
 }
 
-// SpotInstanceFilter removes all instances with spot offerings which are more expensive than the cheapest compatible
-// and available on-demand offering. This ensures we don't launch with a more expensive spot instance for a mixed-launch
-// NodeClaim. Note that instance types with available, compatible reserved offerings will not be filtered out.
+// SpotOfferingFilter removes spot offerings that are more expensive than the cheapest compatible and available
+// on-demand offering. This ensures we don't launch with a more expensive spot instance for a mixed-launch NodeClaim.
 // NOTE: This filter assumes all provided instance types have compatible and available offerings
-func SpotInstanceFilter(requirements scheduling.Requirements) Filter {
-	return spotInstanceFilter{
+func SpotOfferingFilter(requirements scheduling.Requirements) Filter {
+	return spotOfferingFilter{
 		requirements: requirements,
 	}
 }
 
-type spotInstanceFilter struct {
+type spotOfferingFilter struct {
 	requirements scheduling.Requirements
 }
 
 //nolint:gocyclo
-func (f spotInstanceFilter) FilterReject(instanceTypes []*cloudprovider.InstanceType) ([]*cloudprovider.InstanceType, []*cloudprovider.InstanceType) {
+func (f spotOfferingFilter) FilterReject(instanceTypes []*cloudprovider.InstanceType) ([]*cloudprovider.InstanceType, []*cloudprovider.InstanceType) {
 	if f.requirements.HasMinValues() {
 		return instanceTypes, nil
 	}
@@ -367,28 +366,27 @@ func (f spotInstanceFilter) FilterReject(instanceTypes []*cloudprovider.Instance
 		return instanceTypes, nil
 	}
 
-	// Filter out any types where the cheapest spot offering is more expensive than the cheapest on-demand instance type
-	// that would have worked. This prevents us from getting a larger, more-expensive spot instance type compared to the
-	// cheapest sufficiently large on-demand instance type.
-	return lo.FilterReject(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
-		var hasSpotOffering bool
-		for _, o := range it.Offerings.Compatible(f.requirements).Available() {
-			// Always include instance types which have compatible, available reserved offerings since they're modeled as free
-			if o.CapacityType() == karpv1.CapacityTypeReserved {
-				return true
+	var remaining []*cloudprovider.InstanceType
+	for _, it := range instanceTypes {
+		filteredOfferings := lo.Filter(it.Offerings, func(o *cloudprovider.Offering, _ int) bool {
+			if o.CapacityType() == karpv1.CapacityTypeSpot && o.Price > cheapestOnDemand {
+				return false
 			}
-			// If the offering is spot and cheaper than the cheapest on-demand instance type, include the instance type
-			if o.CapacityType() == karpv1.CapacityTypeSpot {
-				hasSpotOffering = true
-				if o.Price <= cheapestOnDemand {
-					return true
-				}
-			}
+			return true
+		})
+		if len(filteredOfferings) > 0 {
+			// WARNING: It is only safe to mutate the slice containing the offerings, not the offerings themselves. The individual
+			// offerings are cached, but not the slice storing them. This helps keep the launch path simple, but changes to the
+			// caching strategy employed by the InstanceType provider could result in unexpected behavior.
+			it.Offerings = filteredOfferings
+			remaining = append(remaining, it)
 		}
-		return !hasSpotOffering
+	}
+	return remaining, lo.Reject(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
+		return lo.Contains(remaining, it)
 	})
 }
 
-func (spotInstanceFilter) Name() string {
-	return "spot-instance-filter"
+func (spotOfferingFilter) Name() string {
+	return "spot-offering-filter"
 }

--- a/pkg/providers/instance/filter/filter_test.go
+++ b/pkg/providers/instance/filter/filter_test.go
@@ -508,143 +508,130 @@ var _ = Describe("InstanceFiltersTest", func() {
 		})
 	})
 
-	Context("SpotInstanceFilter", func() {
-		It("should reject spot instances whose cheapest offering is more expensive than the cheapest on-demand offering", func() {
-			f := filter.SpotInstanceFilter(scheduling.NewRequirements(scheduling.NewRequirement(
-				karpv1.CapacityTypeLabelKey,
-				corev1.NodeSelectorOpExists,
-			)))
-			kept, rejected := f.FilterReject([]*cloudprovider.InstanceType{
-				// Include an expensive on-demand offering to ensure we're comparing against the cheapest. On-demand instances
-				// should always be kept.
-				makeInstanceType("expensive-od-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(15.0)),
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(15.0)),
-				)),
-				// On-demand instances should always be kept
-				makeInstanceType("od-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(5.0)), // cheapest od offering
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(10.0)),
-				)),
-				// Instance should be kept because all offerings are cheaper than the cheapest od instance
-				makeInstanceType("cheap-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0)),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(2.0)),
-				)),
-				// Instance should be kept since it contains a single cheaper offering
-				makeInstanceType("mixed-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0)),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0)),
-				)),
-				// Instance should be rejected because although it has a cheaper offering, that offering is not available
-				makeInstanceType("mixed-unavailable-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, false, withPrice(1.0)),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0)),
-				)),
-				// Instance should be rejected because all offerings are more expensive than the cheapest on-demand offering
-				makeInstanceType("expensive-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0)),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0)),
-				)),
-			})
-			expectInstanceTypes(kept, "expensive-od-instance", "od-instance", "cheap-spot-instance", "mixed-spot-instance")
-			expectInstanceTypes(rejected, "mixed-unavailable-spot-instance", "expensive-spot-instance")
-		})
-		It("should not reject spot instances whose cheapest offering is more expensive than the cheapest on-demand offering if it is only compatible with spot", func() {
-			f := filter.SpotInstanceFilter(scheduling.NewRequirements(
+	Context("SpotOfferingFilter", func() {
+		It("should filter out expensive spot offerings while keeping instance types with remaining offerings", func() {
+			f := filter.SpotOfferingFilter(scheduling.NewRequirements(
 				scheduling.NewRequirement(
 					karpv1.CapacityTypeLabelKey,
 					corev1.NodeSelectorOpExists,
 				),
 				scheduling.NewRequirement(
-					corev1.LabelTopologyZone,
-					corev1.NodeSelectorOpIn,
-					"zone-1a",
-					"zone-1b",
+					"test.karpenter.sh/tag",
+					corev1.NodeSelectorOpExists,
 				),
 			))
-
-			keptInstanceTypes := []*cloudprovider.InstanceType{
-				// Include an expensive on-demand offering to ensure we're comparing against the cheapest. On-demand instances
-				// should always be kept.
-				makeInstanceType("expensive-od-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(15.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(15.0), withZone("zone-1b")),
-				)),
-				// On-demand instances should always be kept
-				makeInstanceType("od-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(5.0), withZone("zone-1a")), // cheapest od offering
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(10.0), withZone("zone-1b")),
-				)),
-				// Instance should be kept because all offerings are cheaper than the cheapest od instance
-				makeInstanceType("cheap-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(2.0), withZone("zone-1b")),
-				)),
-				// Instance should be kept since it contains a single cheaper offering
-				makeInstanceType("mixed-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1b")),
-				)),
-				// Instance should be kept since it contains an offering in a compatible zone cheaper than the cheapest od offering
-				makeInstanceType("mixed-compatible-available-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1c")),
-				)),
-				// Instance should be kept since it contains a reserved offering
-				makeInstanceType("reserved-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1b")),
-					makeOffering(karpv1.CapacityTypeReserved, true, withZone("zone-1b")),
-				)),
-			}
-			rejectedInstanceTypes := []*cloudprovider.InstanceType{
-				// Instance should be rejected because although it has a cheaper offering, that offering is not available
-				makeInstanceType("mixed-unavailable-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, false, withPrice(1.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1b")),
-				)),
-				// Instance should be rejected since it does not contain an offering in a compatible zone cheaper than the
-				// cheapest od offering
-				makeInstanceType("mixed-compatible-unavailable-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0), withZone("zone-1c")),
-				)),
-				// Instance should be rejected because all offerings are more expensive than the cheapest on-demand offering
-				makeInstanceType("expensive-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1a")),
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withZone("zone-1b")),
-				)),
-			}
-
-			kept, rejected := f.FilterReject(lo.Flatten([][]*cloudprovider.InstanceType{keptInstanceTypes, rejectedInstanceTypes}))
-			expectInstanceTypes(kept, lo.Map(keptInstanceTypes, func(it *cloudprovider.InstanceType, _ int) string { return it.Name })...)
-			expectInstanceTypes(rejected, lo.Map(rejectedInstanceTypes, func(it *cloudprovider.InstanceType, _ int) string { return it.Name })...)
-		})
-		It("should not reject instances if the nodeclaim is only compatible with spot", func() {
-			f := filter.SpotInstanceFilter(scheduling.NewRequirements(scheduling.NewRequirement(
-				karpv1.CapacityTypeLabelKey,
-				corev1.NodeSelectorOpIn,
-				karpv1.CapacityTypeSpot,
-			)))
 			kept, rejected := f.FilterReject([]*cloudprovider.InstanceType{
+				// On-demand instance should be kept with all offerings
 				makeInstanceType("od-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(5.0)),
+					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(5.0), withTag("kept")), // cheapest od offering
+					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(10.0), withTag("kept")),
 				)),
+				// Instance with cheap spot offerings should be kept with all offerings
 				makeInstanceType("cheap-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0)),
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0), withTag("kept")),
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(2.0), withTag("kept")),
 				)),
-				makeInstanceType("expensive-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0)),
+				// Instance with mixed spot offerings should be kept but expensive spot offering filtered out
+				makeInstanceType("mixed-spot-instance", withOfferings(
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0), withTag("kept")),
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withTag("rejected")), // should be filtered
 				)),
 			})
-			expectInstanceTypes(kept, "od-instance", "cheap-spot-instance", "expensive-spot-instance")
+			expectInstanceTypes(kept, "od-instance", "cheap-spot-instance", "mixed-spot-instance")
 			Expect(rejected).To(BeEmpty())
+			Expect(lo.Map(kept, func(it *cloudprovider.InstanceType, _ int) int {
+				return len(it.Offerings)
+			})).To(ConsistOf(2, 2, 1))
+			// Check that all kept offerings have tag="kept"
+			for _, it := range kept {
+				for _, o := range it.Offerings {
+					Expect(o.Requirements.Get("test.karpenter.sh/tag").Any()).To(Equal("kept"))
+				}
+			}
 		})
-		It("should not reject instances if minValues is set", func() {
-			f := filter.SpotInstanceFilter(scheduling.NewRequirements(
+		It("should reject instance types with no remaining offerings after filtering", func() {
+			f := filter.SpotOfferingFilter(scheduling.NewRequirements(
 				scheduling.NewRequirement(
 					karpv1.CapacityTypeLabelKey,
+					corev1.NodeSelectorOpExists,
+				),
+				scheduling.NewRequirement(
+					"test.karpenter.sh/tag",
+					corev1.NodeSelectorOpExists,
+				),
+			))
+			kept, rejected := f.FilterReject([]*cloudprovider.InstanceType{
+				makeInstanceType("od-instance", withOfferings(
+					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(5.0), withTag("kept")),
+				)),
+				// Instance with only expensive spot offerings should be rejected
+				makeInstanceType("expensive-spot-instance", withOfferings(
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withTag("kept")),
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(15.0), withTag("kept")),
+				)),
+			})
+			expectInstanceTypes(kept, "od-instance")
+			expectInstanceTypes(rejected, "expensive-spot-instance")
+			Expect(kept[0].Offerings).To(HaveLen(1))
+			for _, o := range kept[0].Offerings {
+				Expect(o.Requirements.Get("test.karpenter.sh/tag").Any()).To(Equal("kept"))
+			}
+		})
+		It("should not filter when no on-demand offerings exist", func() {
+			f := filter.SpotOfferingFilter(scheduling.NewRequirements(
+				scheduling.NewRequirement(
+					karpv1.CapacityTypeLabelKey,
+					corev1.NodeSelectorOpExists,
+				),
+				scheduling.NewRequirement(
+					"test.karpenter.sh/tag",
+					corev1.NodeSelectorOpExists,
+				),
+			))
+			kept, rejected := f.FilterReject([]*cloudprovider.InstanceType{
+				makeInstanceType("spot-instance", withOfferings(
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withTag("kept")),
+				)),
+			})
+			expectInstanceTypes(kept, "spot-instance")
+			Expect(rejected).To(BeEmpty())
+			Expect(kept[0].Offerings).To(HaveLen(1))
+			for _, o := range kept[0].Offerings {
+				Expect(o.Requirements.Get("test.karpenter.sh/tag").Any()).To(Equal("kept"))
+			}
+		})
+		It("should not filter when requirements don't support both spot and on-demand", func() {
+			f := filter.SpotOfferingFilter(scheduling.NewRequirements(
+				scheduling.NewRequirement(
+					karpv1.CapacityTypeLabelKey,
+					corev1.NodeSelectorOpIn,
+					karpv1.CapacityTypeSpot,
+				),
+				scheduling.NewRequirement(
+					"test.karpenter.sh/tag",
+					corev1.NodeSelectorOpExists,
+				),
+			))
+			kept, rejected := f.FilterReject([]*cloudprovider.InstanceType{
+				makeInstanceType("spot-instance", withOfferings(
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withTag("kept")),
+				)),
+			})
+			expectInstanceTypes(kept, "spot-instance")
+			Expect(rejected).To(BeEmpty())
+			Expect(kept[0].Offerings).To(HaveLen(1))
+			for _, o := range kept[0].Offerings {
+				Expect(o.Requirements.Get("test.karpenter.sh/tag").Any()).To(Equal("kept"))
+			}
+		})
+		It("should not filter when minValues is set", func() {
+			f := filter.SpotOfferingFilter(scheduling.NewRequirements(
+				scheduling.NewRequirement(
+					karpv1.CapacityTypeLabelKey,
+					corev1.NodeSelectorOpExists,
+				),
+				scheduling.NewRequirement(
+					"test.karpenter.sh/tag",
 					corev1.NodeSelectorOpExists,
 				),
 				scheduling.NewRequirementWithFlexibility(
@@ -655,17 +642,22 @@ var _ = Describe("InstanceFiltersTest", func() {
 			))
 			kept, rejected := f.FilterReject([]*cloudprovider.InstanceType{
 				makeInstanceType("od-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(5.0)),
-				)),
-				makeInstanceType("cheap-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(1.0)),
+					makeOffering(karpv1.CapacityTypeOnDemand, true, withPrice(5.0), withTag("kept")),
 				)),
 				makeInstanceType("expensive-spot-instance", withOfferings(
-					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0)),
+					makeOffering(karpv1.CapacityTypeSpot, true, withPrice(10.0), withTag("kept")),
 				)),
 			})
-			expectInstanceTypes(kept, "od-instance", "cheap-spot-instance", "expensive-spot-instance")
+			expectInstanceTypes(kept, "od-instance", "expensive-spot-instance")
 			Expect(rejected).To(BeEmpty())
+			Expect(lo.Map(kept, func(it *cloudprovider.InstanceType, _ int) int {
+				return len(it.Offerings)
+			})).To(ConsistOf(1, 1))
+			for _, it := range kept {
+				for _, o := range it.Offerings {
+					Expect(o.Requirements.Get("test.karpenter.sh/tag").Any()).To(Equal("kept"))
+				}
+			}
 		})
 	})
 })
@@ -768,6 +760,19 @@ func withZone(zone string) mockOfferingOptions {
 func withPrice(price float64) mockOfferingOptions {
 	return func(o *cloudprovider.Offering) {
 		o.Price = price
+	}
+}
+
+func withTag(tag string) mockOfferingOptions {
+	return func(o *cloudprovider.Offering) {
+		if o.Requirements == nil {
+			o.Requirements = scheduling.NewRequirements()
+		}
+		o.Requirements.Add(scheduling.NewRequirement(
+			"test.karpenter.sh/tag",
+			corev1.NodeSelectorOpIn,
+			tag,
+		))
 	}
 }
 

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -279,7 +279,7 @@ func (p *DefaultProvider) filterInstanceTypes(ctx context.Context, instanceTypes
 		instancefilter.CapacityBlockFilter(reqs),
 		instancefilter.ReservedOfferingFilter(reqs),
 		instancefilter.ExoticInstanceTypeFilter(reqs),
-		instancefilter.SpotInstanceFilter(reqs),
+		instancefilter.SpotOfferingFilter(reqs),
 	} {
 		remaining, rejected := filter.FilterReject(instanceTypes)
 		if len(remaining) == 0 {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes https://github.com/aws/karpenter-provider-aws/issues/8704

**Description**
Added SpotOfferingFilter that filters expensive spot offerings at the offering level (vs instance type level) and extracted common logic into getCheapestOnDemandPrice() helper to reduce code duplication between spot filters. 

- Also updated go version due to vulnerability
-  Update the private-cluster action because we started seeing this error
```
Error: .github/workflows/e2e.yaml:155:15: could not parse action metadata in "/home/runner/work/karpenter-provider-aws/karpenter-provider-aws/.github/actions/e2e/run-tests-private-cluster": line 4: unexpected key "type" for definition of input "suite" [action]
```

**How was this change tested?**
Added unit tests. Tested on my dev custer.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.