### PR TITLE
fix: invalidate NodeClass on unsupported AMI alias

### DIFF
--- a/pkg/controllers/nodeclass/ami.go
+++ b/pkg/controllers/nodeclass/ami.go
@@ -47,7 +47,7 @@ func NewAMIReconciler(provider amifamily.Provider) *AMI {
 func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	amis, err := a.amiProvider.List(ctx, nodeClass)
 	if err != nil {
-		if amifamily.IsAl2DeprecationError(err) || amifamily.IsWS2025UnsupportedVersionError(err) {
+		if amifamily.IsAl2DeprecationError(err) || amifamily.IsWS2025UnsupportedVersionError(err) || amifamily.IsAMINotFoundForAliasError(err) {
 			nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "UnsupportedAlias", err.Error())
 			return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("getting amis, %w", err))
 		}

--- a/pkg/controllers/nodeclass/ami_test.go
+++ b/pkg/controllers/nodeclass/ami_test.go
@@ -618,6 +618,36 @@ var _ = Describe("NodeClass AMI Status Controller", func() {
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeAMIsReady)).To(BeFalse())
 	})
+	DescribeTable("should set UnsupportedAlias condition when no AMIs are found for alias", func(alias string) {
+		awsEnv.SSMAPI.Parameters = map[string]string{"not-real": "not-real"}
+
+		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
+		ExpectApplied(ctx, env.Client, nodeClass)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady).IsFalse()).To(BeTrue())
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady).Reason).To(Equal("UnsupportedAlias"))
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady).Message).To(ContainSubstring("failed to discover any AMIs for alias"))
+	},
+		Entry("AL2023 with invalid version", "al2023@v20240101"),
+		Entry("Bottlerocket with invalid version", "bottlerocket@v20240101"),
+		Entry("Windows with invalid version", "windows2022@latest"),
+	)
+	DescribeTable("should retry when SSM returns transient errors", func(alias string) {
+		awsEnv.SSMAPI.WantErr = fmt.Errorf("RequestLimitExceeded: Rate exceeded")
+
+		nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
+		ExpectApplied(ctx, env.Client, nodeClass)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeAMIsReady).Reason).ToNot(Equal("UnsupportedAlias"))
+	},
+		Entry("AL2023 with invalid version", "al2023@v20240101"),
+		Entry("Bottlerocket with invalid version", "bottlerocket@v20240101"),
+		Entry("Windows with invalid version", "windows2022@latest"),
+	)
 	Context("NodeClass AMI Status", func() {
 		BeforeEach(func() {
 			// Set time using the injectable/fake clock to now

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -44,6 +44,7 @@ var (
 		"QueueDoesNotExist",
 		"NoSuchEntity",
 		"ParameterNotFound",
+		"ParameterVersionNotFound",
 	)
 	alreadyExistsErrorCodes = sets.New(
 		"EntityAlreadyExists",

--- a/pkg/fake/ssmapi.go
+++ b/pkg/fake/ssmapi.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 
 	"github.com/Pallinder/go-randomdata"
-	"github.com/awslabs/operatorpkg/serrors"
 	"github.com/samber/lo"
 
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
 
 	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
 )
@@ -54,7 +54,10 @@ func (a SSMAPI) GetParameter(_ context.Context, input *ssm.GetParameterInput, _ 
 	if len(a.Parameters) != 0 {
 		value, ok := a.Parameters[parameter]
 		if !ok {
-			return &ssm.GetParameterOutput{}, serrors.Wrap(fmt.Errorf("parameter not found"), "parameter", lo.FromPtr(input.Name))
+			return &ssm.GetParameterOutput{}, &smithy.GenericAPIError{
+				Code:    "ParameterNotFound",
+				Message: fmt.Sprintf("parameter %s not found", parameter),
+			}
 		}
 		return &ssm.GetParameterOutput{
 			Parameter: &ssmtypes.Parameter{

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/errors"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 
@@ -42,6 +43,7 @@ type AL2 struct {
 
 func (a AL2) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
 	ids := map[string][]Variant{}
+	isAllNotFoundErrors := true
 	for path, variants := range map[string][]Variant{
 		fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/%s/image_id", k8sVersion, lo.Ternary(
 			amiVersion == v1.AliasVersionLatest,
@@ -64,12 +66,18 @@ func (a AL2) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k
 			IsMutable: amiVersion == v1.AliasVersionLatest,
 		})
 		if err != nil {
+			isAllNotFoundErrors = isAllNotFoundErrors && errors.IsNotFound(err)
 			continue
 		}
 		ids[imageID] = variants
 	}
 	// Failed to discover any AMIs, we should short circuit AMI discovery
 	if len(ids) == 0 {
+		if isAllNotFoundErrors {
+			return DescribeImageQuery{}, &AMINotFoundForAliasError{
+				error: serrors.Wrap(fmt.Errorf("failed to discover any AMIs for alias"), "alias", fmt.Sprintf("al2@%s", amiVersion)),
+			}
+		}
 		return DescribeImageQuery{}, serrors.Wrap(fmt.Errorf("failed to discover any AMIs for alias"), "alias", fmt.Sprintf("al2@%s", amiVersion))
 	}
 

--- a/pkg/providers/amifamily/al2023.go
+++ b/pkg/providers/amifamily/al2023.go
@@ -27,6 +27,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily/bootstrap"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/ssm"
 )
@@ -38,6 +39,7 @@ type AL2023 struct {
 
 func (a AL2023) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k8sVersion string, amiVersion string) (DescribeImageQuery, error) {
 	ids := map[string]Variant{}
+	isAllNotFoundErrors := true
 	for arch, variants := range map[string][]Variant{
 		"x86_64": {VariantStandard, VariantNvidia, VariantNeuron},
 		"arm64":  {VariantStandard, VariantNvidia},
@@ -49,6 +51,7 @@ func (a AL2023) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider
 				IsMutable: amiVersion == v1.AliasVersionLatest,
 			})
 			if err != nil {
+				isAllNotFoundErrors = isAllNotFoundErrors && errors.IsNotFound(err)
 				continue
 			}
 			ids[imageID] = variant
@@ -56,6 +59,11 @@ func (a AL2023) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider
 	}
 	// Failed to discover any AMIs, we should short circuit AMI discovery
 	if len(ids) == 0 {
+		if isAllNotFoundErrors {
+			return DescribeImageQuery{}, &AMINotFoundForAliasError{
+				error: serrors.Wrap(fmt.Errorf("failed to discover any AMIs for alias"), "alias", fmt.Sprintf("al2023@%s", amiVersion)),
+			}
+		}
 		return DescribeImageQuery{}, serrors.Wrap(fmt.Errorf("failed to discover any AMIs for alias"), "alias", fmt.Sprintf("al2023@%s", amiVersion))
 	}
 

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samber/lo"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily/bootstrap"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/ssm"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
@@ -45,6 +46,7 @@ func (b Bottlerocket) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Pr
 	// Bottlerocket AMIs versions are prefixed with a v on GitHub, but not in the SSM path. We should accept both.
 	trimmedAMIVersion := strings.TrimLeft(amiVersion, "v")
 	ids := map[string][]Variant{}
+	isAllNotFoundErrors := true
 	for path, variants := range map[string][]Variant{
 		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/%s/image_id", k8sVersion, trimmedAMIVersion):        {VariantStandard, VariantNeuron},
 		fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/%s/image_id", k8sVersion, trimmedAMIVersion):         {VariantStandard},
@@ -56,12 +58,18 @@ func (b Bottlerocket) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Pr
 			IsMutable: amiVersion == v1.AliasVersionLatest,
 		})
 		if err != nil {
+			isAllNotFoundErrors = isAllNotFoundErrors && errors.IsNotFound(err)
 			continue
 		}
 		ids[imageID] = variants
 	}
 	// Failed to discover any AMIs, we should short circuit AMI discovery
 	if len(ids) == 0 {
+		if isAllNotFoundErrors {
+			return DescribeImageQuery{}, &AMINotFoundForAliasError{
+				error: serrors.Wrap(fmt.Errorf(`failed to discover any AMIs for alias`), "alias", fmt.Sprintf("bottlerocket@%s", amiVersion)),
+			}
+		}
 		return DescribeImageQuery{}, serrors.Wrap(fmt.Errorf(`failed to discover any AMIs for alias`), "alias", fmt.Sprintf("bottlerocket@%s", amiVersion))
 	}
 

--- a/pkg/providers/amifamily/types.go
+++ b/pkg/providers/amifamily/types.go
@@ -153,3 +153,15 @@ func IsWS2025UnsupportedVersionError(err error) bool {
 	var ws2025Err *WS2025UnsupportedVersionError
 	return errors.As(err, &ws2025Err)
 }
+
+type AMINotFoundForAliasError struct {
+	error
+}
+
+func IsAMINotFoundForAliasError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var notFoundErr *AMINotFoundForAliasError
+	return errors.As(err, &notFoundErr)
+}

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/errors"
 
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -53,6 +54,11 @@ func (w Windows) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provide
 		IsMutable: true,
 	})
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return DescribeImageQuery{}, &AMINotFoundForAliasError{
+				error: serrors.Wrap(fmt.Errorf("failed to discover any AMIs for alias"), "alias", fmt.Sprintf("windows%s@%s", w.Version, amiVersion)),
+			}
+		}
 		return DescribeImageQuery{}, serrors.Wrap(fmt.Errorf("failed to discover any AMIs for alias"), "alias", fmt.Sprintf("windows%s@%s", w.Version, amiVersion))
 	}
 	return DescribeImageQuery{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #9046

**Description**
* Change to mark the NodeClass as invalid when [SSM.GetParameter](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html) returns not found errors for AMIs

**How was this change tested?**
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.