### PR TITLE
fix(disruption): suppress spurious logs during EC2NodeClass deletion

### DIFF
--- a/pkg/controllers/providers/instancetype/capacity/controller.go
+++ b/pkg/controllers/providers/instancetype/capacity/controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -80,6 +81,11 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 	nodeClass, err := c.GetEC2NodeClass(ctx, nodeClaim)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get ec2nodeclass, %w", err)
+	}
+	// Skip instance type refresh when EC2NodeClass is deleting to avoid spurious API errors
+	if !nodeClass.GetDeletionTimestamp().IsZero() {
+		log.FromContext(ctx).V(1).Info("skipping instance type refresh; EC2NodeClass is deleting")
+		return reconcile.Result{}, nil
 	}
 	if err := c.instancetypeProvider.UpdateInstanceTypeCapacityFromNode(ctx, node, nodeClaim, nodeClass); err != nil {
 		return reconcile.Result{}, fmt.Errorf("updating discovered capacity cache, %w", err)


### PR DESCRIPTION
Description:

This PR optimizes the disruption controller to recognize when an EC2NodeClass is in a deletion state. Currently, the controller continues to attempt reconciliation even after a DeletionTimestamp is set, resulting in persistent error logs and unnecessary AWS API calls when the resource is no longer retrievable or valid.

Technical Approach:
I've added a guard clause that checks nodeClass.GetDeletionTimestamp().IsZero(). If the resource is being deleted, the reconcile loop exits early with a Debug level log. This aligns with Kubernetes controller best practices for handling resource finalization and cleanup.

Impact:

Reduces CloudWatch log noise/spam in production clusters.

Decreases unnecessary AWS API calls during infrastructure teardown.

How was this change tested?

Unit Tests: Updated pkg/controllers/disruption/suite_test.go (or equivalent) to simulate a deleting NodeClass and verified no errors are returned.

Manual Verification: Deployed to a development cluster, triggered kubectl delete ec2nodeclass, and observed that logs transitioned from ERROR to a single DEBUG skip message.

Does this change impact docs?

[x] No