### PR TITLE
chore: Replace ioutil with io for ReadAll usage

### DIFF
--- a/hack/code/vpc_limits_gen/main.go
+++ b/hack/code/vpc_limits_gen/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -54,7 +54,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer resp.Body.Close()
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
**Description**
Updated the code to use io.ReadAll instead of the deprecated ioutil.ReadAll for reading HTTP response bodies.

**Does this change impact docs?**
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.