### PR TITLE
fix(crd): update nodepools statusReplicasPath to resources.nodes

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -23,7 +23,7 @@ spec:
         - jsonPath: .spec.template.spec.nodeClassRef.name
           name: NodeClass
           type: string
-        - jsonPath: .status.nodes
+        - jsonPath: .status.resources.nodes
           name: Nodes
           type: string
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
@@ -549,5 +549,5 @@ spec:
       subresources:
         scale:
           specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.nodes
+          statusReplicasPath: .status.resources.nodes
         status: {}


### PR DESCRIPTION


<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

In Karpenter version `1.19.0`, the number of nodes in the status always returns `0` when invoking `nodepools.karpenter.sh`:
```
> kubectl get nodepools.karpenter.sh default 

NAME      NODECLASS   NODES   READY   AGE
default   default     0       True    156d
```

The CRD printer column seems to point to the wrong field.

If you inspect the full YAML of the NodePool, there are two different references to node counts:
```
   status:
     nodes: 0                  # <-- This is what 'kubectl get' displays
     resources:
       ...
       nodes: "21"             # <-- This is the actual number of nodes Karpenter tracks
```

Karpenter perfectly knows that there are 21 nodes provisioned. The scheduling and scaling are working flawlessly based on `.status.resources.nodes`.

Accordingly, we update the JSON path and statusReplicasPath for nodes in the NodePool CRD to point to `.status.resources.nodes` instead of `.status.nodes` to reflect the correct resource status structure.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.