### PR TITLE
docs: fix broken logging config links

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -268,7 +268,7 @@ Consolidation packs pods tightly onto nodes which can leave little free allocata
 
 ### How do I customize or configure the log output?
 
-Karpenter uses [uber-go/zap](https://github.com/uber-go/zap) for logging. You can customize the logging configuration with the following environment variables:
+Karpenter's logging can be customized with the following environment variables:
 
 * `LOG_LEVEL`
 * `LOG_OUTPUT_PATHS`

--- a/website/content/en/v1.0/faq.md
+++ b/website/content/en/v1.0/faq.md
@@ -268,7 +268,7 @@ Consolidation packs pods tightly onto nodes which can leave little free allocata
 
 ### How do I customize or configure the log output?
 
-Karpenter uses [uber-go/zap](https://github.com/uber-go/zap) for logging. You can customize the logging configuration with the following environment variables:
+Karpenter's logging can be customized with the following environment variables:
 
 * `LOG_LEVEL`
 * `LOG_OUTPUT_PATHS`

--- a/website/content/en/v1.7/faq.md
+++ b/website/content/en/v1.7/faq.md
@@ -268,7 +268,7 @@ Consolidation packs pods tightly onto nodes which can leave little free allocata
 
 ### How do I customize or configure the log output?
 
-Karpenter uses [uber-go/zap](https://github.com/uber-go/zap) for logging. You can customize the logging configuration with the following environment variables:
+Karpenter's logging can be customized with the following environment variables:
 
 * `LOG_LEVEL`
 * `LOG_OUTPUT_PATHS`

--- a/website/content/en/v1.8/faq.md
+++ b/website/content/en/v1.8/faq.md
@@ -268,7 +268,7 @@ Consolidation packs pods tightly onto nodes which can leave little free allocata
 
 ### How do I customize or configure the log output?
 
-Karpenter uses [uber-go/zap](https://github.com/uber-go/zap) for logging. You can customize the logging configuration with the following environment variables:
+Karpenter's logging can be customized with the following environment variables:
 
 * `LOG_LEVEL`
 * `LOG_OUTPUT_PATHS`

--- a/website/content/en/v1.9/faq.md
+++ b/website/content/en/v1.9/faq.md
@@ -268,7 +268,7 @@ Consolidation packs pods tightly onto nodes which can leave little free allocata
 
 ### How do I customize or configure the log output?
 
-Karpenter uses [uber-go/zap](https://github.com/uber-go/zap) for logging. You can customize the logging configuration with the following environment variables:
+Karpenter's logging can be customized with the following environment variables:
 
 * `LOG_LEVEL`
 * `LOG_OUTPUT_PATHS`


### PR DESCRIPTION
Fixes #8233

**Description**

Per [Upgrading - v1 Migration](https://karpenter.sh/v1.0/upgrading/v1-migration/#zap-logging-config-removed) - the Zap logging config was deprecated in `v0.32.0` and removed in `v1.0.0`, and there are new variables to configure logging

This updates the docs to remove the references to the configmap, and lists the 3 environment variables available for configuration 

**How was this change tested?**

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.