### PR TITLE
hack/code/bandwidth_gen/main: Replace lo.Contains(lo.Keys()) with dir…

### DIFF
--- a/hack/code/bandwidth_gen/main.go
+++ b/hack/code/bandwidth_gen/main.go
@@ -116,7 +116,7 @@ func main() {
 	// Generate body
 	var body string
 	for _, instanceType := range lo.Without(allInstanceTypes, instanceTypes...) {
-		if lo.Contains(lo.Keys(vagueBandwidth), instanceType) {
+		if _, ok := vagueBandwidth[instanceType]; ok {
 			body += fmt.Sprintf("// %s has vague bandwidth information, bandwidth is %s\n", instanceType, vagueBandwidth[instanceType])
 			continue
 		}


### PR DESCRIPTION
…ect map lookup

Use native Go map lookup instead of allocating a slice of keys and iterating through it. O(1) vs O(n), zero allocations.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.