### PR TITLE
Add applying CRD for "run" target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ ci-test: test coverage ## Runs tests and submits coverage
 
 ci-non-test: verify licenses vulncheck ## Runs checks other than tests
 
-run: ## Run Karpenter controller binary against your local cluster
+run: ## Run Karpenter controller binary against your local cluster with latest CRD's
+	kubectl apply -f ./pkg/apis/crds/
 	SYSTEM_NAMESPACE=${KARPENTER_NAMESPACE} \
 		KUBERNETES_MIN_VERSION="1.19.0-0" \
 		DISABLE_LEADER_ELECTION=true \


### PR DESCRIPTION
Fixes #8892

**Description**
Adds `kubectl apply -f ./pkg/apis/crds/` to `run` target in `Makefile`.

**How was this change tested?**
Tested `make run`.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.