### PR TITLE
fix: Use correct 500Mi eviction threshold for Windows nodes (#8473)

### DIFF
--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1324,6 +1324,33 @@ var _ = Describe("InstanceTypeProvider", func() {
 					)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				})
+				It("should use 500Mi default eviction threshold for Windows nodes when evictionHard not specified", func() {
+					windowsNodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
+						SystemReserved: map[string]string{
+							string(corev1.ResourceMemory): "20Gi",
+						},
+						KubeReserved: map[string]string{
+							string(corev1.ResourceMemory): "10Gi",
+						},
+					}
+					it := instancetype.NewInstanceType(ctx,
+						info,
+						fake.DefaultRegion,
+						nil,
+						nil,
+						windowsNodeClass.Spec.BlockDeviceMappings,
+						windowsNodeClass.Spec.InstanceStorePolicy,
+						windowsNodeClass.Spec.Kubelet.MaxPods,
+						windowsNodeClass.Spec.Kubelet.PodsPerCore,
+						windowsNodeClass.Spec.Kubelet.KubeReserved,
+						windowsNodeClass.Spec.Kubelet.SystemReserved,
+						windowsNodeClass.Spec.Kubelet.EvictionHard,
+						windowsNodeClass.Spec.Kubelet.EvictionSoft,
+						windowsNodeClass.AMIFamily(),
+						nil,
+					)
+					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
+				})
 			})
 			Context("Eviction Soft", func() {
 				It("should use default threshold when only evictionSoft is specified", func() {


### PR DESCRIPTION
Fixes #8473 

Karpenter was using an incorrect eviction hard threshold for Windows nodes, causing a mismatch between Karpenter's estimated node allocatable and the actual value reported by the kubelet.

**Problem**
- Karpenter used `100Mi` as the default `memory.available` eviction hard threshold for all AMI families
- According to [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#hard-eviction-thresholds), Windows nodes should use `500Mi` by default
- This caused Karpenter to overestimate available memory on Windows nodes by 400Mi
- Resulted in potential pod evictions due to incorrect capacity calculations

**Solution**
- Modified `evictionThreshold` function to accept `amiFamily` parameter
- Added type check to use `500Mi` for Windows AMI families, `100Mi` for others
- Added reference to Kubernetes documentation for clarity

**Changes**
- **pkg/providers/instancetype/types.go**
  - Updated `evictionThreshold` function signature to include `amiFamily` parameter
  - Implemented conditional logic to set default memory threshold based on AMI family type
  - Updated function call site to pass `amiFamily`

- **pkg/providers/instancetype/suite_test.go**
  - Added test case "should use 500Mi default eviction threshold for Windows nodes when evictionHard not specified"
  - Verifies Windows nodes use correct 500Mi default value

**Testing**
- [x] Added unit test for Windows default eviction threshold
- [x] Existing tests pass (verifies Linux nodes still use 100Mi)
- [x] Build succeeds

**Checklist**
- [x] Added/modified tests
- [x] Updated relevant documentation (inline code comments with K8s reference)
- [x] Verified backward compatibility (user-specified evictionHard values still override defaults)