### PR TITLE
feat: support EC2 DescribeInstanceStatus health checks in the interruption controller

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -89,6 +89,7 @@ func main() {
 			op.CapacityReservationProvider,
 			op.PlacementGroupProvider,
 			op.AMIResolver,
+			op.InstanceStatusProvider,
 		)...).
 		Start(ctx)
 }

--- a/kwok/main.go
+++ b/kwok/main.go
@@ -102,6 +102,7 @@ func main() {
 			op.CapacityReservationProvider,
 			op.PlacementGroupProvider,
 			op.AMIResolver,
+			op.InstanceStatusProvider,
 		)...).
 		Start(ctx)
 	wg.Wait()

--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -206,10 +206,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 
 	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)
 
-	// Setup field indexers on instanceID -- specifically for the interruption controller
-	if options.FromContext(ctx).InterruptionQueue != "" {
-		SetupIndexers(ctx, operator.Manager)
-	}
+	// Setup field indexers on instanceID -- used by the interruption and instance status controllers
+	SetupIndexers(ctx, operator.Manager)
 	return ctx, &Operator{
 		Operator:                    operator,
 		Config:                      cfg,

--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -59,6 +59,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/placementgroup"
@@ -92,6 +93,7 @@ type Operator struct {
 	VersionProvider             *version.DefaultProvider
 	InstanceTypesProvider       *instancetype.DefaultProvider
 	InstanceProvider            instance.Provider
+	InstanceStatusProvider      *instancestatus.DefaultProvider
 	SSMProvider                 ssmp.Provider
 	CapacityReservationProvider capacityreservation.Provider
 	PlacementGroupProvider      placementgroup.Provider
@@ -202,6 +204,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 	)
 
+	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)
+
 	// Setup field indexers on instanceID -- specifically for the interruption controller
 	if options.FromContext(ctx).InterruptionQueue != "" {
 		SetupIndexers(ctx, operator.Manager)
@@ -223,6 +227,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		PricingProvider:             pricingProvider,
 		InstanceTypesProvider:       instanceTypeProvider,
 		InstanceProvider:            instanceProvider,
+		InstanceStatusProvider:      instanceStatusProvider,
 		SSMProvider:                 ssmProvider,
 		CapacityReservationProvider: capacityReservationProvider,
 		PlacementGroupProvider:      placementGroupProvider,

--- a/pkg/aws/sdk.go
+++ b/pkg/aws/sdk.go
@@ -36,6 +36,7 @@ type EC2API interface {
 	DescribeInstanceTypes(context.Context, *ec2.DescribeInstanceTypesInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
 	DescribeInstanceTypeOfferings(context.Context, *ec2.DescribeInstanceTypeOfferingsInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypeOfferingsOutput, error)
 	DescribeSpotPriceHistory(context.Context, *ec2.DescribeSpotPriceHistoryInput, ...func(*ec2.Options)) (*ec2.DescribeSpotPriceHistoryOutput, error)
+	DescribeInstanceStatus(context.Context, *ec2.DescribeInstanceStatusInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceStatusOutput, error)
 	CreateFleet(context.Context, *ec2.CreateFleetInput, ...func(*ec2.Options)) (*ec2.CreateFleetOutput, error)
 	TerminateInstances(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
 	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
@@ -71,6 +72,7 @@ type SQSAPI interface {
 	ReceiveMessage(context.Context, *sqs.ReceiveMessageInput, ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
 	DeleteMessage(context.Context, *sqs.DeleteMessageInput, ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error)
 	SendMessage(context.Context, *sqs.SendMessageInput, ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
+	GetQueueUrl(context.Context, *sqs.GetQueueUrlInput, ...func(*sqs.Options)) (*sqs.GetQueueUrlOutput, error)
 }
 
 type TimestreamWriteAPI interface {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -39,6 +39,7 @@ import (
 	ssminvalidation "github.com/aws/karpenter-provider-aws/pkg/controllers/providers/ssm/invalidation"
 	controllersversion "github.com/aws/karpenter-provider-aws/pkg/controllers/providers/version"
 	capacityreservationprovider "github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/placementgroup"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
@@ -89,6 +90,7 @@ func NewControllers(
 	capacityReservationProvider capacityreservationprovider.Provider,
 	placementGroupProvider placementgroup.Provider,
 	amiResolver amifamily.Resolver,
+	instanceStatusProvider instancestatus.Provider,
 ) []controller.Controller {
 	controllers := []controller.Controller{
 		nodeclasshash.NewController(kubeClient),
@@ -113,7 +115,10 @@ func NewControllers(
 	if options.FromContext(ctx).InterruptionQueue != "" {
 		sqsAPI := servicesqs.NewFromConfig(cfg)
 		prov, _ := sqs.NewSQSProvider(ctx, sqsAPI)
-		controllers = append(controllers, interruption.NewController(kubeClient, cloudProvider, clk, recorder, prov, sqsAPI, unavailableOfferings, capacityReservationProvider))
+		controllers = append(controllers, interruption.NewController(kubeClient, cloudProvider, clk, recorder, prov, sqsAPI, unavailableOfferings, capacityReservationProvider, instanceStatusProvider))
+	} else {
+		// if no queue is configured, start the interruption controller with only instance status monitoring
+		controllers = append(controllers, interruption.NewController(kubeClient, cloudProvider, clk, recorder, nil, nil, unavailableOfferings, capacityReservationProvider, instanceStatusProvider))
 	}
 	return controllers
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -106,6 +106,7 @@ func NewControllers(
 		crcapacitytype.NewController(kubeClient, cloudProvider),
 		crexpiration.NewController(clk, kubeClient, cloudProvider, capacityReservationProvider),
 		metrics.NewController(kubeClient, cloudProvider),
+		interruption.NewInstanceStatusController(kubeClient, cloudProvider, clk, recorder, instanceStatusProvider),
 	}
 	// Instance profile garbage collection requires IAM API access. Skip registering the controller when running
 	// in isolated VPC mode to avoid initiating calls to public AWS endpoints that won’t be reachable.
@@ -115,10 +116,7 @@ func NewControllers(
 	if options.FromContext(ctx).InterruptionQueue != "" {
 		sqsAPI := servicesqs.NewFromConfig(cfg)
 		prov, _ := sqs.NewSQSProvider(ctx, sqsAPI)
-		controllers = append(controllers, interruption.NewController(kubeClient, cloudProvider, clk, recorder, prov, sqsAPI, unavailableOfferings, capacityReservationProvider, instanceStatusProvider))
-	} else {
-		// if no queue is configured, start the interruption controller with only instance status monitoring
-		controllers = append(controllers, interruption.NewController(kubeClient, cloudProvider, clk, recorder, nil, nil, unavailableOfferings, capacityReservationProvider, instanceStatusProvider))
+		controllers = append(controllers, interruption.NewController(kubeClient, cloudProvider, recorder, prov, sqsAPI, unavailableOfferings, capacityReservationProvider))
 	}
 	return controllers
 }

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -21,11 +21,6 @@ import (
 
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
-	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
-	"github.com/aws/karpenter-provider-aws/pkg/cache"
-	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/sqs"
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
 	"go.uber.org/multierr"
@@ -38,6 +33,12 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+
+	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
+	"github.com/aws/karpenter-provider-aws/pkg/cache"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/sqs"
 )
 
 // Controller is an AWS interruption controller.

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	sqsapi "github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
 	"github.com/awslabs/operatorpkg/reconciler"
@@ -34,7 +35,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
-	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
 	"github.com/aws/karpenter-provider-aws/pkg/cache"
 	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
@@ -47,7 +47,7 @@ import (
 type Controller struct {
 	InterruptionHandler
 	sqsProvider sqs.Provider
-	sqsAPI      sdk.SQSAPI
+	sqsAPI      *sqsapi.Client
 	parser      *EventParser
 	cm          *pretty.ChangeMonitor
 }
@@ -57,7 +57,7 @@ func NewController(
 	cloudProvider cloudprovider.CloudProvider,
 	recorder events.Recorder,
 	sqsProvider sqs.Provider,
-	sqsAPI sdk.SQSAPI,
+	sqsAPI *sqsapi.Client,
 	unavailableOfferingsCache *cache.UnavailableOfferings,
 	capacityReservationProvider capacityreservation.Provider,
 ) *Controller {

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	sqsapi "github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
@@ -43,11 +42,17 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/events"
 
+	lop "github.com/samber/lo/parallel"
+
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
 	"github.com/aws/karpenter-provider-aws/pkg/cache"
 	interruptionevents "github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/events"
 	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages/instancestatusfailure"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/sqs"
 )
 
@@ -58,20 +63,32 @@ const (
 	NoAction       Action = "NoAction"
 )
 
+var (
+	// InstatusStatusInterval is used to rate limit calls to the EC2 DescribeInstanceStatus API
+	// since the Interruption controller runs in a hot loop with an SQS long poller sub-reconciler.
+	// Without this rate limit, if there are a lot of messages in the SQS queue, DescribeInstanceStatus
+	// could be called continuously since the long polling receives messages in small batches.
+	InstanceStatusInterval = 30 * time.Second
+)
+
 // Controller is an AWS interruption controller.
 // It continually polls an SQS queue for events from aws.ec2 and aws.health that
 // trigger node health events, spot interruption/rebalance events, and capacity reservation interruptions.
 type Controller struct {
-	kubeClient                  client.Client
-	cloudProvider               cloudprovider.CloudProvider
-	clk                         clock.Clock
-	recorder                    events.Recorder
-	sqsProvider                 sqs.Provider
-	sqsAPI                      *sqsapi.Client
+	kubeClient    client.Client
+	cloudProvider cloudprovider.CloudProvider
+	clk           clock.Clock
+	recorder      events.Recorder
+	// sqsProvider can be nil when a queue is not configured by the user
+	sqsProvider sqs.Provider
+	// sqsAPI can be nil when a queue is not configured by the user
+	sqsAPI                      sdk.SQSAPI
 	unavailableOfferingsCache   *cache.UnavailableOfferings
+	instanceStatusProvider      instancestatus.Provider
 	capacityReservationProvider capacityreservation.Provider
 	parser                      *EventParser
 	cm                          *pretty.ChangeMonitor
+	lastInstanceStatusRun       time.Time
 }
 
 func NewController(
@@ -80,9 +97,10 @@ func NewController(
 	clk clock.Clock,
 	recorder events.Recorder,
 	sqsProvider sqs.Provider,
-	sqsAPI *sqsapi.Client,
+	sqsAPI sdk.SQSAPI,
 	unavailableOfferingsCache *cache.UnavailableOfferings,
 	capacityReservationProvider capacityreservation.Provider,
+	instanceStatusProvider instancestatus.Provider,
 ) *Controller {
 	return &Controller{
 		kubeClient:                  kubeClient,
@@ -93,6 +111,7 @@ func NewController(
 		sqsAPI:                      sqsAPI,
 		unavailableOfferingsCache:   unavailableOfferingsCache,
 		capacityReservationProvider: capacityReservationProvider,
+		instanceStatusProvider:      instanceStatusProvider,
 		parser:                      NewEventParser(DefaultParsers...),
 		cm:                          pretty.NewChangeMonitor(),
 	}
@@ -100,24 +119,68 @@ func NewController(
 
 func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 	ctx = injection.WithControllerName(ctx, "interruption")
-	if c.sqsProvider == nil {
-		prov, err := sqs.NewSQSProvider(ctx, c.sqsAPI)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to create valid sqs provider")
-			return reconciler.Result{}, fmt.Errorf("creating sqs provider, %w", err)
-		}
-		c.sqsProvider = prov
+
+	reconcilers := []func(context.Context) error{
+		c.reconcileFromSQS,
+		c.reconcileInstanceStatus,
 	}
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("queue", c.sqsProvider.Name()))
-	if c.cm.HasChanged(c.sqsProvider.Name(), nil) {
-		log.FromContext(ctx).V(1).Info("watching interruption queue")
+
+	errs := make([]error, len(reconcilers))
+	lop.ForEach(reconcilers, func(r func(context.Context) error, i int) {
+		errs[i] = r(ctx)
+	})
+
+	if err := multierr.Combine(errs...); err != nil {
+		return reconciler.Result{}, fmt.Errorf("reconciling interruptions, %w", err)
 	}
-	sqsMessages, err := c.sqsProvider.GetSQSMessages(ctx)
-	if err != nil {
-		return reconciler.Result{}, fmt.Errorf("getting messages from queue, %w", err)
-	}
-	if len(sqsMessages) == 0 {
+
+	if options.FromContext(ctx).InterruptionQueue != "" {
 		return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
+	}
+	return reconciler.Result{RequeueAfter: InstanceStatusInterval}, nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("interruption").
+		WatchesRawSource(singleton.Source()).
+		Complete(singleton.AsReconciler(c))
+}
+
+func (c *Controller) reconcileInstanceStatus(ctx context.Context) error {
+	// Pulling instance status more often can result in rate limiting when many SQS messages
+	// are received since the interruption controller runs in a hot loop
+	if c.clk.Since(c.lastInstanceStatusRun) < InstanceStatusInterval {
+		return nil
+	}
+	instanceStatuses, err := c.instanceStatusProvider.List(ctx)
+	if err != nil {
+		return fmt.Errorf("getting instance statuses %w", err)
+	}
+
+	errs := make([]error, len(instanceStatuses))
+	workqueue.ParallelizeUntil(ctx, 10, len(instanceStatuses), func(i int) {
+		if err := c.handleMessage(ctx, instancestatusfailure.Message(instanceStatuses[i])); err != nil {
+			errs[i] = fmt.Errorf("handling instance status check message, %w", err)
+		}
+	})
+	if err = multierr.Combine(errs...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) reconcileFromSQS(ctx context.Context) error {
+	if options.FromContext(ctx).InterruptionQueue == "" {
+		return nil
+	}
+	sqsMessages, err := c.sqsMessages(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(sqsMessages) == 0 {
+		return nil
 	}
 
 	errs := make([]error, len(sqsMessages))
@@ -136,16 +199,34 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		errs[i] = c.deleteMessage(ctx, sqsMessages[i])
 	})
 	if err = multierr.Combine(errs...); err != nil {
-		return reconciler.Result{}, err
+		return err
 	}
-	return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
+	return nil
 }
 
-func (c *Controller) Register(_ context.Context, m manager.Manager) error {
-	return controllerruntime.NewControllerManagedBy(m).
-		Named("interruption").
-		WatchesRawSource(singleton.Source()).
-		Complete(singleton.AsReconciler(c))
+func (c *Controller) sqsMessages(ctx context.Context) ([]*sqstypes.Message, error) {
+	if c.sqsAPI == nil {
+		return nil, nil
+	}
+	// If the provider was unable to instantiate, keep trying.
+	// This would most likely be due to a permissions issue that can be fixed at runtime.
+	if c.sqsProvider == nil {
+		prov, err := sqs.NewSQSProvider(ctx, c.sqsAPI)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to create valid sqs provider")
+			return nil, fmt.Errorf("creating sqs provider, %w", err)
+		}
+		c.sqsProvider = prov
+	}
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("queue", c.sqsProvider.Name()))
+	if c.cm.HasChanged(c.sqsProvider.Name(), nil) {
+		log.FromContext(ctx).V(1).Info("watching interruption queue")
+	}
+	sqsMessages, err := c.sqsProvider.GetSQSMessages(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting messages from queue, %w", err)
+	}
+	return sqsMessages, nil
 }
 
 // parseMessage parses the passed SQS message into an internal Message interface
@@ -270,7 +351,7 @@ func (c *Controller) notifyForMessage(msg messages.Message, nodeClaim *karpv1.No
 	case messages.RebalanceRecommendationKind:
 		c.recorder.Publish(interruptionevents.RebalanceRecommendation(n, nodeClaim)...)
 
-	case messages.ScheduledChangeKind:
+	case messages.ScheduledChangeKind, messages.InstanceStatusFailure:
 		c.recorder.Publish(interruptionevents.Unhealthy(n, nodeClaim)...)
 
 	case messages.SpotInterruptionKind:
@@ -291,7 +372,7 @@ func (c *Controller) notifyForMessage(msg messages.Message, nodeClaim *karpv1.No
 
 func actionForMessage(msg messages.Message) Action {
 	switch msg.Kind() {
-	case messages.ScheduledChangeKind, messages.SpotInterruptionKind, messages.InstanceStoppedKind, messages.InstanceTerminatedKind, messages.CapacityReservationInterruptionKind:
+	case messages.ScheduledChangeKind, messages.SpotInterruptionKind, messages.InstanceStoppedKind, messages.InstanceTerminatedKind, messages.CapacityReservationInterruptionKind, messages.InstanceStatusFailure:
 		return CordonAndDrain
 	default:
 		return NoAction

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -19,175 +19,83 @@ import (
 	"fmt"
 	"time"
 
-	"sigs.k8s.io/karpenter/pkg/cloudprovider"
-	"sigs.k8s.io/karpenter/pkg/metrics"
-
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
+	"github.com/aws/karpenter-provider-aws/pkg/cache"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/sqs"
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
 	"go.uber.org/multierr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
-	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/karpenter/pkg/operator/injection"
-
-	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
-	"sigs.k8s.io/karpenter/pkg/utils/pretty"
-
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
-
-	lop "github.com/samber/lo/parallel"
-
-	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
-	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
-	"github.com/aws/karpenter-provider-aws/pkg/cache"
-	interruptionevents "github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/events"
-	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
-	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages/instancestatusfailure"
-	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/sqs"
-)
-
-type Action string
-
-const (
-	CordonAndDrain Action = "CordonAndDrain"
-	NoAction       Action = "NoAction"
-)
-
-var (
-	// InstatusStatusInterval is used to rate limit calls to the EC2 DescribeInstanceStatus API
-	// since the Interruption controller runs in a hot loop with an SQS long poller sub-reconciler.
-	// Without this rate limit, if there are a lot of messages in the SQS queue, DescribeInstanceStatus
-	// could be called continuously since the long polling receives messages in small batches.
-	InstanceStatusInterval = 30 * time.Second
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
 // Controller is an AWS interruption controller.
 // It continually polls an SQS queue for events from aws.ec2 and aws.health that
 // trigger node health events, spot interruption/rebalance events, and capacity reservation interruptions.
 type Controller struct {
-	kubeClient    client.Client
-	cloudProvider cloudprovider.CloudProvider
-	clk           clock.Clock
-	recorder      events.Recorder
-	// sqsProvider can be nil when a queue is not configured by the user
+	InterruptionHandler
 	sqsProvider sqs.Provider
-	// sqsAPI can be nil when a queue is not configured by the user
-	sqsAPI                      sdk.SQSAPI
-	unavailableOfferingsCache   *cache.UnavailableOfferings
-	instanceStatusProvider      instancestatus.Provider
-	capacityReservationProvider capacityreservation.Provider
-	parser                      *EventParser
-	cm                          *pretty.ChangeMonitor
-	lastInstanceStatusRun       time.Time
+	sqsAPI      sdk.SQSAPI
+	parser      *EventParser
+	cm          *pretty.ChangeMonitor
 }
 
 func NewController(
 	kubeClient client.Client,
 	cloudProvider cloudprovider.CloudProvider,
-	clk clock.Clock,
 	recorder events.Recorder,
 	sqsProvider sqs.Provider,
 	sqsAPI sdk.SQSAPI,
 	unavailableOfferingsCache *cache.UnavailableOfferings,
 	capacityReservationProvider capacityreservation.Provider,
-	instanceStatusProvider instancestatus.Provider,
 ) *Controller {
 	return &Controller{
-		kubeClient:                  kubeClient,
-		cloudProvider:               cloudProvider,
-		clk:                         clk,
-		recorder:                    recorder,
-		sqsProvider:                 sqsProvider,
-		sqsAPI:                      sqsAPI,
-		unavailableOfferingsCache:   unavailableOfferingsCache,
-		capacityReservationProvider: capacityReservationProvider,
-		instanceStatusProvider:      instanceStatusProvider,
-		parser:                      NewEventParser(DefaultParsers...),
-		cm:                          pretty.NewChangeMonitor(),
+		InterruptionHandler: InterruptionHandler{
+			kubeClient:                  kubeClient,
+			cloudProvider:               cloudProvider,
+			recorder:                    recorder,
+			unavailableOfferingsCache:   unavailableOfferingsCache,
+			capacityReservationProvider: capacityReservationProvider,
+		},
+		sqsProvider: sqsProvider,
+		sqsAPI:      sqsAPI,
+		parser:      NewEventParser(DefaultParsers...),
+		cm:          pretty.NewChangeMonitor(),
 	}
 }
 
 func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 	ctx = injection.WithControllerName(ctx, "interruption")
 
-	reconcilers := []func(context.Context) error{
-		c.reconcileFromSQS,
-		c.reconcileInstanceStatus,
+	if c.sqsProvider == nil {
+		prov, err := sqs.NewSQSProvider(ctx, c.sqsAPI)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to create valid sqs provider")
+			return reconciler.Result{}, fmt.Errorf("creating sqs provider, %w", err)
+		}
+		c.sqsProvider = prov
 	}
-
-	errs := make([]error, len(reconcilers))
-	lop.ForEach(reconcilers, func(r func(context.Context) error, i int) {
-		errs[i] = r(ctx)
-	})
-
-	if err := multierr.Combine(errs...); err != nil {
-		return reconciler.Result{}, fmt.Errorf("reconciling interruptions, %w", err)
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("queue", c.sqsProvider.Name()))
+	if c.cm.HasChanged(c.sqsProvider.Name(), nil) {
+		log.FromContext(ctx).V(1).Info("watching interruption queue")
 	}
-
-	if options.FromContext(ctx).InterruptionQueue != "" {
-		return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
-	}
-	return reconciler.Result{RequeueAfter: InstanceStatusInterval}, nil
-}
-
-func (c *Controller) Register(_ context.Context, m manager.Manager) error {
-	return controllerruntime.NewControllerManagedBy(m).
-		Named("interruption").
-		WatchesRawSource(singleton.Source()).
-		Complete(singleton.AsReconciler(c))
-}
-
-func (c *Controller) reconcileInstanceStatus(ctx context.Context) error {
-	// Pulling instance status more often can result in rate limiting when many SQS messages
-	// are received since the interruption controller runs in a hot loop
-	if c.clk.Since(c.lastInstanceStatusRun) < InstanceStatusInterval {
-		return nil
-	}
-	instanceStatuses, err := c.instanceStatusProvider.List(ctx)
+	sqsMessages, err := c.sqsProvider.GetSQSMessages(ctx)
 	if err != nil {
-		return fmt.Errorf("getting instance statuses %w", err)
+		return reconciler.Result{}, fmt.Errorf("getting messages from queue, %w", err)
 	}
-
-	errs := make([]error, len(instanceStatuses))
-	workqueue.ParallelizeUntil(ctx, 10, len(instanceStatuses), func(i int) {
-		categories := map[string]bool{}
-		for _, d := range instanceStatuses[i].Details {
-			categories[string(d.Category)] = true
-		}
-		for cat := range categories {
-			InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
-		}
-		if err := c.handleMessage(ctx, instancestatusfailure.Message(instanceStatuses[i])); err != nil {
-			errs[i] = fmt.Errorf("handling instance status check message, %w", err)
-		}
-	})
-	if err = multierr.Combine(errs...); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *Controller) reconcileFromSQS(ctx context.Context) error {
-	if options.FromContext(ctx).InterruptionQueue == "" {
-		return nil
-	}
-	sqsMessages, err := c.sqsMessages(ctx)
-	if err != nil {
-		return err
-	}
-
 	if len(sqsMessages) == 0 {
-		return nil
+		return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
 	}
 
 	errs := make([]error, len(sqsMessages))
@@ -199,41 +107,25 @@ func (c *Controller) reconcileFromSQS(ctx context.Context) error {
 			errs[i] = c.deleteMessage(ctx, sqsMessages[i])
 			return
 		}
+		ReceivedMessages.Inc(map[string]string{messageTypeLabel: string(msg.Kind())})
 		if e = c.handleMessage(ctx, msg); e != nil {
 			errs[i] = fmt.Errorf("handling message, %w", e)
 			return
 		}
+		MessageLatency.Observe(time.Since(msg.StartTime()).Seconds(), nil)
 		errs[i] = c.deleteMessage(ctx, sqsMessages[i])
 	})
 	if err = multierr.Combine(errs...); err != nil {
-		return err
+		return reconciler.Result{}, err
 	}
-	return nil
+	return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
 }
 
-func (c *Controller) sqsMessages(ctx context.Context) ([]*sqstypes.Message, error) {
-	if c.sqsAPI == nil {
-		return nil, nil
-	}
-	// If the provider was unable to instantiate, keep trying.
-	// This would most likely be due to a permissions issue that can be fixed at runtime.
-	if c.sqsProvider == nil {
-		prov, err := sqs.NewSQSProvider(ctx, c.sqsAPI)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to create valid sqs provider")
-			return nil, fmt.Errorf("creating sqs provider, %w", err)
-		}
-		c.sqsProvider = prov
-	}
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("queue", c.sqsProvider.Name()))
-	if c.cm.HasChanged(c.sqsProvider.Name(), nil) {
-		log.FromContext(ctx).V(1).Info("watching interruption queue")
-	}
-	sqsMessages, err := c.sqsProvider.GetSQSMessages(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting messages from queue, %w", err)
-	}
-	return sqsMessages, nil
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("interruption").
+		WatchesRawSource(singleton.Source()).
+		Complete(singleton.AsReconciler(c))
 }
 
 // parseMessage parses the passed SQS message into an internal Message interface
@@ -249,139 +141,10 @@ func (c *Controller) parseMessage(raw *sqstypes.Message) (messages.Message, erro
 	return msg, nil
 }
 
-// handleMessage takes an action against every node involved in the message that is owned by a NodePool
-func (c *Controller) handleMessage(ctx context.Context, msg messages.Message) (err error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("messageKind", msg.Kind()))
-	ReceivedMessages.Inc(map[string]string{messageTypeLabel: string(msg.Kind())})
-
-	if msg.Kind() == messages.NoOpKind {
-		return nil
-	}
-	for _, instanceID := range msg.EC2InstanceIDs() {
-		nodeClaimList := &karpv1.NodeClaimList{}
-		if e := c.kubeClient.List(ctx, nodeClaimList, client.MatchingFields{"status.instanceID": instanceID}); e != nil {
-			err = multierr.Append(err, e)
-			continue
-		}
-		if len(nodeClaimList.Items) == 0 {
-			continue
-		}
-		for _, nodeClaim := range nodeClaimList.Items {
-			nodeList := &corev1.NodeList{}
-			if e := c.kubeClient.List(ctx, nodeList, client.MatchingFields{"spec.instanceID": instanceID}); e != nil {
-				err = multierr.Append(err, e)
-				continue
-			}
-			var node *corev1.Node
-			if len(nodeList.Items) > 0 {
-				node = &nodeList.Items[0]
-			}
-			if e := c.handleNodeClaim(ctx, msg, &nodeClaim, node); e != nil {
-				err = multierr.Append(err, e)
-			}
-		}
-	}
-	MessageLatency.Observe(time.Since(msg.StartTime()).Seconds(), nil)
-	if err != nil {
-		return fmt.Errorf("acting on NodeClaims, %w", err)
-	}
-	return nil
-}
-
-// deleteMessage removes the passed SQS message from the queue and fires a metric for the deletion
 func (c *Controller) deleteMessage(ctx context.Context, msg *sqstypes.Message) error {
 	if err := c.sqsProvider.DeleteSQSMessage(ctx, msg); err != nil {
 		return fmt.Errorf("deleting sqs message, %w", err)
 	}
 	DeletedMessages.Inc(nil)
 	return nil
-}
-
-// handleNodeClaim retrieves the action for the message and then performs the appropriate action against the node
-func (c *Controller) handleNodeClaim(ctx context.Context, msg messages.Message, nodeClaim *karpv1.NodeClaim, node *corev1.Node) error {
-	action := actionForMessage(msg)
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("NodeClaim", klog.KObj(nodeClaim), "action", string(action)))
-	if node != nil {
-		ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KObj(node)))
-	}
-
-	// Record metric and event for this action
-	c.notifyForMessage(msg, nodeClaim, node)
-
-	// Mark the offering as unavailable in the ICE cache since we got a spot interruption warning
-	if msg.Kind() == messages.SpotInterruptionKind {
-		zone := nodeClaim.Labels[corev1.LabelTopologyZone]
-		instanceType := nodeClaim.Labels[corev1.LabelInstanceTypeStable]
-		if zone != "" && instanceType != "" {
-			unavailableReason := map[string]string{
-				"reason": string(msg.Kind()),
-			}
-			c.unavailableOfferingsCache.MarkUnavailable(ctx, ec2types.InstanceType(instanceType), zone, karpv1.CapacityTypeSpot, unavailableReason)
-		}
-	}
-
-	// Mark the reservation as unavailable in the ICE cache since we got a capacity reservation interruption warning
-	if msg.Kind() == messages.CapacityReservationInterruptionKind {
-		reservationID := nodeClaim.Labels[v1.LabelCapacityReservationID]
-		if reservationID != "" {
-			c.capacityReservationProvider.MarkUnavailable(reservationID)
-		}
-	}
-
-	if action != NoAction {
-		return c.deleteNodeClaim(ctx, msg, nodeClaim, node)
-	}
-	return nil
-}
-
-// deleteNodeClaim removes the NodeClaim from the api-server
-func (c *Controller) deleteNodeClaim(ctx context.Context, msg messages.Message, nodeClaim *karpv1.NodeClaim, node *corev1.Node) error {
-	if !nodeClaim.DeletionTimestamp.IsZero() {
-		return nil
-	}
-	if err := c.kubeClient.Delete(ctx, nodeClaim); err != nil {
-		return client.IgnoreNotFound(fmt.Errorf("deleting the node on interruption message, %w", err))
-	}
-	log.FromContext(ctx).Info("initiating delete from interruption message")
-	c.recorder.Publish(interruptionevents.TerminatingOnInterruption(node, nodeClaim)...)
-	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-		metrics.ReasonLabel:       string(msg.Kind()),
-		metrics.NodePoolLabel:     nodeClaim.Labels[karpv1.NodePoolLabelKey],
-		metrics.CapacityTypeLabel: nodeClaim.Labels[karpv1.CapacityTypeLabelKey],
-	})
-	return nil
-}
-
-// notifyForMessage publishes the relevant alert based on the message kind
-func (c *Controller) notifyForMessage(msg messages.Message, nodeClaim *karpv1.NodeClaim, n *corev1.Node) {
-	switch msg.Kind() {
-	case messages.RebalanceRecommendationKind:
-		c.recorder.Publish(interruptionevents.RebalanceRecommendation(n, nodeClaim)...)
-
-	case messages.ScheduledChangeKind, messages.InstanceStatusFailure:
-		c.recorder.Publish(interruptionevents.Unhealthy(n, nodeClaim)...)
-
-	case messages.SpotInterruptionKind:
-		c.recorder.Publish(interruptionevents.SpotInterrupted(n, nodeClaim)...)
-
-	case messages.CapacityReservationInterruptionKind:
-		c.recorder.Publish(interruptionevents.CapacityReservationInstanceInterrupted(n, nodeClaim)...)
-
-	case messages.InstanceStoppedKind:
-		c.recorder.Publish(interruptionevents.Stopping(n, nodeClaim)...)
-
-	case messages.InstanceTerminatedKind:
-		c.recorder.Publish(interruptionevents.Terminating(n, nodeClaim)...)
-
-	default:
-	}
-}
-
-func actionForMessage(msg messages.Message) Action {
-	switch msg.Kind() {
-	case messages.ScheduledChangeKind, messages.SpotInterruptionKind, messages.InstanceStoppedKind, messages.InstanceTerminatedKind, messages.CapacityReservationInterruptionKind, messages.InstanceStatusFailure:
-		return CordonAndDrain
-	default:
-		return NoAction
-	}
 }

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -160,6 +160,13 @@ func (c *Controller) reconcileInstanceStatus(ctx context.Context) error {
 
 	errs := make([]error, len(instanceStatuses))
 	workqueue.ParallelizeUntil(ctx, 10, len(instanceStatuses), func(i int) {
+		categories := map[string]bool{}
+		for _, d := range instanceStatuses[i].Details {
+			categories[string(d.Category)] = true
+		}
+		for cat := range categories {
+			InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
+		}
 		if err := c.handleMessage(ctx, instancestatusfailure.Message(instanceStatuses[i])); err != nil {
 			errs[i] = fmt.Errorf("handling instance status check message, %w", err)
 		}

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -1,0 +1,109 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interruption
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages/instancestatusfailure"
+	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
+	"github.com/awslabs/operatorpkg/reconciler"
+	"github.com/awslabs/operatorpkg/singleton"
+	"go.uber.org/multierr"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+)
+
+var (
+	// InstanceStatusInterval is the polling interval for the EC2 DescribeInstanceStatus API.
+	InstanceStatusInterval = 30 * time.Second
+	// UnauthorizedRequeueInterval is a longer polling interval used when the controller
+	// receives an unauthorized error from the EC2 DescribeInstanceStatus API.
+	UnauthorizedRequeueInterval = 3 * time.Minute
+)
+
+// InstanceStatusController polls EC2 DescribeInstanceStatus to detect unhealthy instances
+// and scheduled maintenance events, then cordons and drains affected nodes.
+type InstanceStatusController struct {
+	InterruptionHandler
+	clk                    clock.Clock
+	instanceStatusProvider instancestatus.Provider
+}
+
+func NewInstanceStatusController(
+	kubeClient client.Client,
+	cloudProvider cloudprovider.CloudProvider,
+	clk clock.Clock,
+	recorder events.Recorder,
+	instanceStatusProvider instancestatus.Provider,
+) *InstanceStatusController {
+	return &InstanceStatusController{
+		InterruptionHandler: InterruptionHandler{
+			kubeClient:    kubeClient,
+			cloudProvider: cloudProvider,
+			recorder:      recorder,
+		},
+		clk:                    clk,
+		instanceStatusProvider: instanceStatusProvider,
+	}
+}
+
+func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Result, error) {
+	ctx = injection.WithControllerName(ctx, "interruption.instancestatus")
+
+	instanceStatuses, err := c.instanceStatusProvider.List(ctx)
+	if err != nil {
+		if awserrors.IsUnauthorizedOperationError(err) {
+			log.FromContext(ctx).Error(err, "ec2:DescribeInstanceStatus permission is not allowed, instance status health checks will not be monitored")
+			return reconciler.Result{RequeueAfter: UnauthorizedRequeueInterval}, nil
+		}
+		return reconciler.Result{}, fmt.Errorf("getting instance statuses, %w", err)
+	}
+
+	errs := make([]error, len(instanceStatuses))
+	workqueue.ParallelizeUntil(ctx, 10, len(instanceStatuses), func(i int) {
+		categories := map[string]bool{}
+		for _, d := range instanceStatuses[i].Details {
+			categories[string(d.Category)] = true
+		}
+		for cat := range categories {
+			InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
+		}
+		if err := c.handleMessage(ctx, instancestatusfailure.Message(instanceStatuses[i])); err != nil {
+			errs[i] = fmt.Errorf("handling instance status check message, %w", err)
+		}
+	})
+	if err = multierr.Combine(errs...); err != nil {
+		return reconciler.Result{}, err
+	}
+	return reconciler.Result{RequeueAfter: InstanceStatusInterval}, nil
+}
+
+func (c *InstanceStatusController) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("interruption.instancestatus").
+		WatchesRawSource(singleton.Source()).
+		Complete(singleton.AsReconciler(c))
+}

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -40,9 +40,6 @@ import (
 var (
 	// InstanceStatusInterval is the polling interval for the EC2 DescribeInstanceStatus API.
 	InstanceStatusInterval = 1 * time.Minute
-	// UnauthorizedRequeueInterval is a longer polling interval used when the controller
-	// receives an unauthorized error from the EC2 DescribeInstanceStatus API.
-	UnauthorizedRequeueInterval = 3 * time.Minute
 )
 
 // InstanceStatusController polls EC2 DescribeInstanceStatus to detect unhealthy instances
@@ -77,8 +74,8 @@ func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Re
 	instanceStatuses, err := c.instanceStatusProvider.List(ctx)
 	if err != nil {
 		if awserrors.IsUnauthorizedOperationError(err) {
-			log.FromContext(ctx).Error(err, "ec2:DescribeInstanceStatus permission is not allowed, instance status health checks will not be monitored")
-			return reconciler.Result{RequeueAfter: UnauthorizedRequeueInterval}, nil
+			log.FromContext(ctx).Error(err, "ec2:DescribeInstanceStatus permission is not allowed, update the IAM policy and restart the Karpenter deployment to enable instance status health checks")
+			return reconciler.Result{}, nil
 		}
 		return reconciler.Result{}, fmt.Errorf("getting instance statuses, %w", err)
 	}

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -19,9 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages/instancestatusfailure"
-	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
 	"go.uber.org/multierr"
@@ -34,6 +31,10 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages/instancestatusfailure"
+	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 )
 
 var (

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	// InstanceStatusInterval is the polling interval for the EC2 DescribeInstanceStatus API.
-	InstanceStatusInterval = 30 * time.Second
+	InstanceStatusInterval = 1 * time.Minute
 	// UnauthorizedRequeueInterval is a longer polling interval used when the controller
 	// receives an unauthorized error from the EC2 DescribeInstanceStatus API.
 	UnauthorizedRequeueInterval = 3 * time.Minute

--- a/pkg/controllers/interruption/messages/instancestatusfailure/model.go
+++ b/pkg/controllers/interruption/messages/instancestatusfailure/model.go
@@ -1,0 +1,39 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancestatusfailure
+
+import (
+	"time"
+
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
+)
+
+// Message contains the Instance Status from EC2.DescribeInstanceStatus
+// This is not vended via EventBridge but is handled in a similar manner
+// as other EventBridge messages.
+type Message instancestatus.HealthStatus
+
+func (m Message) EC2InstanceIDs() []string {
+	return []string{m.InstanceID}
+}
+
+func (Message) Kind() messages.Kind {
+	return messages.InstanceStatusFailure
+}
+
+func (m Message) StartTime() time.Time {
+	return m.ImpairedSince
+}

--- a/pkg/controllers/interruption/messages/types.go
+++ b/pkg/controllers/interruption/messages/types.go
@@ -41,6 +41,7 @@ const (
 	InstanceStoppedKind                 Kind = "instance_stopped"
 	InstanceTerminatedKind              Kind = "instance_terminated"
 	CapacityReservationInterruptionKind Kind = "capacity_reservation_interrupted"
+	InstanceStatusFailure               Kind = "instance_status_failure"
 	NoOpKind                            Kind = "no_op"
 )
 

--- a/pkg/controllers/interruption/metrics.go
+++ b/pkg/controllers/interruption/metrics.go
@@ -25,6 +25,7 @@ import (
 const (
 	interruptionSubsystem = "interruption"
 	messageTypeLabel      = "message_type"
+	categoryLabel         = "category"
 )
 
 var (
@@ -58,5 +59,15 @@ var (
 			Buckets:   metrics.DurationBuckets(),
 		},
 		[]string{},
+	)
+	InstanceStatusUnhealthy = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: interruptionSubsystem,
+			Name:      "instance_status_unhealthy_total",
+			Help:      "Count of unhealthy instance statuses detected from EC2 DescribeInstanceStatus. Broken down by status check category.",
+		},
+		[]string{categoryLabel},
 	)
 )

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	servicesqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/aws/smithy-go"
@@ -94,7 +96,8 @@ var _ = BeforeSuite(func() {
 	sqsProvider = lo.Must(sqs.NewDefaultProvider(sqsapi, fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/test-cluster", fake.DefaultRegion, fake.DefaultAccount)))
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
 		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
-	controller = interruption.NewController(env.Client, cloudProvider, fakeClock, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, servicesqs.NewFromConfig(aws.Config{}), unavailableOfferingsCache, awsEnv.CapacityReservationProvider)
+	controller = interruption.NewController(env.Client, cloudProvider, fakeClock, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, sqsapi, unavailableOfferingsCache, awsEnv.CapacityReservationProvider, awsEnv.InstanceStatusProvider)
+	interruption.InstanceStatusInterval = 0
 })
 
 var _ = AfterSuite(func() {
@@ -103,6 +106,7 @@ var _ = AfterSuite(func() {
 
 var _ = BeforeEach(func() {
 	ctx = coreoptions.ToContext(ctx, coretest.Options(coretest.OptionsFields{FeatureGates: coretest.FeatureGates{ReservedCapacity: lo.ToPtr(true)}}))
+	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("test-cluster")}))
 	unavailableOfferingsCache.Flush()
 	sqsapi.Reset()
 })
@@ -312,12 +316,79 @@ var _ = Describe("InterruptionHandling", func() {
 
 			Expect(awsEnv.CapacityReservationProvider.GetAvailableInstanceCount("cr-56fac701cc1951b03")).To(Equal(0))
 		})
+		It("should delete the NodeClaim when an instance is unhealthy due to EC2 status checks", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						SystemStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusInitializing,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status: ec2types.StatusTypeInitializing,
+									Name:   ec2types.StatusNameReachability,
+								},
+							},
+						},
+					},
+				},
+			})
+			awsEnv.Clock.Step(time.Hour)
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+			ExpectSingletonReconciled(ctx, controller)
+			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel: "instance_status_failure",
+				"nodepool":          "default",
+			})
+			ExpectNotFound(ctx, env.Client, nodeClaim)
+		})
+		It("should NOT delete the NodeClaim when an instance is unhealthy due to a Scheduled Event Status or EBS Status", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						AttachedEbsStatus: &ec2types.EbsStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.EbsStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+						Events: []ec2types.InstanceStatusEvent{
+							{
+								Code: ec2types.EventCodeInstanceRetirement,
+							},
+						},
+					},
+				},
+			})
+			awsEnv.Clock.Step(time.Hour)
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+			ExpectSingletonReconciled(ctx, controller)
+			ExpectExists(ctx, env.Client, nodeClaim)
+		})
 	})
 })
 
 var _ = Describe("Error Handling", func() {
 	It("should send an error on polling when QueueNotExists", func() {
 		sqsapi.ReceiveMessageBehavior.Error.Set(smithyErrWithCode("QueueDoesNotExist"), fake.MaxCalls(0))
+		_ = ExpectSingletonReconcileFailed(ctx, controller)
 	})
 	It("should send an error on polling when AccessDenied", func() {
 		sqsapi.ReceiveMessageBehavior.Error.Set(smithyErrWithCode("AccessDenied"), fake.MaxCalls(0))

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -79,6 +79,7 @@ var sqsProvider *sqs.DefaultProvider
 var unavailableOfferingsCache *awscache.UnavailableOfferings
 var fakeClock *clock.FakeClock
 var controller *interruption.Controller
+var instanceStatusController *interruption.InstanceStatusController
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -96,8 +97,8 @@ var _ = BeforeSuite(func() {
 	sqsProvider = lo.Must(sqs.NewDefaultProvider(sqsapi, fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/test-cluster", fake.DefaultRegion, fake.DefaultAccount)))
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
 		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
-	controller = interruption.NewController(env.Client, cloudProvider, fakeClock, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, sqsapi, unavailableOfferingsCache, awsEnv.CapacityReservationProvider, awsEnv.InstanceStatusProvider)
-	interruption.InstanceStatusInterval = 0
+	controller = interruption.NewController(env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, sqsapi, unavailableOfferingsCache, awsEnv.CapacityReservationProvider)
+	instanceStatusController = interruption.NewInstanceStatusController(env.Client, cloudProvider, fakeClock, events.NewRecorder(&record.FakeRecorder{}), awsEnv.InstanceStatusProvider)
 })
 
 var _ = AfterSuite(func() {
@@ -352,7 +353,7 @@ var _ = Describe("InterruptionHandling", func() {
 			})
 			awsEnv.Clock.Step(time.Hour)
 			ExpectApplied(ctx, env.Client, nodeClaim, node)
-			ExpectSingletonReconciled(ctx, controller)
+			ExpectSingletonReconciled(ctx, instanceStatusController)
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
 				metrics.ReasonLabel: "instance_status_failure",
 				"nodepool":          "default",
@@ -386,7 +387,7 @@ var _ = Describe("InterruptionHandling", func() {
 			})
 			awsEnv.Clock.Step(time.Hour)
 			ExpectApplied(ctx, env.Client, nodeClaim, node)
-			ExpectSingletonReconciled(ctx, controller)
+			ExpectSingletonReconciled(ctx, instanceStatusController)
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
 	})

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -318,7 +318,7 @@ var _ = Describe("InterruptionHandling", func() {
 
 			Expect(awsEnv.CapacityReservationProvider.GetAvailableInstanceCount("cr-56fac701cc1951b03")).To(Equal(0))
 		})
-		It("should delete the NodeClaim when an instance is unhealthy due to EC2 status checks or scheduled events", func() {
+		It("should delete the NodeClaim when an instance is unhealthy due to EC2 status checks", func() {
 			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
 			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
 				InstanceStatuses: []ec2types.InstanceStatus{
@@ -343,11 +343,6 @@ var _ = Describe("InterruptionHandling", func() {
 								},
 							},
 						},
-						Events: []ec2types.InstanceStatusEvent{
-							{
-								Code: ec2types.EventCodeInstanceRetirement,
-							},
-						},
 					},
 				},
 			})
@@ -360,6 +355,28 @@ var _ = Describe("InterruptionHandling", func() {
 			})
 			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 1, map[string]string{
 				"category": "SystemStatus",
+			})
+			ExpectNotFound(ctx, env.Client, nodeClaim)
+		})
+		It("should delete the NodeClaim when an instance has a scheduled maintenance event", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						Events: []ec2types.InstanceStatusEvent{
+							{
+								Code: ec2types.EventCodeInstanceRetirement,
+							},
+						},
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel: "instance_status_failure",
+				"nodepool":          "default",
 			})
 			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 1, map[string]string{
 				"category": "EventStatus",

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -97,7 +97,7 @@ var _ = BeforeSuite(func() {
 	sqsProvider = lo.Must(sqs.NewDefaultProvider(sqsapi, fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/test-cluster", fake.DefaultRegion, fake.DefaultAccount)))
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
 		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
-	controller = interruption.NewController(env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, sqsapi, unavailableOfferingsCache, awsEnv.CapacityReservationProvider)
+	controller = interruption.NewController(env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, servicesqs.NewFromConfig(aws.Config{}), unavailableOfferingsCache, awsEnv.CapacityReservationProvider)
 	instanceStatusController = interruption.NewInstanceStatusController(env.Client, cloudProvider, fakeClock, events.NewRecorder(&record.FakeRecorder{}), awsEnv.InstanceStatusProvider)
 })
 

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -109,6 +109,7 @@ var _ = BeforeEach(func() {
 	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("test-cluster")}))
 	unavailableOfferingsCache.Flush()
 	sqsapi.Reset()
+	interruption.InstanceStatusUnhealthy.Reset()
 })
 
 var _ = AfterEach(func() {
@@ -316,7 +317,7 @@ var _ = Describe("InterruptionHandling", func() {
 
 			Expect(awsEnv.CapacityReservationProvider.GetAvailableInstanceCount("cr-56fac701cc1951b03")).To(Equal(0))
 		})
-		It("should delete the NodeClaim when an instance is unhealthy due to EC2 status checks", func() {
+		It("should delete the NodeClaim when an instance is unhealthy due to EC2 status checks or scheduled events", func() {
 			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
 			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
 				InstanceStatuses: []ec2types.InstanceStatus{
@@ -341,6 +342,11 @@ var _ = Describe("InterruptionHandling", func() {
 								},
 							},
 						},
+						Events: []ec2types.InstanceStatusEvent{
+							{
+								Code: ec2types.EventCodeInstanceRetirement,
+							},
+						},
 					},
 				},
 			})
@@ -351,9 +357,15 @@ var _ = Describe("InterruptionHandling", func() {
 				metrics.ReasonLabel: "instance_status_failure",
 				"nodepool":          "default",
 			})
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 1, map[string]string{
+				"category": "SystemStatus",
+			})
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 1, map[string]string{
+				"category": "EventStatus",
+			})
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 		})
-		It("should NOT delete the NodeClaim when an instance is unhealthy due to a Scheduled Event Status or EBS Status", func() {
+		It("should NOT delete the NodeClaim when an instance is unhealthy due to EBS Status only", func() {
 			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
 			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
 				InstanceStatuses: []ec2types.InstanceStatus{
@@ -367,11 +379,6 @@ var _ = Describe("InterruptionHandling", func() {
 									Name:          ec2types.StatusNameReachability,
 									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
 								},
-							},
-						},
-						Events: []ec2types.InstanceStatusEvent{
-							{
-								Code: ec2types.EventCodeInstanceRetirement,
 							},
 						},
 					},

--- a/pkg/controllers/interruption/utils.go
+++ b/pkg/controllers/interruption/utils.go
@@ -19,11 +19,6 @@ import (
 	"fmt"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
-	"github.com/aws/karpenter-provider-aws/pkg/cache"
-	interruptionevents "github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/events"
-	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
-	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -33,6 +28,12 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/cache"
+	interruptionevents "github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/events"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 )
 
 type Action string

--- a/pkg/controllers/interruption/utils.go
+++ b/pkg/controllers/interruption/utils.go
@@ -1,0 +1,173 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interruption
+
+import (
+	"context"
+	"fmt"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/cache"
+	interruptionevents "github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/events"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
+	"go.uber.org/multierr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
+)
+
+type Action string
+
+const (
+	CordonAndDrain Action = "CordonAndDrain"
+	NoAction       Action = "NoAction"
+)
+
+// InterruptionHandler contains shared logic for handling interruption messages
+// from both the SQS queue and the DescribeInstanceStatus API.
+type InterruptionHandler struct {
+	kubeClient                  client.Client
+	cloudProvider               cloudprovider.CloudProvider
+	recorder                    events.Recorder
+	unavailableOfferingsCache   *cache.UnavailableOfferings
+	capacityReservationProvider capacityreservation.Provider
+}
+
+// handleMessage takes an action against every node involved in the message that is owned by a NodePool
+func (h *InterruptionHandler) handleMessage(ctx context.Context, msg messages.Message) (err error) {
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("messageKind", msg.Kind()))
+
+	if msg.Kind() == messages.NoOpKind {
+		return nil
+	}
+	for _, instanceID := range msg.EC2InstanceIDs() {
+		nodeClaimList := &karpv1.NodeClaimList{}
+		if e := h.kubeClient.List(ctx, nodeClaimList, client.MatchingFields{"status.instanceID": instanceID}); e != nil {
+			err = multierr.Append(err, e)
+			continue
+		}
+		if len(nodeClaimList.Items) == 0 {
+			continue
+		}
+		for _, nodeClaim := range nodeClaimList.Items {
+			nodeList := &corev1.NodeList{}
+			if e := h.kubeClient.List(ctx, nodeList, client.MatchingFields{"spec.instanceID": instanceID}); e != nil {
+				err = multierr.Append(err, e)
+				continue
+			}
+			var node *corev1.Node
+			if len(nodeList.Items) > 0 {
+				node = &nodeList.Items[0]
+			}
+			if e := h.handleNodeClaim(ctx, msg, &nodeClaim, node); e != nil {
+				err = multierr.Append(err, e)
+			}
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("acting on NodeClaims, %w", err)
+	}
+	return nil
+}
+
+// handleNodeClaim retrieves the action for the message and then performs the appropriate action against the node
+func (h *InterruptionHandler) handleNodeClaim(ctx context.Context, msg messages.Message, nodeClaim *karpv1.NodeClaim, node *corev1.Node) error {
+	action := actionForMessage(msg)
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("NodeClaim", klog.KObj(nodeClaim), "action", string(action)))
+	if node != nil {
+		ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KObj(node)))
+	}
+
+	// Record metric and event for this action
+	h.notifyForMessage(msg, nodeClaim, node)
+
+	// Mark the offering as unavailable in the ICE cache if we got a spot interruption warning
+	if msg.Kind() == messages.SpotInterruptionKind && h.unavailableOfferingsCache != nil {
+		zone := nodeClaim.Labels[corev1.LabelTopologyZone]
+		instanceType := nodeClaim.Labels[corev1.LabelInstanceTypeStable]
+		if zone != "" && instanceType != "" {
+			unavailableReason := map[string]string{
+				"reason": string(msg.Kind()),
+			}
+			h.unavailableOfferingsCache.MarkUnavailable(ctx, ec2types.InstanceType(instanceType), zone, karpv1.CapacityTypeSpot, unavailableReason)
+		}
+	}
+
+	// Mark the reservation as unavailable in the ICE cache if we got a capacity reservation interruption warning
+	if msg.Kind() == messages.CapacityReservationInterruptionKind && h.capacityReservationProvider != nil {
+		reservationID := nodeClaim.Labels[v1.LabelCapacityReservationID]
+		if reservationID != "" {
+			h.capacityReservationProvider.MarkUnavailable(reservationID)
+		}
+	}
+
+	if action != NoAction {
+		return h.deleteNodeClaim(ctx, msg, nodeClaim, node)
+	}
+	return nil
+}
+
+// deleteNodeClaim removes the NodeClaim from the api-server
+func (h *InterruptionHandler) deleteNodeClaim(ctx context.Context, msg messages.Message, nodeClaim *karpv1.NodeClaim, node *corev1.Node) error {
+	if !nodeClaim.DeletionTimestamp.IsZero() {
+		return nil
+	}
+	if err := h.kubeClient.Delete(ctx, nodeClaim); err != nil {
+		return client.IgnoreNotFound(fmt.Errorf("deleting the node on interruption message, %w", err))
+	}
+	log.FromContext(ctx).Info("initiating delete from interruption message")
+	h.recorder.Publish(interruptionevents.TerminatingOnInterruption(node, nodeClaim)...)
+	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+		metrics.ReasonLabel:       string(msg.Kind()),
+		metrics.NodePoolLabel:     nodeClaim.Labels[karpv1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: nodeClaim.Labels[karpv1.CapacityTypeLabelKey],
+	})
+	return nil
+}
+
+// notifyForMessage publishes the relevant alert based on the message kind
+func (h *InterruptionHandler) notifyForMessage(msg messages.Message, nodeClaim *karpv1.NodeClaim, n *corev1.Node) {
+	switch msg.Kind() {
+	case messages.RebalanceRecommendationKind:
+		h.recorder.Publish(interruptionevents.RebalanceRecommendation(n, nodeClaim)...)
+	case messages.ScheduledChangeKind, messages.InstanceStatusFailure:
+		h.recorder.Publish(interruptionevents.Unhealthy(n, nodeClaim)...)
+	case messages.SpotInterruptionKind:
+		h.recorder.Publish(interruptionevents.SpotInterrupted(n, nodeClaim)...)
+	case messages.CapacityReservationInterruptionKind:
+		h.recorder.Publish(interruptionevents.CapacityReservationInstanceInterrupted(n, nodeClaim)...)
+	case messages.InstanceStoppedKind:
+		h.recorder.Publish(interruptionevents.Stopping(n, nodeClaim)...)
+	case messages.InstanceTerminatedKind:
+		h.recorder.Publish(interruptionevents.Terminating(n, nodeClaim)...)
+	default:
+	}
+}
+
+func actionForMessage(msg messages.Message) Action {
+	switch msg.Kind() {
+	case messages.ScheduledChangeKind, messages.SpotInterruptionKind, messages.InstanceStoppedKind, messages.InstanceTerminatedKind, messages.CapacityReservationInterruptionKind, messages.InstanceStatusFailure:
+		return CordonAndDrain
+	default:
+		return NoAction
+	}
+}

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -54,6 +54,7 @@ type EC2Behavior struct {
 	DescribeLaunchTemplatesOutput       AtomicPtr[ec2.DescribeLaunchTemplatesOutput]
 	DescribeInstanceTypesOutput         AtomicPtr[ec2.DescribeInstanceTypesOutput]
 	DescribeInstanceTypeOfferingsOutput AtomicPtr[ec2.DescribeInstanceTypeOfferingsOutput]
+	DescribeInstanceStatusOutput        AtomicPtr[ec2.DescribeInstanceStatusOutput]
 	DescribeAvailabilityZonesOutput     AtomicPtr[ec2.DescribeAvailabilityZonesOutput]
 	DescribeSubnetsBehavior             MockedFunction[ec2.DescribeSubnetsInput, ec2.DescribeSubnetsOutput]
 	DescribeSecurityGroupsBehavior      MockedFunction[ec2.DescribeSecurityGroupsInput, ec2.DescribeSecurityGroupsOutput]
@@ -93,6 +94,7 @@ func (e *EC2API) Reset() {
 	e.DescribeLaunchTemplatesOutput.Reset()
 	e.DescribeInstanceTypesOutput.Reset()
 	e.DescribeInstanceTypeOfferingsOutput.Reset()
+	e.DescribeInstanceStatusOutput.Reset()
 	e.DescribeAvailabilityZonesOutput.Reset()
 	e.DescribeSubnetsBehavior.Reset()
 	e.DescribeSecurityGroupsBehavior.Reset()
@@ -652,4 +654,15 @@ func (e *EC2API) RunInstances(ctx context.Context, input *ec2.RunInstancesInput,
 			Instances: []ec2types.Instance{instance},
 		}, nil
 	})
+}
+
+func (e *EC2API) DescribeInstanceStatus(ctx context.Context, input *ec2.DescribeInstanceStatusInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceStatusOutput, error) {
+	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
+		return nil, e.NextError.Get()
+	}
+	if !e.DescribeInstanceStatusOutput.IsNil() {
+		return e.DescribeInstanceStatusOutput.Clone(), nil
+	}
+	return &ec2.DescribeInstanceStatusOutput{}, nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -57,6 +57,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/placementgroup"
@@ -90,6 +91,7 @@ type Operator struct {
 	VersionProvider             *version.DefaultProvider
 	InstanceTypesProvider       *instancetype.DefaultProvider
 	InstanceProvider            instance.Provider
+	InstanceStatusProvider      *instancestatus.DefaultProvider
 	SSMProvider                 ssmp.Provider
 	CapacityReservationProvider capacityreservation.Provider
 	PlacementGroupProvider      placementgroup.Provider
@@ -210,6 +212,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		placementGroupProvider,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
 	)
+	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)
 
 	// Setup field indexers on instanceID -- specifically for the interruption controller
 	if options.FromContext(ctx).InterruptionQueue != "" {
@@ -232,6 +235,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		PricingProvider:             pricingProvider,
 		InstanceTypesProvider:       instanceTypeProvider,
 		InstanceProvider:            instanceProvider,
+		InstanceStatusProvider:      instanceStatusProvider,
 		SSMProvider:                 ssmProvider,
 		CapacityReservationProvider: capacityReservationProvider,
 		PlacementGroupProvider:      placementGroupProvider,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -214,10 +214,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	)
 	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)
 
-	// Setup field indexers on instanceID -- specifically for the interruption controller
-	if options.FromContext(ctx).InterruptionQueue != "" {
-		SetupIndexers(ctx, operator.Manager)
-	}
+	// Setup field indexers on instanceID -- used by the interruption and instance status controllers
+	SetupIndexers(ctx, operator.Manager)
 	return ctx, &Operator{
 		Operator:                    operator,
 		Config:                      cfg,

--- a/pkg/providers/instancestatus/instancestatus.go
+++ b/pkg/providers/instancestatus/instancestatus.go
@@ -1,0 +1,176 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancestatus
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/samber/lo"
+	"k8s.io/utils/clock"
+
+	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
+)
+
+type Category string
+
+const (
+	InstanceStatus = Category("InstanceStatus")
+	SystemStatus   = Category("SystemStatus")
+	// EventStatus is currently ignored since this is already consumed via EventBridge in the Interruption controller.
+	// The handling of maintenance events is currently primitive where we treat all events as instance degradation
+	// with an involuntary replacement. Only consuming events via EventBridge allows some users to opt-out of maintenance
+	// event handling (https://github.com/aws/karpenter-provider-aws/issues/8524).
+	EventStatus = Category("EventStatus")
+	// EBSStatus check failures are currently ignored until we can differentiate which volumes affect the node vs pods w/ PVCs
+	EBSStatus = Category("EBSStatus")
+)
+
+var (
+	UnhealthyThreshold = 120 * time.Second
+)
+
+type Provider interface {
+	List(context.Context) ([]HealthStatus, error)
+}
+
+type DefaultProvider struct {
+	ec2api sdk.EC2API
+	clk    clock.Clock
+}
+
+type HealthStatus struct {
+	InstanceID    string
+	Overall       ec2types.SummaryStatus
+	ImpairedSince time.Time
+	Details       []Details
+}
+
+type Details struct {
+	Category      Category
+	Name          string
+	ImpairedSince time.Time
+	Status        ec2types.StatusType
+}
+
+func NewDefaultProvider(ec2API sdk.EC2API, clk clock.Clock) *DefaultProvider {
+	return &DefaultProvider{
+		ec2api: ec2API,
+		clk:    clk,
+	}
+}
+
+func (p DefaultProvider) List(ctx context.Context) ([]HealthStatus, error) {
+	var statuses []ec2types.InstanceStatus
+	pager := ec2.NewDescribeInstanceStatusPaginator(p.ec2api, &ec2.DescribeInstanceStatusInput{})
+
+	for pager.HasMorePages() {
+		out, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed describing ec2 instance status checks, %w", err)
+		}
+		statuses = append(statuses, out.InstanceStatuses...)
+	}
+
+	var healthStatuses []HealthStatus
+	for _, statusChecks := range statuses {
+		healthStatus := p.newHealthStatus(statusChecks)
+		// Filter out statuses that we do not consider unhealthy or do not want to handle right now
+		healthStatus.Details = lo.Filter(healthStatus.Details, func(details Details, _ int) bool {
+			if details.Status != ec2types.StatusTypeFailed {
+				return false
+			}
+			// ignore EBS and Scheduled Event health checks for now
+			if details.Category == EBSStatus || details.Category == EventStatus {
+				return false
+			}
+			// Do not evaluate against the unhealthy threshold when its a scheduled maintenance event.
+			// Scheduled maintenance events often have a future scheduled time which makes a thershold
+			// difficult to utilize. We take the stance that if there is a scheduled maintenance event,
+			// then there is something wrong with the underlying host that warrants vacating immediately.
+			// This matches how we process scheduled maintenance events from EventBridge.
+			if details.Category == EventStatus {
+				return true
+			}
+			return p.clk.Since(details.ImpairedSince) >= UnhealthyThreshold
+		})
+		if len(healthStatus.Details) == 0 {
+			continue
+		}
+		healthStatus.ImpairedSince = slices.MinFunc(healthStatus.Details, func(a, b Details) int {
+			return a.ImpairedSince.Compare(b.ImpairedSince)
+		}).ImpairedSince
+		healthStatuses = append(healthStatuses, healthStatus)
+	}
+	return healthStatuses, nil
+}
+
+// newHealthStatus constructs a more consumable version of Health Status Details from the different status checks
+func (p DefaultProvider) newHealthStatus(statusChecks ec2types.InstanceStatus) HealthStatus {
+	healthStatus := HealthStatus{
+		InstanceID: *statusChecks.InstanceId,
+		Overall:    ec2types.SummaryStatusImpaired,
+	}
+	if statusChecks.InstanceStatus != nil {
+		healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.InstanceStatus.Details, func(details ec2types.InstanceStatusDetails, _ int) Details {
+			return p.newDetails(details, InstanceStatus)
+		})...)
+	}
+	if statusChecks.SystemStatus != nil {
+		healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.SystemStatus.Details, func(details ec2types.InstanceStatusDetails, _ int) Details {
+			return p.newDetails(details, SystemStatus)
+		})...)
+	}
+	if statusChecks.AttachedEbsStatus != nil {
+		healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.AttachedEbsStatus.Details, func(details ec2types.EbsStatusDetails, _ int) Details {
+			return p.newDetails(details, EBSStatus)
+		})...)
+	}
+	healthStatus.Details = append(healthStatus.Details, lo.Map(statusChecks.Events, func(details ec2types.InstanceStatusEvent, _ int) Details {
+		return p.newDetails(details, EventStatus)
+	})...)
+	return healthStatus
+}
+
+func (p DefaultProvider) newDetails(details any, category Category) Details {
+	if ec2Details, ok := details.(ec2types.InstanceStatusDetails); ok {
+		return Details{
+			Category:      category,
+			Name:          string(ec2Details.Name),
+			Status:        ec2Details.Status,
+			ImpairedSince: lo.FromPtr(ec2Details.ImpairedSince),
+		}
+	}
+	if ec2Events, ok := details.(ec2types.InstanceStatusEvent); ok {
+		return Details{
+			Category: category,
+			Name:     string(ec2Events.Code),
+			// treat all scheduled maintenance events as failures
+			Status:        ec2types.StatusTypeFailed,
+			ImpairedSince: p.clk.Now(),
+		}
+	}
+	ebsDetails := details.(ec2types.EbsStatusDetails)
+	return Details{
+		Category:      category,
+		Name:          string(ebsDetails.Name),
+		Status:        ebsDetails.Status,
+		ImpairedSince: lo.FromPtr(ebsDetails.ImpairedSince),
+	}
+}

--- a/pkg/providers/instancestatus/instancestatus.go
+++ b/pkg/providers/instancestatus/instancestatus.go
@@ -33,10 +33,9 @@ type Category string
 const (
 	InstanceStatus = Category("InstanceStatus")
 	SystemStatus   = Category("SystemStatus")
-	// EventStatus is currently ignored since this is already consumed via EventBridge in the Interruption controller.
-	// The handling of maintenance events is currently primitive where we treat all events as instance degradation
-	// with an involuntary replacement. Only consuming events via EventBridge allows some users to opt-out of maintenance
-	// event handling (https://github.com/aws/karpenter-provider-aws/issues/8524).
+	// EventStatus surfaces scheduled maintenance events. These are also consumed via EventBridge
+	// in the Interruption controller when an SQS queue is configured. The handling of maintenance events is
+	// currently primitive where we treat all events as instance degradation with an involuntary replacement.
 	EventStatus = Category("EventStatus")
 	// EBSStatus check failures are currently ignored until we can differentiate which volumes affect the node vs pods w/ PVCs
 	EBSStatus = Category("EBSStatus")
@@ -96,12 +95,12 @@ func (p DefaultProvider) List(ctx context.Context) ([]HealthStatus, error) {
 			if details.Status != ec2types.StatusTypeFailed {
 				return false
 			}
-			// ignore EBS and Scheduled Event health checks for now
-			if details.Category == EBSStatus || details.Category == EventStatus {
+			// ignore EBS health checks for now
+			if details.Category == EBSStatus {
 				return false
 			}
 			// Do not evaluate against the unhealthy threshold when its a scheduled maintenance event.
-			// Scheduled maintenance events often have a future scheduled time which makes a thershold
+			// Scheduled maintenance events often have a future scheduled time which makes a threshold
 			// difficult to utilize. We take the stance that if there is a scheduled maintenance event,
 			// then there is something wrong with the underlying host that warrants vacating immediately.
 			// This matches how we process scheduled maintenance events from EventBridge.

--- a/pkg/providers/instancestatus/suite_test.go
+++ b/pkg/providers/instancestatus/suite_test.go
@@ -1,0 +1,152 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancestatus_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/samber/lo"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
+	"github.com/aws/karpenter-provider-aws/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var ctx context.Context
+var env *coretest.Environment
+var awsEnv *test.Environment
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "InstanceStatusProvider")
+}
+
+var _ = BeforeSuite(func() {
+	env = coretest.NewEnvironment(coretest.WithCRDs(v1alpha1.CRDs...))
+	ctx = options.ToContext(ctx, test.Options())
+	awsEnv = test.NewEnvironment(ctx, env)
+})
+
+var _ = Describe("Instance Status Provider", func() {
+
+	BeforeEach(func() {
+		awsEnv.Clock.SetTime(time.Time{})
+		statuses := []ec2types.InstanceStatus{
+			{
+				InstanceId: lo.ToPtr("i-0123456789"),
+				InstanceStatus: &ec2types.InstanceStatusSummary{
+					Status: ec2types.SummaryStatusImpaired,
+					Details: []ec2types.InstanceStatusDetails{
+						{
+							Status:        ec2types.StatusTypeFailed,
+							Name:          ec2types.StatusNameReachability,
+							ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+						},
+					},
+				},
+				SystemStatus: &ec2types.InstanceStatusSummary{
+					Status: ec2types.SummaryStatusImpaired,
+					Details: []ec2types.InstanceStatusDetails{
+						{
+							Status:        ec2types.StatusTypeFailed,
+							Name:          ec2types.StatusNameReachability,
+							ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+						},
+					},
+				},
+				AttachedEbsStatus: &ec2types.EbsStatusSummary{
+					Status: ec2types.SummaryStatusImpaired,
+					Details: []ec2types.EbsStatusDetails{
+						{
+							Status:        ec2types.StatusTypeFailed,
+							Name:          ec2types.StatusNameReachability,
+							ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+						},
+					},
+				},
+				Events: []ec2types.InstanceStatusEvent{
+					{
+						Code: ec2types.EventCodeInstanceRetirement,
+					},
+				},
+			},
+		}
+		awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+			InstanceStatuses: statuses,
+		})
+	})
+	Context("List and Aggregate", func() {
+		It("should return all impairment details", func() {
+			impairedTime := awsEnv.Clock.Now()
+			awsEnv.Clock.Step(1 * time.Hour)
+			statuses, err := awsEnv.InstanceStatusProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(statuses).To(HaveLen(1))
+			Expect(statuses[0].InstanceID).To(Equal("i-0123456789"))
+			Expect(statuses[0].Overall).To(Equal(ec2types.SummaryStatusImpaired))
+			Expect(statuses[0].Details).To(ContainElements([]instancestatus.Details{
+				{
+					Category:      instancestatus.InstanceStatus,
+					Name:          string(ec2types.StatusNameReachability),
+					Status:        ec2types.StatusTypeFailed,
+					ImpairedSince: impairedTime,
+				},
+				{
+					Category:      instancestatus.SystemStatus,
+					Name:          string(ec2types.StatusNameReachability),
+					Status:        ec2types.StatusTypeFailed,
+					ImpairedSince: impairedTime,
+				},
+			}))
+		})
+		It("should not return healthy statuses", func() {
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr("i-0123456789"),
+						SystemStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusInitializing,
+						},
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusInsufficientData,
+						},
+						AttachedEbsStatus: &ec2types.EbsStatusSummary{
+							Status: ec2types.SummaryStatusInitializing,
+						},
+						Events: []ec2types.InstanceStatusEvent{
+							{
+								Code: ec2types.EventCodeInstanceRetirement,
+							},
+						},
+					},
+				},
+			})
+			statuses, err := awsEnv.InstanceStatusProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(statuses).To(HaveLen(0))
+		})
+	})
+})

--- a/pkg/providers/instancestatus/suite_test.go
+++ b/pkg/providers/instancestatus/suite_test.go
@@ -107,20 +107,26 @@ var _ = Describe("Instance Status Provider", func() {
 			Expect(statuses).To(HaveLen(1))
 			Expect(statuses[0].InstanceID).To(Equal("i-0123456789"))
 			Expect(statuses[0].Overall).To(Equal(ec2types.SummaryStatusImpaired))
-			Expect(statuses[0].Details).To(ContainElements([]instancestatus.Details{
-				{
+			Expect(statuses[0].Details).To(ContainElements(
+				instancestatus.Details{
 					Category:      instancestatus.InstanceStatus,
 					Name:          string(ec2types.StatusNameReachability),
 					Status:        ec2types.StatusTypeFailed,
 					ImpairedSince: impairedTime,
 				},
-				{
+				instancestatus.Details{
 					Category:      instancestatus.SystemStatus,
 					Name:          string(ec2types.StatusNameReachability),
 					Status:        ec2types.StatusTypeFailed,
 					ImpairedSince: impairedTime,
 				},
-			}))
+				instancestatus.Details{
+					Category:      instancestatus.EventStatus,
+					Name:          string(ec2types.EventCodeInstanceRetirement),
+					Status:        ec2types.StatusTypeFailed,
+					ImpairedSince: awsEnv.Clock.Now(),
+				},
+			))
 		})
 		It("should not return healthy statuses", func() {
 			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
@@ -136,6 +142,24 @@ var _ = Describe("Instance Status Provider", func() {
 						AttachedEbsStatus: &ec2types.EbsStatusSummary{
 							Status: ec2types.SummaryStatusInitializing,
 						},
+					},
+				},
+			})
+			statuses, err := awsEnv.InstanceStatusProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(statuses).To(HaveLen(0))
+		})
+		It("should return scheduled maintenance events even when other statuses are healthy", func() {
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr("i-0123456789"),
+						SystemStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusInitializing,
+						},
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusInsufficientData,
+						},
 						Events: []ec2types.InstanceStatusEvent{
 							{
 								Code: ec2types.EventCodeInstanceRetirement,
@@ -146,7 +170,9 @@ var _ = Describe("Instance Status Provider", func() {
 			})
 			statuses, err := awsEnv.InstanceStatusProvider.List(ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(statuses).To(HaveLen(0))
+			Expect(statuses).To(HaveLen(1))
+			Expect(statuses[0].Details).To(HaveLen(1))
+			Expect(statuses[0].Details[0].Category).To(Equal(instancestatus.EventStatus))
 		})
 	})
 })

--- a/pkg/providers/sqs/sqs.go
+++ b/pkg/providers/sqs/sqs.go
@@ -104,7 +104,7 @@ func (p *DefaultProvider) DeleteSQSMessage(ctx context.Context, msg *sqstypes.Me
 	return nil
 }
 
-func NewSQSProvider(ctx context.Context, sqsapi *sqs.Client) (Provider, error) {
+func NewSQSProvider(ctx context.Context, sqsapi sdk.SQSAPI) (Provider, error) {
 	out, err := sqsapi.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{QueueName: lo.ToPtr(options.FromContext(ctx).InterruptionQueue)})
 	if err != nil {
 		return nil, err

--- a/pkg/providers/sqs/sqs.go
+++ b/pkg/providers/sqs/sqs.go
@@ -104,7 +104,7 @@ func (p *DefaultProvider) DeleteSQSMessage(ctx context.Context, msg *sqstypes.Me
 	return nil
 }
 
-func NewSQSProvider(ctx context.Context, sqsapi sdk.SQSAPI) (Provider, error) {
+func NewSQSProvider(ctx context.Context, sqsapi *sqs.Client) (Provider, error) {
 	out, err := sqsapi.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{QueueName: lo.ToPtr(options.FromContext(ctx).InterruptionQueue)})
 	if err != nil {
 		return nil, err

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancetype"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/placementgroup"
@@ -97,6 +98,7 @@ type Environment struct {
 	InstanceTypesResolver       *instancetype.DefaultResolver
 	InstanceTypesProvider       *instancetype.DefaultProvider
 	InstanceProvider            *instance.DefaultProvider
+	InstanceStatusProvider      *instancestatus.DefaultProvider
 	SubnetProvider              *subnet.DefaultProvider
 	SecurityGroupProvider       *securitygroup.DefaultProvider
 	InstanceProfileProvider     *instanceprofile.DefaultProvider
@@ -166,6 +168,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	// Instance type updates are hydrated asynchronously after this by controllers.
 	lo.Must0(instanceTypesProvider.UpdateInstanceTypes(ctx))
 	lo.Must0(instanceTypesProvider.UpdateInstanceTypeOfferings(ctx))
+	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, clock)
 	launchTemplateProvider := launchtemplate.NewDefaultProvider(
 		ctx,
 		launchTemplateCache,
@@ -236,6 +239,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		InstanceTypesResolver:       instanceTypesResolver,
 		InstanceTypesProvider:       instanceTypesProvider,
 		InstanceProvider:            instanceProvider,
+		InstanceStatusProvider:      instanceStatusProvider,
 		SubnetProvider:              subnetProvider,
 		SecurityGroupProvider:       securityGroupProvider,
 		LaunchTemplateProvider:      launchTemplateProvider,

--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -267,6 +267,42 @@ var _ = Describe("Interruption", func() {
 		env.EventuallyExpectNotFound(node)
 		env.EventuallyExpectHealthyPodCount(selector, 1)
 	})
+	FIt("should terminate the node when receiving an instance status failure", func() {
+		numPods := 1
+		dep := coretest.Deployment(coretest.DeploymentOptions{
+			Replicas: int32(numPods),
+			PodOptions: coretest.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "my-app"},
+				},
+				TerminationGracePeriodSeconds: lo.ToPtr(int64(0)),
+			},
+		})
+		selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+
+		// schedule the interface to go down after 70 seconds.
+		// this has to be above a minute so that the instance status check initializes to healthy.
+		nodeClass.Spec.UserData = lo.ToPtr(`#!/usr/bin/env bash
+(
+  sleep 30
+  IFACE=$(ip route show default | awk '{print $5}' | head -n1)
+  ip link set dev "$IFACE" down
+) >>/var/log/disable-net.log 2>&1 &`)
+
+		env.ExpectCreated(nodeClass, nodePool, dep)
+
+		env.EventuallyExpectHealthyPodCount(selector, numPods)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		node := env.Monitor.CreatedNodes()[0]
+
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).To(Succeed())
+			g.Expect(!node.DeletionTimestamp.IsZero()).To(BeTrue())
+		}).WithTimeout(15 * time.Minute).Should(Succeed())
+		env.EventuallyExpectNotFound(node)
+		env.EventuallyExpectHealthyPodCount(selector, 1)
+	})
 })
 
 func scheduledChangeMessage(region, accountID, involvedInstanceID string) scheduledchange.Message {

--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -267,7 +267,7 @@ var _ = Describe("Interruption", func() {
 		env.EventuallyExpectNotFound(node)
 		env.EventuallyExpectHealthyPodCount(selector, 1)
 	})
-	FIt("should terminate the node when receiving an instance status failure", func() {
+	It("should terminate the node when receiving an instance status failure", func() {
 		numPods := 1
 		dep := coretest.Deployment(coretest.DeploymentOptions{
 			Replicas: int32(numPods),

--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -19,6 +19,9 @@ import (
 	"testing"
 	"time"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +31,6 @@ import (
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
-
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/controllers/interruption/messages"
@@ -276,15 +277,27 @@ var _ = Describe("Interruption", func() {
 					Labels: map[string]string{"app": "my-app"},
 				},
 				TerminationGracePeriodSeconds: lo.ToPtr(int64(0)),
+				// Tolerate the unreachable taint so that Kubernetes does not evict the pod
+				// and trigger a cascading replacement loop of new nodes that also lose their
+				// network interface before the instance status controller can act.
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "node.kubernetes.io/unreachable",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoExecute,
+					},
+				},
 			},
 		})
 		selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 
-		// schedule the interface to go down after 70 seconds.
-		// this has to be above a minute so that the instance status check initializes to healthy.
+		// Schedule the interface to go down after 90 seconds. This must be above a minute
+		// so that the instance status check initializes to healthy before the interface is
+		// brought down. EC2 instance status checks use ARP requests to verify instance
+		// reachability, so disabling the interface will cause the check to fail.
 		nodeClass.Spec.UserData = lo.ToPtr(`#!/usr/bin/env bash
 (
-  sleep 30
+  sleep 90
   IFACE=$(ip route show default | awk '{print $5}' | head -n1)
   ip link set dev "$IFACE" down
 ) >>/var/log/disable-net.log 2>&1 &`)
@@ -295,14 +308,95 @@ var _ = Describe("Interruption", func() {
 		env.ExpectCreatedNodeCount("==", 1)
 
 		node := env.Monitor.CreatedNodes()[0]
+		instanceID, err := utils.ParseInstanceID(node.Spec.ProviderID)
+		Expect(err).ToNot(HaveOccurred())
 
+		GinkgoWriter.Printf("[DEBUG] Node created: %s, InstanceID: %s, Time: %s\n", node.Name, instanceID, time.Now().UTC().Format(time.RFC3339))
+
+		// The instance status controller polls DescribeInstanceStatus every 30s.
+		// After the interface goes down (~90s), EC2 needs ~1-2 minutes to detect the failure,
+		// then the UnhealthyThreshold (120s) must elapse before the controller acts.
+		// Total expected time: ~90s + ~120s + ~120s + ~30s polling = ~6 minutes.
 		Eventually(func(g Gomega) {
+			// Debug: call DescribeInstanceStatus directly to see what EC2 reports
+			// First call without IncludeAllInstances (what the controller sees)
+			statusOut, statusErr := env.EC2API.DescribeInstanceStatus(env.Context, &ec2.DescribeInstanceStatusInput{
+				InstanceIds: []string{instanceID},
+			})
+			if statusErr != nil {
+				GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (filtered) error: %v\n", time.Now().UTC().Format(time.RFC3339), statusErr)
+			} else if len(statusOut.InstanceStatuses) == 0 {
+				GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (filtered): no results (instance not impaired or not running)\n", time.Now().UTC().Format(time.RFC3339))
+			} else {
+				for _, s := range statusOut.InstanceStatuses {
+					GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (filtered): instance=%s state=%s instanceStatus=%s systemStatus=%s",
+						time.Now().UTC().Format(time.RFC3339),
+						awssdk.ToString(s.InstanceId),
+						s.InstanceState.Name,
+						s.InstanceStatus.Status,
+						s.SystemStatus.Status,
+					)
+					if s.InstanceStatus != nil {
+						for _, d := range s.InstanceStatus.Details {
+							GinkgoWriter.Printf(" instanceDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
+						}
+					}
+					if s.SystemStatus != nil {
+						for _, d := range s.SystemStatus.Details {
+							GinkgoWriter.Printf(" systemDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
+						}
+					}
+					for _, e := range s.Events {
+						GinkgoWriter.Printf(" event=[code=%s notBefore=%v notAfter=%v]", e.Code, e.NotBefore, e.NotAfter)
+					}
+					GinkgoWriter.Println()
+				}
+			}
+
+			// Second call with IncludeAllInstances to see the full picture
+			allStatusOut, allStatusErr := env.EC2API.DescribeInstanceStatus(env.Context, &ec2.DescribeInstanceStatusInput{
+				InstanceIds:         []string{instanceID},
+				IncludeAllInstances: awssdk.Bool(true),
+			})
+			if allStatusErr != nil {
+				GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (all): error: %v\n", time.Now().UTC().Format(time.RFC3339), allStatusErr)
+			} else {
+				for _, s := range allStatusOut.InstanceStatuses {
+					GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (all): instance=%s state=%s instanceStatus=%s systemStatus=%s",
+						time.Now().UTC().Format(time.RFC3339),
+						awssdk.ToString(s.InstanceId),
+						s.InstanceState.Name,
+						s.InstanceStatus.Status,
+						s.SystemStatus.Status,
+					)
+					if s.InstanceStatus != nil {
+						for _, d := range s.InstanceStatus.Details {
+							GinkgoWriter.Printf(" instanceDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
+						}
+					}
+					if s.SystemStatus != nil {
+						for _, d := range s.SystemStatus.Details {
+							GinkgoWriter.Printf(" systemDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
+						}
+					}
+					GinkgoWriter.Println()
+				}
+			}
+
+			// Debug: check node status
 			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).To(Succeed())
+			GinkgoWriter.Printf("[DEBUG] [%s] Node %s: DeletionTimestamp=%v, Ready=%s\n",
+				time.Now().UTC().Format(time.RFC3339),
+				node.Name,
+				node.DeletionTimestamp,
+				getNodeReadyCondition(node),
+			)
 			g.Expect(!node.DeletionTimestamp.IsZero()).To(BeTrue())
-		}).WithTimeout(15 * time.Minute).Should(Succeed())
+		}).WithTimeout(15 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 		env.EventuallyExpectNotFound(node)
 		env.EventuallyExpectHealthyPodCount(selector, 1)
 	})
+
 })
 
 func scheduledChangeMessage(region, accountID, involvedInstanceID string) scheduledchange.Message {
@@ -329,4 +423,13 @@ func scheduledChangeMessage(region, accountID, involvedInstanceID string) schedu
 			},
 		},
 	}
+}
+
+func getNodeReadyCondition(node *corev1.Node) string {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return string(c.Status)
+		}
+	}
+	return "Unknown"
 }

--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 	"time"
 
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -269,6 +267,21 @@ var _ = Describe("Interruption", func() {
 		env.EventuallyExpectHealthyPodCount(selector, 1)
 	})
 	It("should terminate the node when receiving an instance status failure", func() {
+		By("Disabling the SQS interruption queue so only the instance status controller handles interruptions")
+		env.ExpectSettingsOverridden(corev1.EnvVar{Name: "INTERRUPTION_QUEUE", Value: ""})
+		DeferCleanup(func() {
+			env.ExpectSettingsOverridden(corev1.EnvVar{Name: "INTERRUPTION_QUEUE", Value: env.InterruptionQueue})
+		})
+
+		// Pin to amd64 instances because the kernel panic approach used to trigger
+		// EC2 instance status check failures did not work reliably on arm64/Graviton instances.
+		nodePool = coretest.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+			Key:      corev1.LabelArchStable,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"amd64"},
+		})
+
+		By("Creating a single healthy node with a healthy deployment")
 		numPods := 1
 		dep := coretest.Deployment(coretest.DeploymentOptions{
 			Replicas: int32(numPods),
@@ -278,8 +291,7 @@ var _ = Describe("Interruption", func() {
 				},
 				TerminationGracePeriodSeconds: lo.ToPtr(int64(0)),
 				// Tolerate the unreachable taint so that Kubernetes does not evict the pod
-				// and trigger a cascading replacement loop of new nodes that also lose their
-				// network interface before the instance status controller can act.
+				// and trigger a cascading replacement loop of new nodes.
 				Tolerations: []corev1.Toleration{
 					{
 						Key:      "node.kubernetes.io/unreachable",
@@ -291,16 +303,15 @@ var _ = Describe("Interruption", func() {
 		})
 		selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 
-		// Schedule the interface to go down after 90 seconds. This must be above a minute
-		// so that the instance status check initializes to healthy before the interface is
-		// brought down. EC2 instance status checks use ARP requests to verify instance
-		// reachability, so disabling the interface will cause the check to fail.
+		// Schedule a kernel panic after 180 seconds. The EC2 instance status checks
+		// take ~2-3 minutes to initialize from "initializing" to "passing", which must
+		// to happen before the failure.
 		nodeClass.Spec.UserData = lo.ToPtr(`#!/usr/bin/env bash
 (
-  sleep 90
-  IFACE=$(ip route show default | awk '{print $5}' | head -n1)
-  ip link set dev "$IFACE" down
-) >>/var/log/disable-net.log 2>&1 &`)
+  sleep 180
+  echo 0 > /proc/sys/kernel/panic
+  echo c > /proc/sysrq-trigger
+) >>/var/log/trigger-panic.log 2>&1 &`)
 
 		env.ExpectCreated(nodeClass, nodePool, dep)
 
@@ -308,91 +319,12 @@ var _ = Describe("Interruption", func() {
 		env.ExpectCreatedNodeCount("==", 1)
 
 		node := env.Monitor.CreatedNodes()[0]
-		instanceID, err := utils.ParseInstanceID(node.Spec.ProviderID)
-		Expect(err).ToNot(HaveOccurred())
 
-		GinkgoWriter.Printf("[DEBUG] Node created: %s, InstanceID: %s, Time: %s\n", node.Name, instanceID, time.Now().UTC().Format(time.RFC3339))
-
-		// The instance status controller polls DescribeInstanceStatus every 30s.
-		// After the interface goes down (~90s), EC2 needs ~1-2 minutes to detect the failure,
-		// then the UnhealthyThreshold (120s) must elapse before the controller acts.
-		// Total expected time: ~90s + ~120s + ~120s + ~30s polling = ~6 minutes.
+		By("Waiting for the instance status controller to detect the failure and terminate the node")
 		Eventually(func(g Gomega) {
-			// Debug: call DescribeInstanceStatus directly to see what EC2 reports
-			// First call without IncludeAllInstances (what the controller sees)
-			statusOut, statusErr := env.EC2API.DescribeInstanceStatus(env.Context, &ec2.DescribeInstanceStatusInput{
-				InstanceIds: []string{instanceID},
-			})
-			if statusErr != nil {
-				GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (filtered) error: %v\n", time.Now().UTC().Format(time.RFC3339), statusErr)
-			} else if len(statusOut.InstanceStatuses) == 0 {
-				GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (filtered): no results (instance not impaired or not running)\n", time.Now().UTC().Format(time.RFC3339))
-			} else {
-				for _, s := range statusOut.InstanceStatuses {
-					GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (filtered): instance=%s state=%s instanceStatus=%s systemStatus=%s",
-						time.Now().UTC().Format(time.RFC3339),
-						awssdk.ToString(s.InstanceId),
-						s.InstanceState.Name,
-						s.InstanceStatus.Status,
-						s.SystemStatus.Status,
-					)
-					if s.InstanceStatus != nil {
-						for _, d := range s.InstanceStatus.Details {
-							GinkgoWriter.Printf(" instanceDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
-						}
-					}
-					if s.SystemStatus != nil {
-						for _, d := range s.SystemStatus.Details {
-							GinkgoWriter.Printf(" systemDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
-						}
-					}
-					for _, e := range s.Events {
-						GinkgoWriter.Printf(" event=[code=%s notBefore=%v notAfter=%v]", e.Code, e.NotBefore, e.NotAfter)
-					}
-					GinkgoWriter.Println()
-				}
-			}
-
-			// Second call with IncludeAllInstances to see the full picture
-			allStatusOut, allStatusErr := env.EC2API.DescribeInstanceStatus(env.Context, &ec2.DescribeInstanceStatusInput{
-				InstanceIds:         []string{instanceID},
-				IncludeAllInstances: awssdk.Bool(true),
-			})
-			if allStatusErr != nil {
-				GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (all): error: %v\n", time.Now().UTC().Format(time.RFC3339), allStatusErr)
-			} else {
-				for _, s := range allStatusOut.InstanceStatuses {
-					GinkgoWriter.Printf("[DEBUG] [%s] DescribeInstanceStatus (all): instance=%s state=%s instanceStatus=%s systemStatus=%s",
-						time.Now().UTC().Format(time.RFC3339),
-						awssdk.ToString(s.InstanceId),
-						s.InstanceState.Name,
-						s.InstanceStatus.Status,
-						s.SystemStatus.Status,
-					)
-					if s.InstanceStatus != nil {
-						for _, d := range s.InstanceStatus.Details {
-							GinkgoWriter.Printf(" instanceDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
-						}
-					}
-					if s.SystemStatus != nil {
-						for _, d := range s.SystemStatus.Details {
-							GinkgoWriter.Printf(" systemDetail=[name=%s status=%s impairedSince=%v]", d.Name, d.Status, d.ImpairedSince)
-						}
-					}
-					GinkgoWriter.Println()
-				}
-			}
-
-			// Debug: check node status
 			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).To(Succeed())
-			GinkgoWriter.Printf("[DEBUG] [%s] Node %s: DeletionTimestamp=%v, Ready=%s\n",
-				time.Now().UTC().Format(time.RFC3339),
-				node.Name,
-				node.DeletionTimestamp,
-				getNodeReadyCondition(node),
-			)
 			g.Expect(!node.DeletionTimestamp.IsZero()).To(BeTrue())
-		}).WithTimeout(15 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
+		}).WithTimeout(30 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 		env.EventuallyExpectNotFound(node)
 		env.EventuallyExpectHealthyPodCount(selector, 1)
 	})
@@ -423,13 +355,4 @@ func scheduledChangeMessage(region, accountID, involvedInstanceID string) schedu
 			},
 		},
 	}
-}
-
-func getNodeReadyCondition(node *corev1.Node) string {
-	for _, c := range node.Status.Conditions {
-		if c.Type == corev1.NodeReady {
-			return string(c.Status)
-		}
-	}
-	return "Unknown"
 }

--- a/website/content/en/preview/concepts/disruption.md
+++ b/website/content/en/preview/concepts/disruption.md
@@ -220,8 +220,9 @@ Additionally, Karpenter utilizes the [EC2 DescribeInstanceStatus](https://docs.a
 
 * System Status - surfaces failures in the underlying physical host (hardware or software)
 * Instance Status - surfaces failures in the virtual machine 
+* Scheduled Maintenance Events - surfaces upcoming maintenance events that may affect the instance
 
-System and Instance status checks do not require the `--interruption-queue` to be configured, just EC2 DescribeInstanceStatus IAM permissions.
+These status checks do not require the `--interruption-queue` to be configured, just EC2 DescribeInstanceStatus IAM permissions.
 
 ### Node Auto Repair
 

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -350,8 +350,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
-              "Action": "eks:DescribeCluster"
             },
             {
               "Sid": "AllowUnscopedEC2DescribeInstanceStatus",

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -350,6 +350,14 @@ Resources:
               "Effect": "Allow",
               "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
+              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Action": "eks:DescribeCluster"
+            },
+            {
+              "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": "ec2:DescribeInstanceStatus"
             }
           ]
         }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Builds on #8899 

This PR adds support for EC2 Status Checks (i.e. health checks) for consumption by the Interruption Controller. 
Before this PR, the interruption controller only consumed health checks from EventBridge (AWS Health, Spot, and EC2 Instance State Changes). These events only cover EC2 Scheduled Maintenance Events, Spot Interruptions, and EC2 Terminations/Stops. 

EC2:DescribeInstanceStatus is an API that provides the result of EC2 health checks. 
The currently vended health checks are:

- Instance Status  (reachability via an ARP to the EC2 instance via the primary ENI) 
- System Status (reachability to the underlying physical host the EC2 instance is running on)
- EBS Volume Status (problems with attached EBS volumes) 
- Scheduled Maintenance Events

Instance Status, System Status, and EBS Volume Status are not available via EventBridge. This PR does not support EBS Volume Status checks for interruption handling, as they only indicate that at least 1 volume is unhealthy. This is insufficient information to take action from Karpenter's perspective since it could be indicating that a pod's storage is unhealthy via a PVC. EBS Volume checking should be completed in a follow-up PR that uses the EBS Status Checks API which can narrow down which volume is unhealthy.

Scheduled Maintenance Events are already consumed via EventBridge, but they will now also be discovered by DescribeInstanceStatus, meaning that in the future we might be able to remove the need for those events for the interruption queue.

*NOTE: THIS FEATURE REQUIRES A NEW PERMISSION EC2:DescribeInstanceStatus*

It does not inhibit the interruption controller if a queue is configured via `--interruption-queue`. 


**How was this change tested?**
Added unit tests and integration tests, both run in CI ([Integ run](https://github.com/aws/karpenter-provider-aws/actions/runs/24738491539/job/72371644511#logs))
<details>
  <summary>Manual test with additional debug logs:</summary>

      ❯ kn
    NAME                                           STATUS   ROLES    AGE     VERSION
    <test-node>.us-west-2.compute.internal   Ready    <none>   14m     v1.35.3-eks-bbe087e
    <system-node>.us-west-2.compute.internal     Ready    <none>   4h42m   v1.35.3-eks-bbe087e
    <system-node>.us-west-2.compute.internal    Ready    <none>   4h42m   v1.35.3-eks-bbe087e


    aws ssm send-command \
    --instance-ids <test-node> \
    --document-name "AWS-RunShellScript" \
    --parameters 'commands=["echo 0 > /proc/sys/kernel/panic && echo c > /proc/sysrq-trigger"]'


    ❯ kn
    NAME                                           STATUS     ROLES    AGE     VERSION
    <test-node>.us-west-2.compute.internal   NotReady   <none>   15m     v1.35.3-eks-bbe087e
    <system-node>.us-west-2.compute.internal     Ready      <none>   4h43m   v1.35.3-eks-bbe087e
    <system-node>.us-west-2.compute.internal    Ready      <none>   4h43m   v1.35.3-eks-bbe087e


    ❯ aws ec2 describe-instance-status --instance-ids <test-node> | cat
    {
        "InstanceStatuses": [
            {
                "AvailabilityZone": "us-west-2d",
                "Operator": {
                    "Managed": false
                },
                "InstanceId": "<test-node>",
                "InstanceState": {
                    "Code": 16,
                    "Name": "running"
                },
                "InstanceStatus": {
                    "Details": [
                        {
                            "ImpairedSince": "2026-04-20T23:46:00+00:00",
                            "Name": "reachability",
                            "Status": "failed"
                        }
                    ],
                    "Status": "impaired"
                },
                "SystemStatus": {
                    "Details": [
                        {
                            "Name": "reachability",
                            "Status": "passed"
                        }
                    ],
                    "Status": "ok"
                },
                "AttachedEbsStatus": {
                    "Details": [
                        {
                            "Name": "reachability",
                            "Status": "passed"
                        }
                    ],
                    "Status": "ok"
                }
            }
        ]
    }


    {"level":"DEBUG","time":"2026-04-20T23:47:53.844Z","logger":"controller","caller":"instancestatus/instancestatus.go:89","message":"raw instance status","controller":"interruption.instancestatus","namespace":"","name":"","reconcileID":"5bc4b110-470b-42ff-9bab-38d8cc193d1f","instanceID":"<test-node>","instanceState":{"Code":16,"Name":"running"},"systemStatus":{"Details":[{"ImpairedSince":null,"Name":"reachability","Status":"passed"}],"Status":"ok"},"instanceStatus":{"Details":[{"ImpairedSince":"2026-04-20T23:46:00Z","Name":"reachability","Status":"failed"}],"Status":"impaired"},"ebsStatus":{"Details":[{"ImpairedSince":null,"Name":"reachability","Status":"passed"}],"Status":"ok"},"events":null}



    {"level":"DEBUG","time":"2026-04-20T23:48:53.928Z","logger":"controller","caller":"instancestatus/instancestatus.go:101","message":"fetched instance statuses from EC2","controller":"interruption.instancestatus","namespace":"","name":"","reconcileID":"c7d09f08-acdd-431a-940d-bf065d24f2d4","totalInstances":14}
    {"level":"DEBUG","time":"2026-04-20T23:48:53.928Z","logger":"controller","caller":"instancestatus/instancestatus.go:132","message":"found unhealthy instance","controller":"interruption.instancestatus","namespace":"","name":"","reconcileID":"c7d09f08-acdd-431a-940d-bf065d24f2d4","instanceID":"<test-node>","categories":["InstanceStatus"],"impairedSince":"2026-04-20T23:46:00.000Z"}
    {"level":"DEBUG","time":"2026-04-20T23:48:53.928Z","logger":"controller","caller":"interruption/instancestatus_controller.go:86","message":"polled instance statuses","controller":"interruption.instancestatus","namespace":"","name":"","reconcileID":"c7d09f08-acdd-431a-940d-bf065d24f2d4","unhealthyCount":1}
    {"level":"DEBUG","time":"2026-04-20T23:48:53.928Z","logger":"controller","caller":"interruption/instancestatus_controller.go:97","message":"handling unhealthy instance","controller":"interruption.instancestatus","namespace":"","name":"","reconcileID":"c7d09f08-acdd-431a-940d-bf065d24f2d4","instanceID":"<test-node>","detailCount":1}
    {"level":"INFO","time":"2026-04-20T23:48:53.947Z","logger":"controller","caller":"interruption/utils.go:138","message":"initiating delete from interruption message","controller":"interruption.instancestatus","namespace":"","name":"","reconcileID":"c7d09f08-acdd-431a-940d-bf065d24f2d4","messageKind":"instance_status_failure","NodeClaim":{"name":"default-rdq5t"},"action":"CordonAndDrain","Node":{"name":"<test-node>.us-west-2.compute.internal"}}
    {"level":"INFO","time":"2026-04-20T23:48:53.984Z","logger":"controller","caller":"terminator/terminator.go:89","message":"tainted node","controller":"node.termination","controllerGroup":"","controllerKind":"Node","Node":{"name":"<test-node>.us-west-2.compute.internal"},"namespace":"","name":"<test-node>.us-west-2.compute.internal","reconcileID":"d5b2bece-9a17-47a7-9fe2-611c05bd1c9b","NodeClaim":{"name":"default-rdq5t"},"taint.Key":"karpenter.sh/disrupted","taint.Value":"","taint.Effect":"NoSchedule"}

    ❯ knc
    NAME            TYPE         CAPACITY    ZONE         NODE                                           READY   AGE
    default-92ndr   c6a.xlarge   on-demand   us-west-2d   <new-node>.us-west-2.compute.internal    True    75s
    default-rdq5t   c6a.xlarge   on-demand   us-west-2d   <test-node>.us-west-2.compute.internal   True    21m
    ❯ kn
    NAME                                           STATUS     ROLES    AGE     VERSION
    <test-node>.us-west-2.compute.internal   NotReady   <none>   21m     v1.35.3-eks-bbe087e
    <system-node>.us-west-2.compute.internal     Ready      <none>   4h49m   v1.35.3-eks-bbe087e
    <new-node>.us-west-2.compute.internal    Ready      <none>   61s     v1.35.3-eks-bbe087e
    <system-node>.us-west-2.compute.internal    Ready      <none>   4h49m   v1.35.3-eks-bbe087e


    k describe node <test-node>.us-west-2.compute.internal
    Events:
    Type     Reason                     Age                  From                   Message
    ----     ------                     ----                 ----                   -------
    Normal   Synced                     24m                  cloud-node-controller  Node synced successfully
    Normal   RegisteredNode             24m                  node-controller        Node <test-node>.us-west-2.compute.internal event: Registered Node <test-node>.us-west-2.compute.internal in Controller
    Normal   DisruptionBlocked          24m                  karpenter              Node isn't initialized
    Normal   Ready                      24m                  karpenter              Status condition transitioned, Type: Ready, Status: False -> True, Reason: KubeletReady, Message: kubelet is posting ready status
    Normal   Unconsolidatable           22m                  karpenter              Can't replace with a cheaper node
    Normal   DisruptionBlocked          11m                  karpenter              NodePool not found (NodePool=default)
    Normal   DisruptionBlocked          11m                  karpenter              NodePool not found (NodePool=default)
    Normal   Unconsolidatable           10m                  karpenter              Can't replace with a cheaper node
    Normal   NodeNotReady               9m17s                node-controller        Node <test-node>.us-west-2.compute.internal status is now: NodeNotReady
    Normal   MemoryPressure             9m17s                karpenter              Status condition transitioned, Type: MemoryPressure, Status: False -> Unknown, Reason: NodeStatusUnknown, Message: Kubelet stopped posting node status.
    Normal   DiskPressure               9m17s                karpenter              Status condition transitioned, Type: DiskPressure, Status: False -> Unknown, Reason: NodeStatusUnknown, Message: Kubelet stopped posting node status.
    Normal   PIDPressure                9m17s                karpenter              Status condition transitioned, Type: PIDPressure, Status: False -> Unknown, Reason: NodeStatusUnknown, Message: Kubelet stopped posting node status.
    Normal   Ready                      9m17s                karpenter              Status condition transitioned, Type: Ready, Status: True -> Unknown, Reason: NodeStatusUnknown, Message: Kubelet stopped posting node status.
    Warning  InstanceUnhealthy          4m15s                karpenter              An unhealthy warning was triggered for the instance
    Warning  TerminatingOnInterruption  4m15s                karpenter              Interruption triggered termination for the Node
    Normal   DisruptionBlocked          10s (x3 over 4m11s)  karpenter              Node is deleting or marked for deletion


    ❯ kn
    NAME                                          STATUS   ROLES    AGE     VERSION
    <system-node>.us-west-2.compute.internal    Ready    <none>   4h53m   v1.35.3-eks-bbe087e
    <new-node>.us-west-2.compute.internal   Ready    <none>   4m48s   v1.35.3-eks-bbe087e
    <system-node>.us-west-2.compute.internal   Ready    <none>   4h53m   v1.35.3-eks-bbe087e
  
</details>


**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.