### PR TITLE
feat: support nodeclaim drift on CA bundle

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -42,6 +42,7 @@ func main() {
 		op.CapacityReservationProvider,
 		op.PlacementGroupProvider,
 		op.InstanceTypeStore,
+		op.CABundle,
 	)
 	overlayUndecoratedCloudProvider := metrics.Decorate(awsCloudProvider)
 	cloudProvider := overlay.Decorate(overlayUndecoratedCloudProvider, op.GetClient(), op.InstanceTypeStore)
@@ -90,6 +91,7 @@ func main() {
 			op.PlacementGroupProvider,
 			op.AMIResolver,
 			op.InstanceStatusProvider,
+			op.CABundle,
 		)...).
 		Start(ctx)
 }

--- a/hack/tools/allocatable_diff/main.go
+++ b/hack/tools/allocatable_diff/main.go
@@ -81,6 +81,7 @@ func main() {
 		op.CapacityReservationProvider,
 		op.PlacementGroupProvider,
 		op.InstanceTypeStore,
+		lo.ToPtr(""),
 	)
 	instanceTypes := lo.Must(cloudProvider.GetInstanceTypes(ctx, nil))
 

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/nodeoverlay"
 	"sigs.k8s.io/karpenter/pkg/events"
 
+	"github.com/samber/lo"
+
 	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/capacityreservation"
@@ -56,6 +58,7 @@ func New(
 			capacityReservationProvider,
 			placementGroupProvider,
 			instanceTypeStore,
+			lo.ToPtr(""),
 		),
 	}
 }

--- a/kwok/main.go
+++ b/kwok/main.go
@@ -15,6 +15,7 @@ package main
 import (
 	"sync"
 
+	"github.com/samber/lo"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
 	corecontrollers "sigs.k8s.io/karpenter/pkg/controllers"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
@@ -103,6 +104,7 @@ func main() {
 			op.PlacementGroupProvider,
 			op.AMIResolver,
 			op.InstanceStatusProvider,
+			lo.ToPtr(""),
 		)...).
 		Start(ctx)
 	wg.Wait()

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -533,15 +533,16 @@ type EC2NodeClass struct {
 // 1. A field changes its default value for an existing field that is already hashed
 // 2. A field is added to the hash calculation with an already-set value
 // 3. A field is removed from the hash calculations
-const EC2NodeClassHashVersion = "v4"
+const EC2NodeClassHashVersion = "v5"
 
-func (in *EC2NodeClass) Hash() string {
+func (in *EC2NodeClass) Hash(caBundle *string) string {
 	return fmt.Sprint(lo.Must(hashstructure.Hash([]any{
 		in.Spec,
 		// AMIFamily should be hashed using the dynamically resolved value rather than the literal value of the field.
 		// This ensures that scenarios such as changing the field from nil to AL2023 with the alias "al2023@latest"
 		// doesn't trigger drift.
 		in.AMIFamily(),
+		lo.FromPtr(caBundle),
 	}, hashstructure.FormatV2, &hashstructure.HashOptions{
 		SlicesAsSets:    true,
 		IgnoreZeroValue: true,

--- a/pkg/apis/v1/ec2nodeclass_hash_test.go
+++ b/pkg/apis/v1/ec2nodeclass_hash_test.go
@@ -29,8 +29,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var testCABundle = lo.ToPtr("test-ca-bundle")
+
 var _ = Describe("Hash", func() {
-	const staticHash = "4950366118253097694"
+	const staticHash = "2608468723537941485"
 	var nodeClass *v1.EC2NodeClass
 	BeforeEach(func() {
 		nodeClass = &v1.EC2NodeClass{
@@ -77,30 +79,30 @@ var _ = Describe("Hash", func() {
 		"should match static hash on field value change",
 		func(hash string, changes v1.EC2NodeClass) {
 			Expect(mergo.Merge(nodeClass, changes, mergo.WithOverride, mergo.WithSliceDeepCopy)).To(Succeed())
-			Expect(nodeClass.Hash()).To(Equal(hash))
+			Expect(nodeClass.Hash(testCABundle)).To(Equal(hash))
 		},
 		Entry("Base EC2NodeClass", staticHash, v1.EC2NodeClass{}),
 		// Static fields, expect changed hash from base
 
-		Entry("UserData", "9034828637236670345", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{UserData: aws.String("userdata-test-2")}}),
-		Entry("Tags", "6878220270322275255", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{Tags: map[string]string{"keyTag-test-3": "valueTag-test-3"}}}),
-		Entry("Context", "13953931752662869657", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{Context: aws.String("context-2")}}),
-		Entry("DetailedMonitoring", "14187487647319890991", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{DetailedMonitoring: aws.Bool(true)}}),
-		Entry("InstanceStorePolicy", "4160809219257698490", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{InstanceStorePolicy: lo.ToPtr(v1.InstanceStorePolicyRAID0)}}),
-		Entry("AssociatePublicIPAddress", "4469320567057431454", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{AssociatePublicIPAddress: lo.ToPtr(true)}}),
-		Entry("MetadataOptions HTTPEndpoint", "1277386558528601282", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPEndpoint: lo.ToPtr("enabled")}}}),
-		Entry("MetadataOptions HTTPProtocolIPv6", "14697047633165484196", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPProtocolIPv6: lo.ToPtr("enabled")}}}),
-		Entry("MetadataOptions HTTPPutResponseHopLimit", "2086799014304536137", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPPutResponseHopLimit: lo.ToPtr(int64(10))}}}),
-		Entry("MetadataOptions HTTPTokens", "14750841460622248593", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPTokens: lo.ToPtr("required")}}}),
-		Entry("BlockDeviceMapping DeviceName", "11716516558705174498", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{DeviceName: lo.ToPtr("map-device-test-3")}}}}),
-		Entry("BlockDeviceMapping RootVolume", "11900810786014401721", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{RootVolume: true}}}}),
-		Entry("BlockDeviceMapping DeleteOnTermination", "14586255897156659742", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{DeleteOnTermination: lo.ToPtr(true)}}}}}),
-		Entry("BlockDeviceMapping Encrypted", "10872029821841773628", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{Encrypted: lo.ToPtr(true)}}}}}),
-		Entry("BlockDeviceMapping IOPS", "9202874311950700210", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{IOPS: lo.ToPtr(int64(10))}}}}}),
-		Entry("BlockDeviceMapping KMSKeyID", "14601456769467439478", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{KMSKeyID: lo.ToPtr("test")}}}}}),
-		Entry("BlockDeviceMapping SnapshotID", "8031059801598053215", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{SnapshotID: lo.ToPtr("test")}}}}}),
-		Entry("BlockDeviceMapping Throughput", "14410045481146650034", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{Throughput: lo.ToPtr(int64(10))}}}}}),
-		Entry("BlockDeviceMapping VolumeType", "9480251663542054235", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{VolumeType: lo.ToPtr("io1")}}}}}),
+		Entry("UserData", "2153344579995979450", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{UserData: aws.String("userdata-test-2")}}),
+		Entry("Tags", "4608386791045313156", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{Tags: map[string]string{"keyTag-test-3": "valueTag-test-3"}}}),
+		Entry("Context", "11612053647989098410", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{Context: aws.String("context-2")}}),
+		Entry("DetailedMonitoring", "11845605438531206428", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{DetailedMonitoring: aws.Bool(true)}}),
+		Entry("InstanceStorePolicy", "6430637013089544585", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{InstanceStorePolicy: lo.ToPtr(v1.InstanceStorePolicyRAID0)}}),
+		Entry("AssociatePublicIPAddress", "6811176403923819181", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{AssociatePublicIPAddress: lo.ToPtr(true)}}),
+		Entry("MetadataOptions HTTPEndpoint", "8158886403801636337", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPEndpoint: lo.ToPtr("enabled")}}}),
+		Entry("MetadataOptions HTTPProtocolIPv6", "12355196004817691031", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPProtocolIPv6: lo.ToPtr("enabled")}}}),
+		Entry("MetadataOptions HTTPPutResponseHopLimit", "8968306366664488826", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPPutResponseHopLimit: lo.ToPtr(int64(10))}}}),
+		Entry("MetadataOptions HTTPTokens", "12408995450371615650", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPTokens: lo.ToPtr("required")}}}),
+		Entry("BlockDeviceMapping DeviceName", "13986335469721503441", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{DeviceName: lo.ToPtr("map-device-test-3")}}}}),
+		Entry("BlockDeviceMapping RootVolume", "14242690863945643402", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{RootVolume: true}}}}),
+		Entry("BlockDeviceMapping DeleteOnTermination", "12316454167870753581", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{DeleteOnTermination: lo.ToPtr(true)}}}}}),
+		Entry("BlockDeviceMapping Encrypted", "17753517657333560591", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{Encrypted: lo.ToPtr(true)}}}}}),
+		Entry("BlockDeviceMapping IOPS", "2249322442135400321", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{IOPS: lo.ToPtr(int64(10))}}}}}),
+		Entry("BlockDeviceMapping KMSKeyID", "12259594419287406661", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{KMSKeyID: lo.ToPtr("test")}}}}}),
+		Entry("BlockDeviceMapping SnapshotID", "1149563513090550380", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{SnapshotID: lo.ToPtr("test")}}}}}),
+		Entry("BlockDeviceMapping Throughput", "12068199760789564545", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{Throughput: lo.ToPtr(int64(10))}}}}}),
+		Entry("BlockDeviceMapping VolumeType", "16361719363399715944", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{BlockDeviceMappings: []*v1.BlockDeviceMapping{{EBS: &v1.BlockDevice{VolumeType: lo.ToPtr("io1")}}}}}),
 
 		// Behavior / Dynamic fields, expect same hash as base
 		Entry("Modified AMISelector", staticHash, v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{AMISelectorTerms: []v1.AMISelectorTerm{{Tags: map[string]string{"": "ami-test-value"}}}}}),
@@ -111,25 +113,25 @@ var _ = Describe("Hash", func() {
 	// doesn't work well with unexported fields, like the ones that are present in resource.Quantity
 	It("should match static hash when updating blockDeviceMapping volumeSize", func() {
 		nodeClass.Spec.BlockDeviceMappings[0].EBS.VolumeSize = resource.NewScaledQuantity(10, resource.Giga)
-		Expect(nodeClass.Hash()).To(Equal("5906178522470964189"))
+		Expect(nodeClass.Hash(testCABundle)).To(Equal("3564293065344858862"))
 	})
 	It("should match static hash for instanceProfile", func() {
 		nodeClass.Spec.Role = ""
 		nodeClass.Spec.InstanceProfile = lo.ToPtr("test-instance-profile")
-		Expect(nodeClass.Hash()).To(Equal("5855570904022890593"))
+		Expect(nodeClass.Hash(testCABundle)).To(Equal("3585768058063247698"))
 	})
 	It("should match static hash when reordering tags", func() {
 		nodeClass.Spec.Tags = map[string]string{"keyTag-2": "valueTag-2", "keyTag-1": "valueTag-1"}
-		Expect(nodeClass.Hash()).To(Equal(staticHash))
+		Expect(nodeClass.Hash(testCABundle)).To(Equal(staticHash))
 	})
 	It("should match static hash when reordering blockDeviceMappings", func() {
 		nodeClass.Spec.BlockDeviceMappings[0], nodeClass.Spec.BlockDeviceMappings[1] = nodeClass.Spec.BlockDeviceMappings[1], nodeClass.Spec.BlockDeviceMappings[0]
-		Expect(nodeClass.Hash()).To(Equal(staticHash))
+		Expect(nodeClass.Hash(testCABundle)).To(Equal(staticHash))
 	})
 	DescribeTable("should change hash when static fields are updated", func(changes v1.EC2NodeClass) {
-		hash := nodeClass.Hash()
+		hash := nodeClass.Hash(testCABundle)
 		Expect(mergo.Merge(nodeClass, changes, mergo.WithOverride, mergo.WithSliceDeepCopy)).To(Succeed())
-		updatedHash := nodeClass.Hash()
+		updatedHash := nodeClass.Hash(testCABundle)
 		Expect(hash).ToNot(Equal(updatedHash))
 	},
 		Entry("UserData", v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{UserData: aws.String("userdata-test-2")}}),
@@ -155,33 +157,33 @@ var _ = Describe("Hash", func() {
 	// We create a separate test for updating blockDeviceMapping volumeSize, since resource.Quantity is a struct, and mergo.WithSliceDeepCopy
 	// doesn't work well with unexported fields, like the ones that are present in resource.Quantity
 	It("should change hash blockDeviceMapping volumeSize is updated", func() {
-		hash := nodeClass.Hash()
+		hash := nodeClass.Hash(testCABundle)
 		nodeClass.Spec.BlockDeviceMappings[0].EBS.VolumeSize = resource.NewScaledQuantity(10, resource.Giga)
-		updatedHash := nodeClass.Hash()
+		updatedHash := nodeClass.Hash(testCABundle)
 		Expect(hash).ToNot(Equal(updatedHash))
 	})
 	It("should change hash when instanceProfile is updated", func() {
 		nodeClass.Spec.Role = ""
 		nodeClass.Spec.InstanceProfile = lo.ToPtr("test-instance-profile")
-		hash := nodeClass.Hash()
+		hash := nodeClass.Hash(testCABundle)
 		nodeClass.Spec.InstanceProfile = lo.ToPtr("other-instance-profile")
-		updatedHash := nodeClass.Hash()
+		updatedHash := nodeClass.Hash(testCABundle)
 		Expect(hash).ToNot(Equal(updatedHash))
 	})
 	It("should not change hash when tags are re-ordered", func() {
-		hash := nodeClass.Hash()
+		hash := nodeClass.Hash(testCABundle)
 		nodeClass.Spec.Tags = map[string]string{"keyTag-2": "valueTag-2", "keyTag-1": "valueTag-1"}
-		updatedHash := nodeClass.Hash()
+		updatedHash := nodeClass.Hash(testCABundle)
 		Expect(hash).To(Equal(updatedHash))
 	})
 	It("should not change hash when blockDeviceMappings are re-ordered", func() {
-		hash := nodeClass.Hash()
+		hash := nodeClass.Hash(testCABundle)
 		nodeClass.Spec.BlockDeviceMappings[0], nodeClass.Spec.BlockDeviceMappings[1] = nodeClass.Spec.BlockDeviceMappings[1], nodeClass.Spec.BlockDeviceMappings[0]
-		updatedHash := nodeClass.Hash()
+		updatedHash := nodeClass.Hash(testCABundle)
 		Expect(hash).To(Equal(updatedHash))
 	})
 	It("should not change hash when behavior/dynamic fields are updated", func() {
-		hash := nodeClass.Hash()
+		hash := nodeClass.Hash(testCABundle)
 
 		// Update a behavior/dynamic field
 		nodeClass.Spec.SubnetSelectorTerms = []v1.SubnetSelectorTerm{{
@@ -196,13 +198,13 @@ var _ = Describe("Hash", func() {
 		nodeClass.Spec.CapacityReservationSelectorTerms = []v1.CapacityReservationSelectorTerm{{
 			Tags: map[string]string{"cr-test-key": "cr-test-value"},
 		}}
-		updatedHash := nodeClass.Hash()
+		updatedHash := nodeClass.Hash(testCABundle)
 		Expect(hash).To(Equal(updatedHash))
 	})
 	It("should expect two EC2NodeClasses with the same spec to have the same hash", func() {
 		otherNodeClass := &v1.EC2NodeClass{
 			Spec: nodeClass.Spec,
 		}
-		Expect(nodeClass.Hash()).To(Equal(otherNodeClass.Hash()))
+		Expect(nodeClass.Hash(testCABundle)).To(Equal(otherNodeClass.Hash(testCABundle)))
 	})
 })

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -70,6 +70,7 @@ type CloudProvider struct {
 	capacityReservationProvider capacityreservation.Provider
 	placementGroupProvider      placementgroup.Provider
 	instanceTypeStore           *nodeoverlay.InstanceTypeStore
+	caBundle                    *string
 }
 
 func New(
@@ -82,6 +83,7 @@ func New(
 	capacityReservationProvider capacityreservation.Provider,
 	placementGroupProvider placementgroup.Provider,
 	store *nodeoverlay.InstanceTypeStore,
+	caBundle *string,
 ) *CloudProvider {
 	return &CloudProvider{
 		instanceTypeProvider:        instanceTypeProvider,
@@ -93,6 +95,7 @@ func New(
 		placementGroupProvider:      placementGroupProvider,
 		recorder:                    recorder,
 		instanceTypeStore:           store,
+		caBundle:                    caBundle,
 	}
 }
 
@@ -152,7 +155,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 	})
 	nc := c.instanceToNodeClaim(ctx, instance, instanceType, nodeClass, nodeClaim)
 	nc.Annotations = lo.Assign(nc.Annotations, map[string]string{
-		v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(),
+		v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(c.caBundle),
 		v1.AnnotationEC2NodeClassHashVersion: v1.EC2NodeClassHashVersion,
 		v1.AnnotationInstanceProfile:         nodeClass.Status.InstanceProfile,
 	})

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -72,6 +72,7 @@ var cloudProvider *cloudprovider.CloudProvider
 var cluster *state.Cluster
 var fakeClock *clock.FakeClock
 var recorder events.Recorder
+var testCABundle = lo.ToPtr("test-ca-bundle")
 
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -92,7 +93,7 @@ var _ = BeforeSuite(func() {
 	fakeClock = clock.NewFakeClock(time.Now())
 	recorder = events.NewRecorder(&record.FakeRecorder{})
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, recorder,
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr("test-ca-bundle"))
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, fakeClock)
 })
@@ -800,13 +801,13 @@ var _ = Describe("CloudProvider", func() {
 				Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{instance}}},
 			})
 			nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{
-				v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(),
+				v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(testCABundle),
 				v1.AnnotationEC2NodeClassHashVersion: v1.EC2NodeClassHashVersion,
 			})
 			nodeClaim.Status.ProviderID = fake.ProviderID(lo.FromPtr(instance.InstanceId))
 			nodeClaim.Status.ImageID = amdAMIID
 			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
-				v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(),
+				v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(testCABundle),
 				v1.AnnotationEC2NodeClassHashVersion: v1.EC2NodeClassHashVersion,
 			})
 			nodeClaim.Labels = lo.Assign(nodeClaim.Labels, map[string]string{corev1.LabelInstanceTypeStable: selectedInstanceType.Name})
@@ -1064,8 +1065,8 @@ var _ = Describe("CloudProvider", func() {
 						},
 					},
 				}
-				nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash()})
-				nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash()})
+				nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash(testCABundle)})
+				nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash(testCABundle)})
 			})
 			DescribeTable("should return drifted if a statically drifted EC2NodeClass.Spec field is updated",
 				func(changes v1.EC2NodeClass) {
@@ -1075,7 +1076,7 @@ var _ = Describe("CloudProvider", func() {
 					Expect(isDrifted).To(BeEmpty())
 
 					Expect(mergo.Merge(nodeClass, changes, mergo.WithOverride, mergo.WithSliceDeepCopy)).To(Succeed())
-					nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash()})
+					nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash(testCABundle)})
 
 					ExpectApplied(ctx, env.Client, nodeClass)
 					isDrifted, err = cloudProvider.IsDrifted(ctx, nodeClaim)
@@ -1106,7 +1107,7 @@ var _ = Describe("CloudProvider", func() {
 			// doesn't work well with unexported fields, like the ones that are present in resource.Quantity
 			It("should return drifted when updating blockDeviceMapping volumeSize", func() {
 				nodeClass.Spec.BlockDeviceMappings[0].EBS.VolumeSize = resource.NewScaledQuantity(10, resource.Giga)
-				nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash()})
+				nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash(testCABundle)})
 
 				ExpectApplied(ctx, env.Client, nodeClass)
 				isDrifted, err := cloudProvider.IsDrifted(ctx, nodeClaim)
@@ -1121,7 +1122,7 @@ var _ = Describe("CloudProvider", func() {
 					Expect(isDrifted).To(BeEmpty())
 
 					Expect(mergo.Merge(nodeClass, changes, mergo.WithOverride))
-					nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash()})
+					nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{v1.AnnotationEC2NodeClassHash: nodeClass.Hash(testCABundle)})
 
 					ExpectApplied(ctx, env.Client, nodeClass)
 					isDrifted, err = cloudProvider.IsDrifted(ctx, nodeClaim)

--- a/pkg/controllers/capacityreservation/capacitytype/suite_test.go
+++ b/pkg/controllers/capacityreservation/capacitytype/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	awsEnv = test.NewEnvironment(ctx, env)
 
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	controller = capacitytype.NewController(env.Client, cloudProvider)
 })
 

--- a/pkg/controllers/capacityreservation/expiration/suite_test.go
+++ b/pkg/controllers/capacityreservation/expiration/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	awsEnv = test.NewEnvironment(ctx, env)
 
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	controller = expiration.NewController(awsEnv.Clock, env.Client, cloudProvider, awsEnv.CapacityReservationProvider)
 })
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -91,9 +91,10 @@ func NewControllers(
 	placementGroupProvider placementgroup.Provider,
 	amiResolver amifamily.Resolver,
 	instanceStatusProvider instancestatus.Provider,
+	caBundle *string,
 ) []controller.Controller {
 	controllers := []controller.Controller{
-		nodeclasshash.NewController(kubeClient),
+		nodeclasshash.NewController(kubeClient, caBundle),
 		nodeclass.NewController(clk, kubeClient, cloudProvider, recorder, cfg.Region, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider, instanceTypeProvider, launchTemplateProvider, capacityReservationProvider, placementGroupProvider, ec2api, validationCache, recreationCache, amiResolver, options.FromContext(ctx).DisableDryRun),
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider),
 		nodeclaimtagging.NewController(kubeClient, cloudProvider, instanceProvider),

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 	sqsapi = &fake.SQSAPI{}
 	sqsProvider = lo.Must(sqs.NewDefaultProvider(sqsapi, fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/test-cluster", fake.DefaultRegion, fake.DefaultAccount)))
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	controller = interruption.NewController(env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, servicesqs.NewFromConfig(aws.Config{}), unavailableOfferingsCache, awsEnv.CapacityReservationProvider)
 	instanceStatusController = interruption.NewInstanceStatusController(env.Client, cloudProvider, fakeClock, events.NewRecorder(&record.FakeRecorder{}), awsEnv.InstanceStatusProvider)
 })

--- a/pkg/controllers/metrics/suite_test.go
+++ b/pkg/controllers/metrics/suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	awsEnv = test.NewEnvironment(ctx, env)
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	controller = metrics.NewController(env.Client, cloudProvider)
 
 	pricingController = pricing.NewController(awsEnv.PricingProvider)

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 	ctx = coreoptions.ToContext(ctx, coretest.Options(coretest.OptionsFields{FeatureGates: coretest.FeatureGates{ReservedCapacity: lo.ToPtr(true)}}))
 	awsEnv = test.NewEnvironment(ctx, env)
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	garbageCollectionController = garbagecollection.NewController(env.Client, cloudProvider)
 })
 

--- a/pkg/controllers/nodeclaim/tagging/suite_test.go
+++ b/pkg/controllers/nodeclaim/tagging/suite_test.go
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	awsEnv = test.NewEnvironment(ctx, env)
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	taggingController = tagging.NewController(env.Client, cloudProvider, awsEnv.InstanceProvider)
 })
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodeclass/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclass/garbagecollection/suite_test.go
@@ -93,6 +93,7 @@ var _ = BeforeSuite(func() {
 		awsEnv.CapacityReservationProvider,
 		awsEnv.PlacementGroupProvider,
 		awsEnv.InstanceTypeStore,
+		lo.ToPtr(""),
 	)
 
 	gcController = garbagecollection.NewController(

--- a/pkg/controllers/nodeclass/hash/controller.go
+++ b/pkg/controllers/nodeclass/hash/controller.go
@@ -36,11 +36,13 @@ import (
 
 type Controller struct {
 	kubeClient client.Client
+	caBundle   *string
 }
 
-func NewController(kubeClient client.Client) *Controller {
+func NewController(kubeClient client.Client, caBundle *string) *Controller {
 	return &Controller{
 		kubeClient: kubeClient,
+		caBundle:   caBundle,
 	}
 }
 
@@ -55,7 +57,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 		}
 	}
 	nodeClass.Annotations = lo.Assign(nodeClass.Annotations, map[string]string{
-		v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(),
+		v1.AnnotationEC2NodeClassHash:        nodeClass.Hash(c.caBundle),
 		v1.AnnotationEC2NodeClassHashVersion: v1.EC2NodeClassHashVersion,
 	})
 
@@ -103,7 +105,7 @@ func (c *Controller) updateNodeClaimHash(ctx context.Context, nodeClass *v1.EC2N
 			// Since the hashing mechanism has changed we will not be able to determine if the drifted status of the NodeClaim has changed
 			if nc.StatusConditions().Get(karpv1.ConditionTypeDrifted) == nil {
 				nc.Annotations = lo.Assign(nc.Annotations, map[string]string{
-					v1.AnnotationEC2NodeClassHash: nodeClass.Hash(),
+					v1.AnnotationEC2NodeClassHash: nodeClass.Hash(c.caBundle),
 				})
 			}
 

--- a/pkg/controllers/nodeclass/hash/suite_test.go
+++ b/pkg/controllers/nodeclass/hash/suite_test.go
@@ -47,6 +47,7 @@ var ctx context.Context
 var env *coretest.Environment
 var awsEnv *test.Environment
 var hashController *hash.Controller
+var caBundle = lo.ToPtr("test-ca-bundle")
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -60,7 +61,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	awsEnv = test.NewEnvironment(ctx, env)
 
-	hashController = hash.NewController(env.Client)
+	hashController = hash.NewController(env.Client, caBundle)
 })
 
 var _ = AfterSuite(func() {
@@ -119,7 +120,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 
-		expectedHash := nodeClass.Hash()
+		expectedHash := nodeClass.Hash(caBundle)
 		Expect(nodeClass.ObjectMeta.Annotations[v1.AnnotationEC2NodeClassHash]).To(Equal(expectedHash))
 
 		Expect(mergo.Merge(nodeClass, changes, mergo.WithOverride)).To(Succeed())
@@ -128,7 +129,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 
-		expectedHashTwo := nodeClass.Hash()
+		expectedHashTwo := nodeClass.Hash(caBundle)
 		Expect(nodeClass.Annotations[v1.AnnotationEC2NodeClassHash]).To(Equal(expectedHashTwo))
 		Expect(expectedHash).ToNot(Equal(expectedHashTwo))
 
@@ -140,12 +141,31 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		Entry("MetadataOptions Drift", &v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{MetadataOptions: &v1.MetadataOptions{HTTPEndpoint: aws.String("disabled")}}}),
 		Entry("Context Drift", &v1.EC2NodeClass{Spec: v1.EC2NodeClassSpec{Context: aws.String("context-2")}}),
 	)
+	It("should update the drift hash when the CA bundle changes", func() {
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+
+		originalHash := nodeClass.Annotations[v1.AnnotationEC2NodeClassHash]
+		Expect(originalHash).To(Equal(nodeClass.Hash(caBundle)))
+
+		// Simulate a CA bundle change by creating a new controller with a different CA bundle
+		newCABundle := lo.ToPtr("new-ca-bundle")
+		newHashController := hash.NewController(env.Client, newCABundle)
+
+		ExpectObjectReconciled(ctx, env.Client, newHashController, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+
+		newHash := nodeClass.Annotations[v1.AnnotationEC2NodeClassHash]
+		Expect(newHash).To(Equal(nodeClass.Hash(newCABundle)))
+		Expect(newHash).ToNot(Equal(originalHash))
+	})
 	It("should not update the drift hash when dynamic field is updated", func() {
 		ExpectApplied(ctx, env.Client, nodeClass)
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 
-		expectedHash := nodeClass.Hash()
+		expectedHash := nodeClass.Hash(caBundle)
 		Expect(nodeClass.Annotations[v1.AnnotationEC2NodeClassHash]).To(Equal(expectedHash))
 
 		nodeClass.Spec.SubnetSelectorTerms = []v1.SubnetSelectorTerm{
@@ -179,7 +199,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		ExpectObjectReconciled(ctx, env.Client, hashController, nodeClass)
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 
-		expectedHash := nodeClass.Hash()
+		expectedHash := nodeClass.Hash(caBundle)
 		// Expect ec2nodeclass-hash on the NodeClass to be updated
 		Expect(nodeClass.Annotations).To(HaveKeyWithValue(v1.AnnotationEC2NodeClassHash, expectedHash))
 		Expect(nodeClass.Annotations).To(HaveKeyWithValue(v1.AnnotationEC2NodeClassHashVersion, v1.EC2NodeClassHashVersion))
@@ -229,7 +249,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		nodeClaimOne = ExpectExists(ctx, env.Client, nodeClaimOne)
 		nodeClaimTwo = ExpectExists(ctx, env.Client, nodeClaimTwo)
 
-		expectedHash := nodeClass.Hash()
+		expectedHash := nodeClass.Hash(caBundle)
 		// Expect ec2nodeclass-hash on the NodeClaims to be updated
 		Expect(nodeClaimOne.Annotations).To(HaveKeyWithValue(v1.AnnotationEC2NodeClassHash, expectedHash))
 		Expect(nodeClaimOne.Annotations).To(HaveKeyWithValue(v1.AnnotationEC2NodeClassHashVersion, v1.EC2NodeClassHashVersion))
@@ -263,7 +283,7 @@ var _ = Describe("NodeClass Hash Controller", func() {
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
-		expectedHash := nodeClass.Hash()
+		expectedHash := nodeClass.Hash(caBundle)
 
 		// Expect ec2nodeclass-hash on the NodeClass to be updated
 		Expect(nodeClass.Annotations).To(HaveKeyWithValue(v1.AnnotationEC2NodeClassHash, expectedHash))

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	awsEnv = test.NewEnvironment(ctx, env)
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/providers/instancetype/capacity/suite_test.go
+++ b/pkg/controllers/providers/instancetype/capacity/suite_test.go
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func() {
 	nodeClaim = coretest.NodeClaim()
 	node = coretest.Node()
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	controller = controllersinstancetypecapacity.NewController(env.Client, cloudProvider, awsEnv.InstanceTypesProvider)
 })
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -96,6 +96,7 @@ type Operator struct {
 	CapacityReservationProvider capacityreservation.Provider
 	PlacementGroupProvider      placementgroup.Provider
 	EC2API                      *ec2.Client
+	CABundle                    *string
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
@@ -164,6 +165,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(awscache.PlacementGroupAvailabilityTTL, awscache.DefaultCleanupInterval),
 	)
 	amiResolver := amifamily.NewDefaultResolver(cfg.Region)
+	caBundle := lo.Must(GetCABundle(ctx, operator.GetConfig()))
 	launchTemplateProvider := launchtemplate.NewDefaultProvider(
 		ctx,
 		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
@@ -173,7 +175,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		securityGroupProvider,
 		subnetProvider,
 		placementGroupProvider,
-		lo.Must(GetCABundle(ctx, operator.GetConfig())),
+		caBundle,
 		operator.Elected(),
 		kubeDNSIP,
 		clusterEndpoint,
@@ -238,6 +240,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		CapacityReservationProvider: capacityReservationProvider,
 		PlacementGroupProvider:      placementGroupProvider,
 		EC2API:                      ec2api,
+		CABundle:                    caBundle,
 	}
 }
 

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	awsEnv = test.NewEnvironment(ctx, env)
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	awsEnv = test.NewEnvironment(ctx, env)
 	fakeClock = &clock.FakeClock{}
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, fakeClock)
 })

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -103,7 +103,7 @@ var _ = BeforeSuite(func() {
 	fakeClock = &clock.FakeClock{}
 	recorder = events.NewRecorder(&record.FakeRecorder{})
 	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, recorder,
-		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
+		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore, lo.ToPtr(""))
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, fakeClock)
 })

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -472,7 +472,7 @@ var _ = Describe("Drift", Ordered, func() {
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
 		nodeClaim := env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
 		nodeClass = env.ExpectExists(nodeClass).(*v1.EC2NodeClass)
-		expectedHash := nodeClass.Hash()
+		expectedHash := nodeClass.Hash(lo.ToPtr(env.ExpectCABundle()))
 
 		By(fmt.Sprintf("expect nodeclass %s and nodeclaim %s to contain %s and %s annotations", nodeClass.Name, nodeClaim.Name, v1.AnnotationEC2NodeClassHash, v1.AnnotationEC2NodeClassHashVersion))
 		Eventually(func(g Gomega) {
@@ -502,7 +502,7 @@ var _ = Describe("Drift", Ordered, func() {
 
 		// The nodeclaim will need to be updated first, as the hash controller will only be triggered on changes to the nodeclass
 		env.ExpectUpdated(nodeClaim, nodeClass)
-		expectedHash = nodeClass.Hash()
+		expectedHash = nodeClass.Hash(lo.ToPtr(env.ExpectCABundle()))
 
 		// Expect all nodeclaims not to be drifted and contain an updated `nodepool-hash` and `nodepool-hash-version` annotation
 		Eventually(func(g Gomega) {

--- a/test/suites/integration/hash_test.go
+++ b/test/suites/integration/hash_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package integration_test
 
 import (
+	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -34,7 +35,7 @@ var _ = Describe("CRD Hash", func() {
 
 			hash, found := nc.Annotations[v1.AnnotationEC2NodeClassHash]
 			g.Expect(found).To(BeTrue())
-			g.Expect(hash).To(Equal(nc.Hash()))
+			g.Expect(hash).To(Equal(nc.Hash(lo.ToPtr(env.ExpectCABundle()))))
 		})
 	})
 })

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -93,7 +93,7 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 **Do not** upgrade to `1.1.0`+ without following the [Migration Guide]({{<ref "../../v1.0/upgrading/v1-migration.md#before-upgrading-to-v110">}}).
 {{% /alert %}}
 
-* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). The updated hashing logic will mark existing nodes as [drifted]({{<ref "../../concepts/disruption/#drift">}}).
+* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). The updated hashing logic will mark existing nodes as [drifted]({{<ref "../concepts/disruption/#drift">}}).
 
 Full Changelog:
 * https://github.com/aws/karpenter-provider-aws/releases/tag/v1.12.0

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -93,7 +93,7 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 **Do not** upgrade to `1.1.0`+ without following the [Migration Guide]({{<ref "../../v1.0/upgrading/v1-migration.md#before-upgrading-to-v110">}}).
 {{% /alert %}}
 
-* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). The updated hashing logic will mark existing nodes as [drifted]({{<ref "../concepts/disruption/#drift">}}).
+* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). The updated hashing logic will mark existing nodes as [drifted]({{<ref "../../concepts/disruption/#drift">}}).
 
 Full Changelog:
 * https://github.com/aws/karpenter-provider-aws/releases/tag/v1.12.0

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -93,7 +93,7 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 **Do not** upgrade to `1.1.0`+ without following the [Migration Guide]({{<ref "../../v1.0/upgrading/v1-migration.md#before-upgrading-to-v110">}}).
 {{% /alert %}}
 
-* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). The updated hashing logic will mark existing nodes as [drifted]({{<ref "../../docs/concepts/disruption/#drift">}}).
+* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). The updated hashing logic will mark existing nodes as [drifted]({{<ref "../concepts/disruption/#drift">}}).
 
 Full Changelog:
 * https://github.com/aws/karpenter-provider-aws/releases/tag/v1.12.0

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -86,6 +86,19 @@ If you get the error `invalid ownership metadata; label validation error:` while
 WHEN CREATING A NEW SECTION OF THE UPGRADE GUIDANCE FOR NEWER VERSIONS, ENSURE THAT YOU COPY THE BETA API ALERT SECTION FROM THE LAST RELEASE TO PROPERLY WARN USERS OF THE RISK OF UPGRADING WITHOUT GOING TO 0.32.x FIRST
 -->
 
+### Upgrading to `1.12.0`+
+
+{{% alert title="Warning" color="warning" %}}
+Karpenter `1.1.0` drops the support for `v1beta1` APIs.
+**Do not** upgrade to `1.1.0`+ without following the [Migration Guide]({{<ref "../../v1.0/upgrading/v1-migration.md#before-upgrading-to-v110">}}).
+{{% /alert %}}
+
+* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). Upgrading will initiate drift due to a change in the hashing behavior.
+
+Full Changelog:
+* https://github.com/aws/karpenter-provider-aws/releases/tag/v1.12.0
+* https://github.com/kubernetes-sigs/karpenter/releases/tag/v1.12.0
+
 ### Upgrading to `1.11.0`+
 
 {{% alert title="Warning" color="warning" %}}

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -93,7 +93,7 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 **Do not** upgrade to `1.1.0`+ without following the [Migration Guide]({{<ref "../../v1.0/upgrading/v1-migration.md#before-upgrading-to-v110">}}).
 {{% /alert %}}
 
-* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). Upgrading will initiate drift due to a change in the hashing behavior.
+* This version adds support for [drift on CA bundle](https://github.com/aws/karpenter-provider-aws/pull/9083). The updated hashing logic will mark existing nodes as [drifted]({{<ref "../../docs/concepts/disruption/#drift">}}).
 
 Full Changelog:
 * https://github.com/aws/karpenter-provider-aws/releases/tag/v1.12.0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

add support for drifting nodes on CA bundle changes
- wired the CA bundle from flags to nodeclass hashing controller
- update nodeclass hash function to include CA bundle
- drift nodes based on nodeclass hash which now includes CA bundle

**How was this change tested?**
unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.