### PR TITLE
[do not merge] chore: add min drain time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/aws/karpenter-provider-aws
 
 go 1.24.6
 
+replace sigs.k8s.io/karpenter => github.com/ryan-mist/karpenter v0.0.0-20251219224046-2af2b40b26fd
+
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/PuerkitoBio/goquery v1.10.3

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/ryan-mist/karpenter v0.0.0-20251219224046-2af2b40b26fd h1:CPgcWTON8e5noEojg8wEURue18rnxzivWCpGZwNqGsQ=
+github.com/ryan-mist/karpenter v0.0.0-20251219224046-2af2b40b26fd/go.mod h1:vTPTH38JguJmS0mTfUKHAH/XcC6Wd0FATl097sWXuLI=
 github.com/samber/lo v1.50.0 h1:XrG0xOeHs+4FQ8gJR97zDz5uOFMW7OwFWiFVzqopKgY=
 github.com/samber/lo v1.50.0/go.mod h1:RjZyNk6WSnUFRKK6EyOhsRJMqft3G+pg7dCWHQCWvsc=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
@@ -361,8 +363,6 @@ sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytI
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
-sigs.k8s.io/karpenter v1.5.4 h1:NcbDQqTKQDJqAGuYcH/nsKjYXpGyS9b6JSM3rfQAUoA=
-sigs.k8s.io/karpenter v1.5.4/go.mod h1:vTPTH38JguJmS0mTfUKHAH/XcC6Wd0FATl097sWXuLI=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
* pulls in https://github.com/kubernetes-sigs/karpenter/pull/2726
* add option `MIN_NODE_DRAIN_TIME` to allow configuration of minimum time we spend draining the Node during termination
  * the check is done by adding an annotation on the Node to indicate when draining started

**How was this change tested?**
* manual testing to ensure annotation is added to the Node and minDrainTime is respected
```
Annotations:        alpha.kubernetes.io/provided-node-ip: 192.168.123.182
...
                    karpenter.sh/disrupted-taint-time: 2025-12-19T13:28:10-08:00
...
CreationTimestamp:  Fri, 19 Dec 2025 10:57:55 -0800
Taints:             karpenter.sh/disrupted:NoSchedule
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.