### PR TITLE
temp: enable manual dispatch of release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,11 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        type: string
+
 jobs:
   release:
     permissions:
@@ -16,17 +21,19 @@ jobs:
     if: github.repository == 'aws/karpenter-provider-aws'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-      - name: Create GitHub Release
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
-        with:
-          repo_token: '${{ secrets.GITHUB_TOKEN }}'
-          prerelease: false
+      # TEMP: Skip the GitHub release process and
+      # - name: Create GitHub Release
+      #   uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
+      #   with:
+      #     repo_token: '${{ secrets.GITHUB_TOKEN }}'
+      #     prerelease: false
       - uses: ./.github/actions/install-deps
         with:
           use-cache: false
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref != '' && inputs.git_ref || github.ref }}
       - uses: ./.github/actions/e2e/install-helm
         with:
           version: v3.18.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws
 
-go 1.24.11
+go 1.25.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Temporarily enables a workflow_dispatch trigger for the release workflow and bumps the go version to 1.25.5. This will enable us to workaround the following release failure: https://github.com/aws/karpenter-provider-aws/actions/runs/20243204627/job/58124443314

The release will now work like this:
- A repo owner will trigger a workflow dispatch, specifying the git_ref that was originally released.
- Dependencies will be resolved based on the head of the branch (which uses 1.25.5). This will enable ko to be installed successfully
- We will then checkout the commit to be released, and the rest of the release will proceed as normal.

This PR will be reverted once the release has been cut.

Note: The GitHub release step has been removed as well since the release has already been created.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.