### PR TITLE
fix: nil pointer dereference in CapacityReservationFromEC2 for Interruptible field

### DIFF
--- a/pkg/apis/v1/ec2nodeclass_status.go
+++ b/pkg/apis/v1/ec2nodeclass_status.go
@@ -263,7 +263,7 @@ func CapacityReservationFromEC2(clk clock.Clock, cr *ec2types.CapacityReservatio
 		InstanceType:          *cr.InstanceType,
 		OwnerID:               *cr.OwnerId,
 		ReservationType:       reservationType,
-		Interruptible:         lo.Ternary(cr.Interruptible == nil, false, *cr.Interruptible),
+		Interruptible:         lo.FromPtrOr(cr.Interruptible, false),
 		State:                 state,
 	}, nil
 }

--- a/pkg/controllers/nodeclass/capacityreservation_test.go
+++ b/pkg/controllers/nodeclass/capacityreservation_test.go
@@ -131,8 +131,32 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 					ReservationType:        ec2types.CapacityReservationTypeDefault,
 					Interruptible:          lo.ToPtr(true),
 				},
+				{
+					AvailabilityZone:       lo.ToPtr("test-zone-1a"),
+					InstanceType:           lo.ToPtr("m5.large"),
+					OwnerId:                lo.ToPtr(selfOwnerID),
+					InstanceMatchCriteria:  ec2types.InstanceMatchCriteriaTargeted,
+					CapacityReservationId:  lo.ToPtr("cr-nil-interruptible"),
+					AvailableInstanceCount: lo.ToPtr[int32](5),
+					State:                  ec2types.CapacityReservationStateActive,
+					ReservationType:        ec2types.CapacityReservationTypeDefault,
+					// Interruptible intentionally omitted (nil) — this is the default
+					// for standard ODCRs and capacity blocks returned by the EC2 API
+				},
 			},
 		})
+	})
+	It("should handle capacity reservations with nil Interruptible field", func() {
+		nodeClass.Spec.CapacityReservationSelectorTerms = append(nodeClass.Spec.CapacityReservationSelectorTerms, v1.CapacityReservationSelectorTerm{
+			ID: "cr-nil-interruptible",
+		})
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(1))
+		Expect(nodeClass.Status.CapacityReservations[0].ID).To(Equal("cr-nil-interruptible"))
+		Expect(nodeClass.Status.CapacityReservations[0].Interruptible).To(BeFalse())
 	})
 	It("should resolve capacity reservations by ID", func() {
 		const targetID = "cr-m5.large-1a-1"
@@ -206,10 +230,10 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
-		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(5))
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(6))
 		Expect(lo.Map(nodeClass.Status.CapacityReservations, func(cr v1.CapacityReservation, _ int) string {
 			return cr.ID
-		})).To(ContainElements("cr-m5.large-1a-1", "cr-m5.large-1a-2", "cr-p5.48xlarge-1a", "cr-m5.large-1b-1", "cr-m5.large-1b-2"))
+		})).To(ContainElements("cr-m5.large-1a-1", "cr-m5.large-1a-2", "cr-p5.48xlarge-1a", "cr-m5.large-1b-1", "cr-m5.large-1b-2", "cr-nil-interruptible"))
 		for _, cr := range nodeClass.Status.CapacityReservations {
 			Expect(cr.InstanceMatchCriteria).To(Equal("targeted"))
 		}


### PR DESCRIPTION
## Description

Fixes #9079

`lo.Ternary` eagerly evaluates all arguments in Go, so:

```go
Interruptible: lo.Ternary(cr.Interruptible == nil, false, *cr.Interruptible),
```

dereferences `*cr.Interruptible` unconditionally, panicking when the pointer is nil. The `Interruptible` field may be absent from the EC2 API response depending on partition/region — when absent, the Go SDK deserializes the `*bool` as `nil`, triggering the panic.

Any user configuring `capacityReservationSelectorTerms` on an EC2NodeClass will hit this panic if any matched reservation has a nil `Interruptible` field.

## Changes

- Replace `lo.Ternary(cr.Interruptible == nil, false, *cr.Interruptible)` with `lo.FromPtrOr(cr.Interruptible, false)` which safely returns the default when nil
- Add test fixture with nil `Interruptible` and a regression test to `capacityreservation_test.go`

## How was this change tested?

- Added unit test with a capacity reservation fixture that omits the `Interruptible` field (nil pointer). The existing test fixtures all set `Interruptible: lo.ToPtr(false)`, which is why this bug was not caught.
- Validated on a live EKS cluster (Karpenter v1.10.0, us-west-2) with 6 capacity reservations (2 capacity blocks + 4 ODCRs), all with nil `Interruptible`. Before fix: continuous panic. After fix: all reservations discovered successfully.