### PR TITLE
chore: Add instances ineligible for free tier error

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -246,6 +246,9 @@ func ToReasonMessage(err error) (string, string) {
 	if strings.Contains(err.Error(), "InternalError") {
 		return "InternalError", "An internal error has occurred"
 	}
+	if strings.Contains(err.Error(), "not eligible for Free Tier") {
+		return "FreeTierIneligible", "The specified instance type is not eligible for Free Tier"
+	}
 	// ICE Errors come last in this list because we should return a generic ICE error if all of the errors that are returned from
 	// fleet are ICE errors
 	if strings.Contains(err.Error(), "MaxFleetCountExceeded") {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds "instance type not eligible for Free Tier" error for nodeclaim launch failure classification

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.