### PR TITLE
ci: add workspace make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,15 @@ deploy-cfn: ## Deploys the cloudformation stack defined in the docs preview dire
 		--capabilities CAPABILITY_NAMED_IAM \
 		--parameter-overrides "ClusterName=${CLUSTER_NAME}"
 
+workspace: ## Creates a new workspace or updates the existing workspace with all modules
+	@if [ -z $$(go env GOWORK) ]; then \
+		go work init; \
+		printf "creating workspace: %s\n" $$(go env GOWORK); \
+	else \
+		printf "updating workspace: %s\n" $$(go env GOWORK); \
+	fi
+	$(foreach dir,$(MOD_DIRS),go work use $(dir) $(newline))
+
 
 .PHONY: help presubmit ci-test ci-non-test run test deflake e2etests e2etests-deflake benchmark coverage verify vulncheck licenses image apply install delete docgen codegen stable-release-pr snapshot release prepare-website toolchain issues website tidy download update-karpenter
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Adds a quality of life Makefile target which adds all MOD_DIRS to the existing workspace. If a workspace doesn't exist, a new workspace will be created at the root of the project. 

**How was this change tested?**
Manual

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.