### PR TITLE
backport: fix: nil pointer dereference in CapacityReservationFromEC2 (#9080)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws
 
-go 1.26.1
+go 1.26.2
 
 // TODO: migrate tablewriter to v1.0.8
 // https://github.com/olekukonko/tablewriter/blob/c64d84b3ecc64a18cfc8ba10cdd8c52cc13a7d23/MIGRATION.md?plain=1#L661

--- a/pkg/apis/v1/ec2nodeclass_status.go
+++ b/pkg/apis/v1/ec2nodeclass_status.go
@@ -263,7 +263,7 @@ func CapacityReservationFromEC2(clk clock.Clock, cr *ec2types.CapacityReservatio
 		InstanceType:          *cr.InstanceType,
 		OwnerID:               *cr.OwnerId,
 		ReservationType:       reservationType,
-		Interruptible:         lo.Ternary(cr.Interruptible == nil, false, *cr.Interruptible),
+		Interruptible:         lo.FromPtrOr(cr.Interruptible, false),
 		State:                 state,
 	}, nil
 }

--- a/pkg/controllers/nodeclass/capacityreservation_test.go
+++ b/pkg/controllers/nodeclass/capacityreservation_test.go
@@ -131,8 +131,32 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 					ReservationType:        ec2types.CapacityReservationTypeDefault,
 					Interruptible:          lo.ToPtr(true),
 				},
+				{
+					AvailabilityZone:       lo.ToPtr("test-zone-1a"),
+					InstanceType:           lo.ToPtr("m5.large"),
+					OwnerId:                lo.ToPtr(selfOwnerID),
+					InstanceMatchCriteria:  ec2types.InstanceMatchCriteriaTargeted,
+					CapacityReservationId:  lo.ToPtr("cr-nil-interruptible"),
+					AvailableInstanceCount: lo.ToPtr[int32](5),
+					State:                  ec2types.CapacityReservationStateActive,
+					ReservationType:        ec2types.CapacityReservationTypeDefault,
+					// Interruptible intentionally omitted (nil) — this is the default
+					// for standard ODCRs and capacity blocks returned by the EC2 API
+				},
 			},
 		})
+	})
+	It("should handle capacity reservations with nil Interruptible field", func() {
+		nodeClass.Spec.CapacityReservationSelectorTerms = append(nodeClass.Spec.CapacityReservationSelectorTerms, v1.CapacityReservationSelectorTerm{
+			ID: "cr-nil-interruptible",
+		})
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(1))
+		Expect(nodeClass.Status.CapacityReservations[0].ID).To(Equal("cr-nil-interruptible"))
+		Expect(nodeClass.Status.CapacityReservations[0].Interruptible).To(BeFalse())
 	})
 	It("should resolve capacity reservations by ID", func() {
 		const targetID = "cr-m5.large-1a-1"
@@ -206,10 +230,10 @@ var _ = Describe("NodeClass Capacity Reservation Reconciler", func() {
 		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeCapacityReservationsReady).IsTrue()).To(BeTrue())
-		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(5))
+		Expect(nodeClass.Status.CapacityReservations).To(HaveLen(6))
 		Expect(lo.Map(nodeClass.Status.CapacityReservations, func(cr v1.CapacityReservation, _ int) string {
 			return cr.ID
-		})).To(ContainElements("cr-m5.large-1a-1", "cr-m5.large-1a-2", "cr-p5.48xlarge-1a", "cr-m5.large-1b-1", "cr-m5.large-1b-2"))
+		})).To(ContainElements("cr-m5.large-1a-1", "cr-m5.large-1a-2", "cr-p5.48xlarge-1a", "cr-m5.large-1b-1", "cr-m5.large-1b-2", "cr-nil-interruptible"))
 		for _, cr := range nodeClass.Status.CapacityReservations {
 			Expect(cr.InstanceMatchCriteria).To(Equal("targeted"))
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
* backports https://github.com/aws/karpenter-provider-aws/pull/9080 to `v1.11.x`

**How was this change tested?**
* make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.