### PR TITLE
chore: add SecurityGroupSubnetVPCMismatch to NodeClaim

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -237,6 +237,9 @@ func ToReasonMessage(err error) (string, string) {
 		}
 		return "Unauthorized", "User is not authorized to perform this operation because no identity-based policy allows it"
 	}
+	if strings.Contains(err.Error(), "InvalidParameter") && strings.Contains(err.Error(), "belong to different networks") {
+		return "SecurityGroupSubnetVPCMismatch", "Security groups and subnets must be in the same VPC."
+	}
 	if strings.Contains(err.Error(), "iamInstanceProfile.name is invalid") {
 		return "InstanceProfileNameInvalid", "Instance profile name used from EC2NodeClass status does not exist"
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
* adds launch reason/message on NodeClaim when security groups and subnets are not in the same VPC

Currently, the only visibility is through controller logs and nothing is persisted to the NodeClaim:
> {"level":"ERROR",... "error":"launching nodeclaim, creating instance, creating nodeclaim, InvalidParameter: Security group sg-058cbd54d320cfffb and subnet subnet-05554aec17a3027d0 belong to different networks. (aws-error-code=UnfulfillableCapacity, aws-operation-name=CreateFleet, ...}

**How was this change tested?**
* make presubmit

**Before**
```
Status:
  Conditions:
    Last Transition Time:  2026-04-21T16:39:08Z
    Message:               Instance launch failed
    Observed Generation:   1
    Reason:                LaunchFailed
    Status:                Unknown
    Type:                  Launched
```

**After**
```
Status:
  Conditions:
    Last Transition Time:  2026-04-21T16:46:49Z
    Message:               Security groups and subnets must be in the same VPC.
    Observed Generation:   1
    Reason:                SecurityGroupSubnetVPCMismatch
    Status:                Unknown
    Type:                  Launched
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.