### PR TITLE
docs: document Gte and Lte requirement operators

### DIFF
--- a/website/content/en/preview/concepts/nodeoverlays.md
+++ b/website/content/en/preview/concepts/nodeoverlays.md
@@ -36,7 +36,7 @@ spec:
       operator: In
       values: ["spot"]
     - key: karpenter.k8s.aws/instance-cpu 
-      operator: Gt
+      operator: Gte
       values: ["32"]
   
   # Price and priceAdjustment are mutually exclusive

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -85,7 +85,7 @@ spec:
 
       # Requirements that constrain the parameters of provisioned nodes.
       # These requirements are combined with pod.spec.topologySpreadConstraints, pod.spec.affinity.nodeAffinity, pod.spec.affinity.podAffinity, and pod.spec.nodeSelector rules.
-      # Operators { In, NotIn, Exists, DoesNotExist, Gt, and Lt } are supported.
+      # Operators { In, NotIn, Exists, DoesNotExist, Gt, Lt, Gte, and Lte } are supported.
       # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#operators
       requirements:
         - key: "karpenter.k8s.aws/instance-category"
@@ -105,8 +105,8 @@ spec:
           operator: In
           values: ["nitro"]
         - key: "karpenter.k8s.aws/instance-generation"
-          operator: Gt
-          values: ["2"]
+          operator: Gte
+          values: ["3"]
         - key: "topology.kubernetes.io/zone"
           operator: In
           values: ["us-west-2a", "us-west-2b"]
@@ -306,8 +306,8 @@ spec:
           operator: Exists
           minValues: 10
         - key: karpenter.k8s.aws/instance-generation
-          operator: Gt
-          values: ["2"]
+          operator: Gte
+          values: ["3"]
 ```
 
 Note that `minValues` can be used with multiple operators and multiple requirements. And if the `minValues` are defined with multiple operators for the same requirement key, scheduler considers the max of all the `minValues` for that requirement. For example, the below spec requires scheduler to consider at least 5 instance-family to schedule the pods.
@@ -338,8 +338,8 @@ spec:
           operator: Exists
           minValues: 10
         - key: karpenter.k8s.aws/instance-generation
-          operator: Gt
-          values: ["2"]
+          operator: Gte
+          values: ["3"]
 ```
 
 {{% alert title="Recommended" color="primary" %}}
@@ -365,8 +365,8 @@ spec:
           operator: In
           values: ["c", "m", "r"]
         - key: karpenter.k8s.aws/instance-generation
-          operator: Gt
-          values: ["2"]
+          operator: Gte
+          values: ["3"]
 ```
 
 {{% /alert %}}

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -138,6 +138,10 @@ This can include well-known labels or custom labels you create yourself.
 
 You can use `affinity` to define more complicated constraints, see [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for the complete specification.
 
+{{% alert title="Note" color="primary" %}}
+Karpenter extends the upstream Kubernetes requirement operators with `Gte` (>=) and `Lte` (<=) for more intuitive numeric comparisons on labels like `karpenter.k8s.aws/instance-cpu` or `karpenter.k8s.aws/instance-memory`.
+{{% /alert %}}
+
 ### Labels
 Well-known labels may be specified as NodePool requirements or pod scheduling constraints. You can also define your own custom labels by specifying `requirements` or `labels` on your NodePool and select them using `nodeAffinity` or `nodeSelectors` on your Pods.
 
@@ -616,8 +620,8 @@ Pod example of requiring at least 100GB of NVME disk:
        nodeSelectorTerms:
          - matchExpressions:
             - key: "karpenter.k8s.aws/instance-local-nvme"
-              operator: Gt
-              values: ["99"]
+              operator: Gte
+              values: ["100"]
 ...
 ```
 
@@ -626,8 +630,8 @@ NodePool Example:
 ...
 requirement:
   - key: "karpenter.k8s.aws/instance-local-nvme"
-    operator: Gt
-    values: ["99"]
+    operator: Gte
+    values: ["100"]
 ...
 ```
 
@@ -647,8 +651,8 @@ Pod example of requiring at least 50 Gbps of network bandwidth:
        nodeSelectorTerms:
          - matchExpressions:
             - key: "karpenter.k8s.aws/instance-network-bandwidth"
-              operator: Gt
-              values: ["49999"]
+              operator: Gte
+              values: ["50000"]
 ...
 ```
 
@@ -657,14 +661,10 @@ NodePool Example:
 ...
 requirement:
   - key: "karpenter.k8s.aws/instance-network-bandwidth"
-    operator: Gt
-    values: ["49999"]
+    operator: Gte
+    values: ["50000"]
 ...
 ```
-
-{{% alert title="Note" color="primary" %}}
-If using Gt/Lt operators, make sure to use values under the actual label values of the desired resource.
-{{% /alert %}}
 
 ### `Exists` Operator
 


### PR DESCRIPTION
Documents the new `Gte` (>=) and `Lte` (<=) requirement operators added in kubernetes-sigs/karpenter#2674.

Changes:
- Add note in scheduling.md explaining Karpenter extends upstream operators with Gte/Lte
- Update supported operators list in nodepools.md to include Gte and Lte
- Update all Gt examples to use Gte for better ergonomics