### PR TITLE
chore: use Provider interface in version controller

### DIFF
--- a/pkg/controllers/providers/version/controller.go
+++ b/pkg/controllers/providers/version/controller.go
@@ -31,11 +31,11 @@ import (
 type UpdateVersion func(context.Context) error
 
 type Controller struct {
-	versionProvider *version.DefaultProvider
+	versionProvider version.Provider
 	updateVersion   UpdateVersion
 }
 
-func NewController(versionProvider *version.DefaultProvider, updateVersion UpdateVersion) *Controller {
+func NewController(versionProvider version.Provider, updateVersion UpdateVersion) *Controller {
 	return &Controller{
 		versionProvider: versionProvider,
 		updateVersion:   updateVersion,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Changes the version controller to use the version Provider interface of the DefaultProvider struct.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.