### PR TITLE
feat: support EC2 DescribeInstanceStatus health checks in the interruption controller

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -85,6 +85,7 @@ func main() {
 			op.InstanceTypesProvider,
 			op.CapacityReservationProvider,
 			op.AMIResolver,
+			op.InstanceStatusProvider,
 		)...).
 		Start(ctx)
 }

--- a/kwok/main.go
+++ b/kwok/main.go
@@ -100,6 +100,7 @@ func main() {
 			op.InstanceTypesProvider,
 			op.CapacityReservationProvider,
 			op.AMIResolver,
+			op.InstanceStatusProvider,
 		)...).
 		Start(ctx)
 	wg.Wait()

--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -59,6 +59,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
@@ -91,6 +92,7 @@ type Operator struct {
 	VersionProvider             *version.DefaultProvider
 	InstanceTypesProvider       *instancetype.DefaultProvider
 	InstanceProvider            instance.Provider
+	InstanceStatusProvider      *instancestatus.DefaultProvider
 	SSMProvider                 ssmp.Provider
 	CapacityReservationProvider capacityreservation.Provider
 	EC2API                      *kwokec2.Client
@@ -192,6 +194,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 	)
 
+	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)
+
 	// Setup field indexers on instanceID -- specifically for the interruption controller
 	if options.FromContext(ctx).InterruptionQueue != "" {
 		SetupIndexers(ctx, operator.Manager)
@@ -213,6 +217,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		PricingProvider:             pricingProvider,
 		InstanceTypesProvider:       instanceTypeProvider,
 		InstanceProvider:            instanceProvider,
+		InstanceStatusProvider:      instanceStatusProvider,
 		SSMProvider:                 ssmProvider,
 		CapacityReservationProvider: capacityReservationProvider,
 		EC2API:                      ec2api,

--- a/pkg/aws/sdk.go
+++ b/pkg/aws/sdk.go
@@ -35,6 +35,7 @@ type EC2API interface {
 	DescribeInstanceTypes(context.Context, *ec2.DescribeInstanceTypesInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
 	DescribeInstanceTypeOfferings(context.Context, *ec2.DescribeInstanceTypeOfferingsInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypeOfferingsOutput, error)
 	DescribeSpotPriceHistory(context.Context, *ec2.DescribeSpotPriceHistoryInput, ...func(*ec2.Options)) (*ec2.DescribeSpotPriceHistoryOutput, error)
+	DescribeInstanceStatus(context.Context, *ec2.DescribeInstanceStatusInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceStatusOutput, error)
 	CreateFleet(context.Context, *ec2.CreateFleetInput, ...func(*ec2.Options)) (*ec2.CreateFleetOutput, error)
 	TerminateInstances(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
 	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
@@ -70,6 +71,7 @@ type SQSAPI interface {
 	ReceiveMessage(context.Context, *sqs.ReceiveMessageInput, ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
 	DeleteMessage(context.Context, *sqs.DeleteMessageInput, ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error)
 	SendMessage(context.Context, *sqs.SendMessageInput, ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
+	GetQueueUrl(context.Context, *sqs.GetQueueUrlInput, ...func(*sqs.Options)) (*sqs.GetQueueUrlOutput, error)
 }
 
 type TimestreamWriteAPI interface {

--- a/pkg/controllers/interruption/messages/instancestatusfailure/model.go
+++ b/pkg/controllers/interruption/messages/instancestatusfailure/model.go
@@ -1,0 +1,39 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancestatusfailure
+
+import (
+	"time"
+
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
+)
+
+// Message contains the Instance Status from EC2.DescribeInstanceStatus
+// This is not vended via EventBridge but is handled in a similar manner
+// as other EventBridge messages.
+type Message instancestatus.HealthStatus
+
+func (m Message) EC2InstanceIDs() []string {
+	return []string{m.InstanceID}
+}
+
+func (Message) Kind() messages.Kind {
+	return messages.InstanceStatusFailure
+}
+
+func (m Message) StartTime() time.Time {
+	return m.ImpairedSince
+}

--- a/pkg/controllers/interruption/messages/types.go
+++ b/pkg/controllers/interruption/messages/types.go
@@ -40,6 +40,7 @@ const (
 	SpotInterruptionKind        Kind = "spot_interrupted"
 	InstanceStoppedKind         Kind = "instance_stopped"
 	InstanceTerminatedKind      Kind = "instance_terminated"
+	InstanceStatusFailure       Kind = "instance_status_failure"
 	NoOpKind                    Kind = "no_op"
 )
 

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -53,6 +53,7 @@ type EC2Behavior struct {
 	DescribeLaunchTemplatesOutput       AtomicPtr[ec2.DescribeLaunchTemplatesOutput]
 	DescribeInstanceTypesOutput         AtomicPtr[ec2.DescribeInstanceTypesOutput]
 	DescribeInstanceTypeOfferingsOutput AtomicPtr[ec2.DescribeInstanceTypeOfferingsOutput]
+	DescribeInstanceStatusOutput        AtomicPtr[ec2.DescribeInstanceStatusOutput]
 	DescribeAvailabilityZonesOutput     AtomicPtr[ec2.DescribeAvailabilityZonesOutput]
 	DescribeSubnetsBehavior             MockedFunction[ec2.DescribeSubnetsInput, ec2.DescribeSubnetsOutput]
 	DescribeSecurityGroupsBehavior      MockedFunction[ec2.DescribeSecurityGroupsInput, ec2.DescribeSecurityGroupsOutput]
@@ -92,6 +93,7 @@ func (e *EC2API) Reset() {
 	e.DescribeLaunchTemplatesOutput.Reset()
 	e.DescribeInstanceTypesOutput.Reset()
 	e.DescribeInstanceTypeOfferingsOutput.Reset()
+	e.DescribeInstanceStatusOutput.Reset()
 	e.DescribeAvailabilityZonesOutput.Reset()
 	e.DescribeSubnetsBehavior.Reset()
 	e.DescribeSecurityGroupsBehavior.Reset()
@@ -638,4 +640,15 @@ func (e *EC2API) RunInstances(ctx context.Context, input *ec2.RunInstancesInput,
 			Instances: []ec2types.Instance{instance},
 		}, nil
 	})
+}
+
+func (e *EC2API) DescribeInstanceStatus(ctx context.Context, input *ec2.DescribeInstanceStatusInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceStatusOutput, error) {
+	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
+		return nil, e.NextError.Get()
+	}
+	if !e.DescribeInstanceStatusOutput.IsNil() {
+		return e.DescribeInstanceStatusOutput.Clone(), nil
+	}
+	return &ec2.DescribeInstanceStatusOutput{}, nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -57,6 +57,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
@@ -89,6 +90,7 @@ type Operator struct {
 	VersionProvider             *version.DefaultProvider
 	InstanceTypesProvider       *instancetype.DefaultProvider
 	InstanceProvider            instance.Provider
+	InstanceStatusProvider      *instancestatus.DefaultProvider
 	SSMProvider                 ssmp.Provider
 	CapacityReservationProvider capacityreservation.Provider
 	EC2API                      *ec2.Client
@@ -200,6 +202,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		capacityReservationProvider,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 	)
+	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)
 
 	// Setup field indexers on instanceID -- specifically for the interruption controller
 	if options.FromContext(ctx).InterruptionQueue != "" {
@@ -222,6 +225,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		PricingProvider:             pricingProvider,
 		InstanceTypesProvider:       instanceTypeProvider,
 		InstanceProvider:            instanceProvider,
+		InstanceStatusProvider:      instanceStatusProvider,
 		SSMProvider:                 ssmProvider,
 		CapacityReservationProvider: capacityReservationProvider,
 		EC2API:                      ec2api,

--- a/pkg/providers/instancestatus/instancestatus.go
+++ b/pkg/providers/instancestatus/instancestatus.go
@@ -1,0 +1,176 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancestatus
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/samber/lo"
+	"k8s.io/utils/clock"
+
+	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
+)
+
+type Category string
+
+const (
+	InstanceStatus = Category("InstanceStatus")
+	SystemStatus   = Category("SystemStatus")
+	// EventStatus is currently ignored since this is already consumed via EventBridge in the Interruption controller.
+	// The handling of maintenance events is currently primitive where we treat all events as instance degradation
+	// with an involuntary replacement. Only consuming events via EventBridge allows some users to opt-out of maintenance
+	// event handling (https://github.com/aws/karpenter-provider-aws/issues/8524).
+	EventStatus = Category("EventStatus")
+	// EBSStatus check failures are currently ignored until we can differentiate which volumes affect the node vs pods w/ PVCs
+	EBSStatus = Category("EBSStatus")
+)
+
+var (
+	UnhealthyThreshold = 120 * time.Second
+)
+
+type Provider interface {
+	List(context.Context) ([]HealthStatus, error)
+}
+
+type DefaultProvider struct {
+	ec2api sdk.EC2API
+	clk    clock.Clock
+}
+
+type HealthStatus struct {
+	InstanceID    string
+	Overall       ec2types.SummaryStatus
+	ImpairedSince time.Time
+	Details       []Details
+}
+
+type Details struct {
+	Category      Category
+	Name          string
+	ImpairedSince time.Time
+	Status        ec2types.StatusType
+}
+
+func NewDefaultProvider(ec2API sdk.EC2API, clk clock.Clock) *DefaultProvider {
+	return &DefaultProvider{
+		ec2api: ec2API,
+		clk:    clk,
+	}
+}
+
+func (p DefaultProvider) List(ctx context.Context) ([]HealthStatus, error) {
+	var statuses []ec2types.InstanceStatus
+	pager := ec2.NewDescribeInstanceStatusPaginator(p.ec2api, &ec2.DescribeInstanceStatusInput{})
+
+	for pager.HasMorePages() {
+		out, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed describing ec2 instance status checks, %w", err)
+		}
+		statuses = append(statuses, out.InstanceStatuses...)
+	}
+
+	var healthStatuses []HealthStatus
+	for _, statusChecks := range statuses {
+		healthStatus := p.newHealthStatus(statusChecks)
+		// Filter out statuses that we do not consider unhealthy or do not want to handle right now
+		healthStatus.Details = lo.Filter(healthStatus.Details, func(details Details, _ int) bool {
+			if details.Status != ec2types.StatusTypeFailed {
+				return false
+			}
+			// ignore EBS and Scheduled Event health checks for now
+			if details.Category == EBSStatus || details.Category == EventStatus {
+				return false
+			}
+			// Do not evaluate against the unhealthy threshold when its a scheduled maintenance event.
+			// Scheduled maintenance events often have a future scheduled time which makes a thershold
+			// difficult to utilize. We take the stance that if there is a scheduled maintenance event,
+			// then there is something wrong with the underlying host that warrants vacating immediately.
+			// This matches how we process scheduled maintenance events from EventBridge.
+			if details.Category == EventStatus {
+				return true
+			}
+			return p.clk.Since(details.ImpairedSince) >= UnhealthyThreshold
+		})
+		if len(healthStatus.Details) == 0 {
+			continue
+		}
+		healthStatus.ImpairedSince = slices.MinFunc(healthStatus.Details, func(a, b Details) int {
+			return a.ImpairedSince.Compare(b.ImpairedSince)
+		}).ImpairedSince
+		healthStatuses = append(healthStatuses, healthStatus)
+	}
+	return healthStatuses, nil
+}
+
+// newHealthStatus constructs a more consumable version of Health Status Details from the different status checks
+func (p DefaultProvider) newHealthStatus(statusChecks ec2types.InstanceStatus) HealthStatus {
+	healthStatus := HealthStatus{
+		InstanceID: *statusChecks.InstanceId,
+		Overall:    ec2types.SummaryStatusImpaired,
+	}
+	if statusChecks.InstanceStatus != nil {
+		healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.InstanceStatus.Details, func(details ec2types.InstanceStatusDetails, _ int) Details {
+			return p.newDetails(details, InstanceStatus)
+		})...)
+	}
+	if statusChecks.SystemStatus != nil {
+		healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.SystemStatus.Details, func(details ec2types.InstanceStatusDetails, _ int) Details {
+			return p.newDetails(details, SystemStatus)
+		})...)
+	}
+	if statusChecks.AttachedEbsStatus != nil {
+		healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.AttachedEbsStatus.Details, func(details ec2types.EbsStatusDetails, _ int) Details {
+			return p.newDetails(details, EBSStatus)
+		})...)
+	}
+	healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.Events, func(details ec2types.InstanceStatusEvent, _ int) Details {
+		return p.newDetails(details, EventStatus)
+	})...)
+	return healthStatus
+}
+
+func (p DefaultProvider) newDetails(details any, category Category) Details {
+	if ec2Details, ok := details.(ec2types.InstanceStatusDetails); ok {
+		return Details{
+			Category:      category,
+			Name:          string(ec2Details.Name),
+			Status:        ec2Details.Status,
+			ImpairedSince: lo.FromPtr(ec2Details.ImpairedSince),
+		}
+	}
+	if ec2Events, ok := details.(ec2types.InstanceStatusEvent); ok {
+		return Details{
+			Category: category,
+			Name:     string(ec2Events.Code),
+			// treat all scheduled maintenance events as failures
+			Status:        ec2types.StatusTypeFailed,
+			ImpairedSince: p.clk.Now(),
+		}
+	}
+	ebsDetails := details.(ec2types.EbsStatusDetails)
+	return Details{
+		Category:      category,
+		Name:          string(ebsDetails.Name),
+		Status:        ebsDetails.Status,
+		ImpairedSince: lo.FromPtr(ebsDetails.ImpairedSince),
+	}
+}

--- a/pkg/providers/instancestatus/suite_test.go
+++ b/pkg/providers/instancestatus/suite_test.go
@@ -1,0 +1,152 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancestatus_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/samber/lo"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
+	"github.com/aws/karpenter-provider-aws/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var ctx context.Context
+var env *coretest.Environment
+var awsEnv *test.Environment
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "InstanceStatusProvider")
+}
+
+var _ = BeforeSuite(func() {
+	env = coretest.NewEnvironment(coretest.WithCRDs(v1alpha1.CRDs...))
+	ctx = options.ToContext(ctx, test.Options())
+	awsEnv = test.NewEnvironment(ctx, env)
+})
+
+var _ = Describe("Instance Status Provider", func() {
+
+	BeforeEach(func() {
+		awsEnv.Clock.SetTime(time.Time{})
+		statuses := []ec2types.InstanceStatus{
+			{
+				InstanceId: lo.ToPtr("i-0123456789"),
+				InstanceStatus: &ec2types.InstanceStatusSummary{
+					Status: ec2types.SummaryStatusImpaired,
+					Details: []ec2types.InstanceStatusDetails{
+						{
+							Status:        ec2types.StatusTypeFailed,
+							Name:          ec2types.StatusNameReachability,
+							ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+						},
+					},
+				},
+				SystemStatus: &ec2types.InstanceStatusSummary{
+					Status: ec2types.SummaryStatusImpaired,
+					Details: []ec2types.InstanceStatusDetails{
+						{
+							Status:        ec2types.StatusTypeFailed,
+							Name:          ec2types.StatusNameReachability,
+							ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+						},
+					},
+				},
+				AttachedEbsStatus: &ec2types.EbsStatusSummary{
+					Status: ec2types.SummaryStatusImpaired,
+					Details: []ec2types.EbsStatusDetails{
+						{
+							Status:        ec2types.StatusTypeFailed,
+							Name:          ec2types.StatusNameReachability,
+							ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+						},
+					},
+				},
+				Events: []ec2types.InstanceStatusEvent{
+					{
+						Code: ec2types.EventCodeInstanceRetirement,
+					},
+				},
+			},
+		}
+		awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+			InstanceStatuses: statuses,
+		})
+	})
+	Context("List and Aggregate", func() {
+		It("should return all impairment details", func() {
+			impairedTime := awsEnv.Clock.Now()
+			awsEnv.Clock.Step(1 * time.Hour)
+			statuses, err := awsEnv.InstanceStatusProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(statuses).To(HaveLen(1))
+			Expect(statuses[0].InstanceID).To(Equal("i-0123456789"))
+			Expect(statuses[0].Overall).To(Equal(ec2types.SummaryStatusImpaired))
+			Expect(statuses[0].Details).To(ContainElements([]instancestatus.Details{
+				{
+					Category:      instancestatus.InstanceStatus,
+					Name:          string(ec2types.StatusNameReachability),
+					Status:        ec2types.StatusTypeFailed,
+					ImpairedSince: impairedTime,
+				},
+				{
+					Category:      instancestatus.SystemStatus,
+					Name:          string(ec2types.StatusNameReachability),
+					Status:        ec2types.StatusTypeFailed,
+					ImpairedSince: impairedTime,
+				},
+			}))
+		})
+		It("should not return healthy statuses", func() {
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr("i-0123456789"),
+						SystemStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusInitializing,
+						},
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusInsufficientData,
+						},
+						AttachedEbsStatus: &ec2types.EbsStatusSummary{
+							Status: ec2types.SummaryStatusInitializing,
+						},
+						Events: []ec2types.InstanceStatusEvent{
+							{
+								Code: ec2types.EventCodeInstanceRetirement,
+							},
+						},
+					},
+				},
+			})
+			statuses, err := awsEnv.InstanceStatusProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(statuses).To(HaveLen(0))
+		})
+	})
+})

--- a/pkg/providers/sqs/sqs.go
+++ b/pkg/providers/sqs/sqs.go
@@ -104,7 +104,7 @@ func (p *DefaultProvider) DeleteSQSMessage(ctx context.Context, msg *sqstypes.Me
 	return nil
 }
 
-func NewSQSProvider(ctx context.Context, sqsapi *sqs.Client) (Provider, error) {
+func NewSQSProvider(ctx context.Context, sqsapi sdk.SQSAPI) (Provider, error) {
 	out, err := sqsapi.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{QueueName: lo.ToPtr(options.FromContext(ctx).InterruptionQueue)})
 	if err != nil {
 		return nil, err

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
@@ -94,6 +95,7 @@ type Environment struct {
 	InstanceTypesResolver       *instancetype.DefaultResolver
 	InstanceTypesProvider       *instancetype.DefaultProvider
 	InstanceProvider            *instance.DefaultProvider
+	InstanceStatusProvider      *instancestatus.DefaultProvider
 	SubnetProvider              *subnet.DefaultProvider
 	SecurityGroupProvider       *securitygroup.DefaultProvider
 	InstanceProfileProvider     *instanceprofile.DefaultProvider
@@ -160,6 +162,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	// Instance type updates are hydrated asynchronously after this by controllers.
 	lo.Must0(instanceTypesProvider.UpdateInstanceTypes(ctx))
 	lo.Must0(instanceTypesProvider.UpdateInstanceTypeOfferings(ctx))
+	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, clock)
 	launchTemplateProvider := launchtemplate.NewDefaultProvider(
 		ctx,
 		launchTemplateCache,
@@ -226,6 +229,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		InstanceTypesResolver:       instanceTypesResolver,
 		InstanceTypesProvider:       instanceTypesProvider,
 		InstanceProvider:            instanceProvider,
+		InstanceStatusProvider:      instanceStatusProvider,
 		SubnetProvider:              subnetProvider,
 		SecurityGroupProvider:       securityGroupProvider,
 		LaunchTemplateProvider:      launchTemplateProvider,

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -348,6 +348,14 @@ Resources:
               "Effect": "Allow",
               "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
+              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Action": "eks:DescribeCluster"
+            },
+            {
+              "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": "ec2:DescribeInstanceStatus"
             }
           ]
         }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes https://github.com/aws/karpenter-provider-aws/issues/8821 <!-- issue number -->

**Description**

Adds support for EC2 Status Checks (i.e. health checks) for consumption by the Interruption Controller. 
Before this PR, the interruption controller only consumed health checks from EventBridge (AWS Health, Spot, and EC2 Instance State Changes). These events only cover EC2 Scheduled Maintenance Events, Spot Interruptions, and EC2 Terminations/Stops. 

EC2:DescribeInstanceStatus is an API that provides the result of EC2 health checks. 
The currently vended health checks are:

- Instance Status  (reachability via an ARP to the EC2 instance via the primary ENI) 
- System Status (reachability to the underlying physical host the EC2 instance is running on)
- EBS Volume Status (problems with attached EBS volumes) 
- Scheduled Maintenance Events

Instance Status, System Status, and EBS Volume Status is not available via EventBridge.  This PR only supports Instance Status and System Status checks for interruption handling.

Scheduled Maintenance Events are already consumed via EventBridge, so we are ignoring them when parsing DescribeInstanceStatus for now. We may want to revisit this later to remove the need for those events for the interruption queue.

Additionally, EBS Volume Status indicates that at least 1 volume is unhealthy. This is insufficient information to take action from Karpenter's perspective since it could be indicating that a pod's storage is unhealthy via a PVC. EBS Volume checking should be completed in a follow-up PR that uses the EBS Status Checks API which can narrow down which volume is unhealthy.

*NOTE: THIS FEATURE REQUIRES A NEW PERMISSION EC2:DescribeInstanceStatus*

If you launch Karpenter without EC2:DescribeInstanceStatus permissions, the following error is logged:

```
karpenter-6c47d6799-lth2w controller {"level":"ERROR","time":"2026-01-29T15:07:01.234Z","logger":"controller","caller":"controller/controller.go:474","message":"Reconciler error","commit":"3c50d4a-dirty","controller":"interruption","namespace":"","name":"","reconcileID":"2365d24c-500a-4b88-9422-866efc679e4d","aws-error-code":"UnauthorizedOperation","aws-operation-name":"DescribeInstanceStatus","aws-request-id":"032b63a8-52c2-4e42-be18-ff7c3afc6405","aws-service-name":"EC2","aws-status-code":403,"error":"reconciling interruptions, getting instance statusesm failed describing ec2 instance status checks, operation error EC2: DescribeInstanceStatus, https response error StatusCode: 403, RequestID: 032b63a8-52c2-4e42-be18-ff7c3afc6405, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::xxxxxxxxxxxxx:assumed-role/xxxxxxxx-karpenter-dev-karpenter/eks-xxxxxxx-k-karpenter--f33a7ef1-4cf6-40ce-ad50-f3c17999b158 is not authorized to perform: ec2:DescribeInstanceStatus because no identity-based policy allows the ec2:DescribeInstanceStatus action (aws-error-code=UnauthorizedOperation, aws-operation-name=DescribeInstanceStatus, aws-request-id=032b63a8-52c2-4e42-be18-ff7c3afc6405, aws-service-name=EC2, aws-status-code=403)"}
```

It does not inhibit the interruption controller if a queue is configured via `--interruption-queue`. 

**How was this change tested?**

Added suite tests but also performed manual testing:

For manual testing, I had Karpenter create a node, and then I SSH'd to the node and down'd the primary network interface:

```
> k scale deploy inflate --replicas=2
> ec2-connect i-023383730ebc0d024
   > ip link set dev enp39s0 down
```

Applicable Logs:

```
karpenter-6c47d6799-lth2w controller {"level":"INFO","time":"2026-01-29T15:31:05.949Z","logger":"controller","caller":"interruption/controller.go:324","message":"initiating delete from interruption message","commit":"3c50d4a-dirty","controller":"interruption","namespace":"","name":"","reconcileID":"14060d4c-63b6-4841-abac-1f551cdade4f","messageKind":"instance_status_failure","NodeClaim":{"name":"default-nj2pf"},"action":"CordonAndDrain","Node":{"name":"ip-192-168-56-163.us-east-2.compute.internal"}}
```


**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.