### PR TITLE
fix: exponential backoff for EC2NodeClass auth validation retries

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -47,6 +47,10 @@ const (
 	DiscoveredCapacityCacheTTL = 60 * 24 * time.Hour
 	// ValidationTTL is time to check authorization errors with validation controller
 	ValidationTTL = 30 * time.Minute
+	// AuthRetryInitialDelay is the initial retry delay for authorization failures during validation
+	AuthRetryInitialDelay = 30 * time.Second
+	// AuthRetryMaxDelay is the maximum retry delay for authorization failures during validation
+	AuthRetryMaxDelay = 5 * time.Minute
 	// RecreationTTL is the duration to suppress instance profile recreation for the same role to avoid duplicates
 	RecreationTTL = 1 * time.Minute
 	// ProtectedProfilesTTL is the duration to keep profiles as protected before nodeclass garbagecollector considers deletion


### PR DESCRIPTION
fix: exponential backoff for EC2NodeClass auth validation retries

Fixes #8114

**Description**

This PR addresses the issue where EC2NodeClass remains in NotReady state for 30 minutes after IAM permission attachment, even though IAM propagation typically completes within seconds to minutes.

The current implementation uses a fixed 30-minute retry interval for all validation failures, including authorization errors. This was increased from 10 minutes in PR #8439 to reduce API rate limiting. However, this creates a poor UX for the common case of attaching IAM permissions immediately before creating an EC2NodeClass.

Changes:
- Add `AuthRetryInitialDelay` (30s) and `AuthRetryMaxDelay` (5m) constants
- Implement `getAuthRetryDelay()` for exponential backoff calculation (30s -> 60s -> 120s -> 240s -> 5m)
- Apply exponential backoff specifically to authorization failures in:
  - `validateCreateLaunchTemplate`
  - `validateCreateFleet`  
  - `validateRunInstances`
- Clear retry count on successful validation
- Preserve the existing annotation-based cache invalidation workaround for urgent manual intervention

Impact:
- Typical case: EC2NodeClass becomes Ready in ~30 seconds instead of 30 minutes
- API load: For 20 EC2NodeClasses failing simultaneously, increases from 40 requests/30min to ~100 requests/10min before settling at 5-minute intervals
- Backward compatible: Non-auth failures still use 30-minute interval

**How was this change tested?**

- Added unit test `should use exponential backoff for auth failures` to verify:
  - Retry delays follow exponential backoff pattern
  - Maximum delay caps at 5 minutes
  - Retry count resets on successful validation
- Existing validation tests continue to pass

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.