### PR TITLE
fix: Avoid hash collisions for instance type zone info

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -218,7 +218,7 @@ func (p *DefaultProvider) get(ctx context.Context, nodeClass NodeClass, name ec2
 
 func (p *DefaultProvider) cacheKey(nodeClass NodeClass) string {
 	// Compute fully initialized instance types hash key
-	subnetZonesHash, _ := hashstructure.Hash(nodeClass.ZoneInfo(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	subnetZonesHash := hashZoneInfo(nodeClass.ZoneInfo())
 	// Compute hash key against node class AMIs (used to force cache rebuild when AMIs change)
 	amiHash, _ := hashstructure.Hash(nodeClass.AMIs(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	return fmt.Sprintf("%016x-%016x-%s",
@@ -360,4 +360,14 @@ func (p *DefaultProvider) Reset() {
 func discoveredCapacityCacheKey(instanceType string, nodeClass NodeClass) string {
 	amiHash, _ := hashstructure.Hash(nodeClass.AMIs(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	return fmt.Sprintf("%s-%016x", instanceType, amiHash)
+}
+
+// hashZoneInfo hashes each ZoneInfo element individually and collects the hashes
+// into a set, avoiding the hashstructure SlicesAsSets bug from https://github.com/mitchellh/hashstructure/issues/36
+func hashZoneInfo(zoneInfo []v1.ZoneInfo) uint64 {
+	zoneInfoHashes := sets.New[uint64]()
+	for i := range zoneInfo {
+		zoneInfoHashes.Insert(lo.Must(hashstructure.Hash(zoneInfo[i], hashstructure.FormatV2, nil)))
+	}
+	return lo.Must(hashstructure.Hash(zoneInfoHashes, hashstructure.FormatV2, nil))
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #8909 <!-- issue number -->

**Description**
* changes subnet hashing for getting the instance type provider key from hashing all zones to hash each zone at a time (and collecting them in a set)

* this fixes a bug where 2 NodeClasses can hash to the same value for instance type information - causing incorrect scheduling requirements to be injecting for the instance type

**How was this change tested?**

* e2e tests
* Manual Testing
2 different NodeClasses, both with 2 subnets in the same zone

NodeClass `default-2a`
```
  Subnets:
    Id:       subnet-xxx
    Zone:     us-west-2a
    Zone Id:  usw2-az1
    Id:       subnet-xxx
    Zone:     us-west-2a
    Zone Id:  usw2-az1
```

NodeClass `default-2d`
```
  Subnets:
    Id:       subnet-xxx
    Zone:     us-west-2d
    Zone Id:  usw2-az4
    Id:       subnet-xxx
    Zone:     us-west-2d
    Zone Id:  usw2-az4
```

Before, both NodeClasses hash to `823d249cb86005b7-0000000000000000-5232b832f0e630c6-0000000000000000-0000000000000000-0000000000000000--AL2023`

After this change
* `default-2a` hashes to `823d249cb86005b7-b2ba9a7eae2f7bf0-5232b832f0e630c6-0000000000000000-0000000000000000--AL2023`
* `default-2d` hashes to `823d249cb86005b7-1e7fa6f023970e3c-5232b832f0e630c6-0000000000000000-0000000000000000--AL2023`



**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.