### PR TITLE
fix: error message with bottlerocket userdata

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -135,7 +135,7 @@ func (c *BottlerocketConfig) UnmarshalTOML(ctx context.Context, data []byte) err
 		return err
 	}
 
-	// To log misconfigured / unsuported k8s userData, we re-marshal the k8s settings
+	// To log misconfigured / unsupported k8s userData, we re-marshal the k8s settings
 	// and re-unmarshal with TOML strict mode to log any errors
 	if k8sRaw, ok := c.SettingsRaw["kubernetes"]; ok {
 		k8sData, err := toml.Marshal(k8sRaw)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
* Fix error message with bottle rocket user data where valid, non-k8s settings were logged as errors

For example, the following valid configuration logged an error:
```
userData: |
  [settings.aws]
  region = "us-east-1"
  [settings.kubernetes]
  log-level = 2
  cpu-manager-policy = "static"
```
With log
```
{"level":"ERROR","time":"2026-01-29T14:56:42.462-0800","logger":"controller","message":"Unknown parameter in userData K8s settings","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"bottlerocket-good"},"namespace":"","name":"bottlerocket-good","reconcileID":"f8c489cc-81af-4cb1-a5c7-5566638560f6","launch-template-name":"karpenter.k8s.aws/17675488995952475562","reason":"1| [settings.aws]\n |  ~~~~~~~~~~~~ missing table\n2| region = \"us-east-1\"\n3| [settings.kubernetes]\n4| log-level = 2","error":"strict mode: fields in the document are missing in the target struct"}
```


**How was this change tested?**
* make presubmit
* manual testing

With valid user data, no error message occurs:
```
userData: |
  [settings.aws]
  region = "us-east-1"
  [settings.kubernetes]
  log-level = 2
  cpu-manager-policy = "static"
```

With invalid user data, errors are logged:
```
userData: |
  [settings.aws]
  region = "us-east-1"
  [settings.kubernetes]
  log-level = 2
  cpu-manager-policy = "static"
  unknown = "yes"
```
Log -
```
{"level":"ERROR","time":"2026-01-29T14:39:01.858-0800","logger":"controller","message":"Unknown parameter in userData K8s settings","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"bottlerockenodet-bad"},"namespace":"","name":"bottlerockenodet-bad","reconcileID":"4d2eebd7-789a-4f39-a517-219570acaec5","launch-template-name":"karpenter.k8s.aws/16720847957041441588","reason":"1| cpu-manager-policy = 'static'\n2| log-level = 2\n3| unknown = 'yes'\n | ~~~~~~~ missing field","error":"strict mode: fields in the document are missing in the target struct"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.