### PR TITLE
chore: Remove unnecessary clk from instancestatus controller

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -106,7 +106,7 @@ func NewControllers(
 		crcapacitytype.NewController(kubeClient, cloudProvider),
 		crexpiration.NewController(clk, kubeClient, cloudProvider, capacityReservationProvider),
 		metrics.NewController(kubeClient, cloudProvider),
-		interruption.NewInstanceStatusController(kubeClient, cloudProvider, clk, recorder, instanceStatusProvider),
+		interruption.NewInstanceStatusController(kubeClient, cloudProvider, recorder, instanceStatusProvider),
 	}
 	// Instance profile garbage collection requires IAM API access. Skip registering the controller when running
 	// in isolated VPC mode to avoid initiating calls to public AWS endpoints that won’t be reachable.

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/awslabs/operatorpkg/singleton"
 	"go.uber.org/multierr"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -46,14 +45,12 @@ var (
 // and scheduled maintenance events, then cordons and drains affected nodes.
 type InstanceStatusController struct {
 	InterruptionHandler
-	clk                    clock.Clock
 	instanceStatusProvider instancestatus.Provider
 }
 
 func NewInstanceStatusController(
 	kubeClient client.Client,
 	cloudProvider cloudprovider.CloudProvider,
-	clk clock.Clock,
 	recorder events.Recorder,
 	instanceStatusProvider instancestatus.Provider,
 ) *InstanceStatusController {
@@ -63,7 +60,6 @@ func NewInstanceStatusController(
 			cloudProvider: cloudProvider,
 			recorder:      recorder,
 		},
-		clk:                    clk,
 		instanceStatusProvider: instanceStatusProvider,
 	}
 }

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -98,7 +98,7 @@ var _ = BeforeSuite(func() {
 	cloudProvider := cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, events.NewRecorder(&record.FakeRecorder{}),
 		env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.CapacityReservationProvider, awsEnv.PlacementGroupProvider, awsEnv.InstanceTypeStore)
 	controller = interruption.NewController(env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), sqsProvider, servicesqs.NewFromConfig(aws.Config{}), unavailableOfferingsCache, awsEnv.CapacityReservationProvider)
-	instanceStatusController = interruption.NewInstanceStatusController(env.Client, cloudProvider, fakeClock, events.NewRecorder(&record.FakeRecorder{}), awsEnv.InstanceStatusProvider)
+	instanceStatusController = interruption.NewInstanceStatusController(env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), awsEnv.InstanceStatusProvider)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Remove an unnecessary clock from the instancestatus controller introduced here - https://github.com/aws/karpenter-provider-aws/pull/9064

**How was this change tested?**
CI

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.