### PR TITLE
Backport #8565 to 1.8.x: fix: use only evictionHard for allocatable capacity calculation

### DIFF
--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1338,11 +1338,11 @@ var _ = Describe("InstanceTypeProvider", func() {
 						nodeClass.AMIFamily(),
 						nil,
 					)
-					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("50Mi"))
+					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				})
 			})
 			Context("Eviction Soft", func() {
-				It("should override eviction threshold when specified as a quantity", func() {
+				It("should use default threshold when only evictionSoft is specified", func() {
 					nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 						SystemReserved: map[string]string{
 							string(corev1.ResourceMemory): "20Gi",
@@ -1370,9 +1370,9 @@ var _ = Describe("InstanceTypeProvider", func() {
 						nodeClass.AMIFamily(),
 						nil,
 					)
-					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
+					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				})
-				It("should override eviction threshold when specified as a percentage value", func() {
+				It("should use evictionHard percentage and ignore evictionSoft percentage", func() {
 					nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 						SystemReserved: map[string]string{
 							string(corev1.ResourceMemory): "20Gi",
@@ -1403,9 +1403,9 @@ var _ = Describe("InstanceTypeProvider", func() {
 						nodeClass.AMIFamily(),
 						nil,
 					)
-					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
+					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.05, 10))
 				})
-				It("should consider the eviction threshold disabled when specified as 100%", func() {
+				It("should use default threshold when evictionSoft is 100% (ignored)", func() {
 					nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 						SystemReserved: map[string]string{
 							string(corev1.ResourceMemory): "20Gi",
@@ -1433,7 +1433,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 						nodeClass.AMIFamily(),
 						nil,
 					)
-					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("0"))
+					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				})
 				It("should ignore eviction threshold when using Bottlerocket AMI", func() {
 					nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "bottlerocket@latest"}}
@@ -1492,7 +1492,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				Expect(it.Overhead.EvictionThreshold.StorageEphemeral().AsApproximateFloat64()).To(BeNumerically("~", resources.Quantity("2Gi").AsApproximateFloat64()))
 			})
-			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
+			It("should use only evictionHard for overhead, ignoring evictionSoft", func() {
 				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 					SystemReserved: map[string]string{
 						string(corev1.ResourceMemory): "20Gi",
@@ -1523,9 +1523,10 @@ var _ = Describe("InstanceTypeProvider", func() {
 					nodeClass.AMIFamily(),
 					nil,
 				)
-				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("3Gi"))
+				// Should use evictionHard (1Gi), not evictionSoft (3Gi)
+				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("1Gi"))
 			})
-			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
+			It("should use only evictionHard percentage for overhead, ignoring evictionSoft", func() {
 				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 					SystemReserved: map[string]string{
 						string(corev1.ResourceMemory): "20Gi",
@@ -1556,9 +1557,10 @@ var _ = Describe("InstanceTypeProvider", func() {
 					nodeClass.AMIFamily(),
 					nil,
 				)
+				// Should use evictionHard (5%), not evictionSoft (2%)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.05, 10))
 			})
-			It("should take the greater of evictionHard and evictionSoft for overhead with mixed percentage/value", func() {
+			It("should use only evictionHard value with mixed percentage/value types", func() {
 				nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 					SystemReserved: map[string]string{
 						string(corev1.ResourceMemory): "20Gi",
@@ -1589,7 +1591,8 @@ var _ = Describe("InstanceTypeProvider", func() {
 					nodeClass.AMIFamily(),
 					nil,
 				)
-				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
+				// Should use evictionHard (1Gi), not evictionSoft (10%)
+				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("1Gi"))
 			})
 		})
 		It("should default max pods based off of network interfaces", func() {
@@ -2618,7 +2621,6 @@ var _ = Describe("InstanceTypeProvider", func() {
 			// kubelet.kubeReserved
 			// kubelet.systemReserved
 			// kubelet.evictionHard
-			// kubelet.evictionSoft
 			// kubelet.maxPods
 			nodeClass.Spec.Kubelet = &v1.KubeletConfiguration{
 				KubeReserved:   map[string]string{string(corev1.ResourceCPU): "1"},
@@ -2634,7 +2636,6 @@ var _ = Describe("InstanceTypeProvider", func() {
 				{KubeReserved: map[string]string{string(corev1.ResourceCPU): "20"}},
 				{SystemReserved: map[string]string{string(corev1.ResourceMemory): "10Gi"}},
 				{EvictionHard: map[string]string{"memory.available": "52%"}},
-				{EvictionSoft: map[string]string{"nodefs.available": "132%"}},
 				{MaxPods: aws.Int32(20)},
 			}
 			ExpectApplied(ctx, env.Client, nodeClass)
@@ -2656,7 +2657,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 				instanceTypeResults = append(instanceTypeResults, instancetypes)
 			}
 
-			// Based on the nodeclass configuration, we expect to have 5 unique set of instance types
+			// Based on the nodeclass configuration, we expect to have 4 unique set of instance types
 			ExpectUniqueInstanceTypeLists(instanceTypeResults...)
 		})
 		It("changes to nodeclass fields should result in a different set of instances types", func() {


### PR DESCRIPTION
**Description**
This PR backports #8565 to 1.8.x. This code was contributed by @moko-poi in the aforementioned PR. Thank you! 

I'm affected by the bug, so I'm proposing a backport to 1.8.x, hoping that we can get a bugfix release.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.