### PR TITLE
fix: make instance profile naming deterministic to prevent churn

### DIFF
--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
@@ -507,7 +506,7 @@ func (in *EC2NodeClass) LegacyInstanceProfileName(clusterName, region string) st
 }
 
 func (in *EC2NodeClass) InstanceProfileName(clusterName, region string) string {
-	return fmt.Sprintf("%s_%d", clusterName, lo.Must(hashstructure.Hash(fmt.Sprintf("%s%s%s", region, in.Name, uuid.New().String()), hashstructure.FormatV2, nil)))
+	return fmt.Sprintf("%s_%d", clusterName, lo.Must(hashstructure.Hash(fmt.Sprintf("%s%s%s", region, in.Name, in.Spec.Role), hashstructure.FormatV2, nil)))
 }
 
 func (in *EC2NodeClass) InstanceProfileRole() string {

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -17,6 +17,7 @@ package nodeclass
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
@@ -75,7 +76,12 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 		}
 
 		// If role has changed, create new profile
-		if currentRole != nodeClass.Spec.Role {
+		// Normalize role names by stripping IAM path prefixes before comparison.
+		// IAM returns role names without paths (e.g., "my-role" instead of "/custom-path/my-role"),
+		// so comparing the raw values would cause false mismatches after cache expiry.
+		normalizedCurrentRole := lo.LastOr(strings.Split(currentRole, "/"), currentRole)
+		normalizedSpecRole := lo.LastOr(strings.Split(nodeClass.Spec.Role, "/"), nodeClass.Spec.Role)
+		if normalizedCurrentRole != normalizedSpecRole {
 			// Generate new profile name
 			newProfileName := nodeClass.InstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
 

--- a/pkg/controllers/nodeclass/instanceprofile_test.go
+++ b/pkg/controllers/nodeclass/instanceprofile_test.go
@@ -467,9 +467,9 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		profileA2 := nodeClass.Status.InstanceProfile
 
-		// Verify unique names even when reusing role-A
-		Expect(profileA2).NotTo(Equal(profileA))
-		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(4))
+		// With deterministic naming, returning to the same role reuses the same profile name
+		Expect(profileA2).To(Equal(profileA))
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(3))
 	})
 
 	It("should return error on transient failures getting instance profile", func() {
@@ -547,5 +547,76 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(0))
 		Expect(awsEnv.IAMAPI.DeleteInstanceProfileBehavior.CalledWithInput.Len()).To(Equal(1))
+	})
+
+	It("should not create duplicate profiles when cache expires and status is lost", func() {
+		nodeClass.Spec.Role = "role-A"
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		initialProfileName := nodeClass.Status.InstanceProfile
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
+
+		// Simulate cache expiry and status patch failure (controller restart scenario)
+		awsEnv.InstanceProfileCache.Flush()
+		awsEnv.RecreationCache.Flush()
+		nodeClass.Status.InstanceProfile = ""
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+
+		// Should reuse the same deterministic profile name, not create a new one
+		Expect(nodeClass.Status.InstanceProfile).To(Equal(initialProfileName))
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
+	})
+
+	It("should not create duplicate profiles when IAM returns profile with empty roles", func() {
+		nodeClass.Spec.Role = "role-A"
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		profileName := nodeClass.Status.InstanceProfile
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
+
+		// Simulate IAM eventual consistency: profile exists but roles list is empty
+		awsEnv.IAMAPI.InstanceProfiles[profileName].Roles = []iamtypes.Role{}
+		awsEnv.InstanceProfileCache.Flush()
+
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		// Deterministic naming generates the same name, provider finds existing profile and re-attaches role
+		Expect(nodeClass.Status.InstanceProfile).To(Equal(profileName))
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
+	})
+
+	It("should not create new profile when IAM returns role name without path prefix", func() {
+		nodeClass.Spec.Role = "/custom-path/role-A"
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		profileName := nodeClass.Status.InstanceProfile
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
+
+		// IAM strips path prefixes from role names in its responses.
+		// Simulate this by replacing the cached role with the path-stripped version.
+		awsEnv.IAMAPI.InstanceProfiles[profileName].Roles = []iamtypes.Role{
+			{RoleName: aws.String("role-A")},
+		}
+		awsEnv.InstanceProfileCache.Flush()
+
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		// Path normalization should prevent the reconciler from treating this as a role change
+		Expect(nodeClass.Status.InstanceProfile).To(Equal(profileName))
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
+		Expect(awsEnv.IAMAPI.CreateInstanceProfileBehavior.Calls()).To(Equal(1))
 	})
 })


### PR DESCRIPTION
## Summary
Fixes #8838

- Replace `uuid.New()` with `in.Spec.Role` in `InstanceProfileName()` hash input, making profile names deterministic per (nodeclass, role) pair. This prevents runaway instance profile creation caused by IAM eventual consistency triggering the creation branch with a new UUID-based name each time.
- Normalize role name comparison in the reconciler by stripping IAM path prefixes before comparing `currentRole` with `spec.Role`, preventing false mismatches when roles use IAM paths.

## Root Cause

Two reinforcing bugs caused a sawtooth pattern in instance profile counts after upgrading from v1.6 to v1.7+:

1. **Non-deterministic naming**: `InstanceProfileName()` used `uuid.New()`, so every call produced a different name
2. **False empty `currentRole`**: IAM eventual consistency (empty roles, NotFound), empty status, or controller restarts caused the reconciler to think no profile existed

Together: cache expires → IAM returns stale data → role mismatch → new UUID-named profile created → old profile orphaned → GC cleans up → repeat every ~15 min.

## Fix

Making `InstanceProfileName()` deterministic by including `spec.Role` in the hash means even when the reconciler falsely enters the creation branch, it generates the **same** name. The provider's `Create` finds the existing profile, calls `ensureRole` (idempotent), and returns — no orphan created.

Role changes still produce different profile names (different role → different hash), preserving zero-downtime role switching.

## Edge Cases

| Scenario | Behavior |
|---|---|
| Upgrading from v1.6 (legacy names) | Get(legacyName) finds profile, role matches, no creation |
| Upgrading from v1.7/v1.8 (UUID names) | Get(uuidName) finds profile, role matches, no creation |
| Status patch failure + controller restart | Deterministic name regenerated, Create finds existing profile |
| Role change | New deterministic name, new profile, old one cleaned by GC |
| Role with IAM path prefix | Path normalization prevents false mismatches |
