### PR TITLE
fix: Skip legacy instanceProfile invalid cleanup

### DIFF
--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -17,6 +17,7 @@ package nodeclass
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"go.uber.org/multierr"
@@ -39,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -71,6 +73,8 @@ type Controller struct {
 	validation              *Validation
 	reconcilers             []reconcile.TypedReconciler[*v1.EC2NodeClass]
 }
+
+var iamInstanceProfileNameRegex = regexp.MustCompile(`^[\w+=,.@-]+$`)
 
 func NewController(
 	clk clock.Clock,
@@ -184,6 +188,29 @@ func (c *Controller) cleanupInstanceProfiles(ctx context.Context, nodeClass *v1.
 	return nil
 }
 
+func (c *Controller) cleanupLegacyInstanceProfile(ctx context.Context, nodeClass *v1.EC2NodeClass) error {
+	legacyProfileName := nodeClass.LegacyInstanceProfileName(options.FromContext(ctx).ClusterName, c.region)
+	if !isValidIAMInstanceProfileName(legacyProfileName) {
+		log.FromContext(ctx).V(1).Info("skipping legacy instance profile cleanup, synthesized name is not IAM-valid", "instance-profile", legacyProfileName)
+		return nil
+	}
+	if err := c.instanceProfileProvider.Delete(ctx, legacyProfileName); err != nil {
+		return serrors.Wrap(fmt.Errorf("deleting instance profile, %w", err), "instance-profile", legacyProfileName)
+	}
+	return nil
+}
+
+func (c *Controller) cleanupManagedInstanceProfiles(ctx context.Context, nodeClass *v1.EC2NodeClass) error {
+	// Instance profile cleanup should be skipped in isolated VPCs to avoid IAM calls.
+	if options.FromContext(ctx).IsolatedVPC {
+		return nil
+	}
+	if err := c.cleanupInstanceProfiles(ctx, nodeClass); err != nil {
+		return err
+	}
+	return c.cleanupLegacyInstanceProfile(ctx, nodeClass)
+}
+
 func (c *Controller) finalize(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	stored := nodeClass.DeepCopy()
 	if !controllerutil.ContainsFinalizer(nodeClass, v1.TerminationFinalizer) {
@@ -197,17 +224,8 @@ func (c *Controller) finalize(ctx context.Context, nodeClass *v1.EC2NodeClass) (
 		c.recorder.Publish(WaitingOnNodeClaimTerminationEvent(nodeClass, lo.Map(nodeClaims.Items, func(nc karpv1.NodeClaim, _ int) string { return nc.Name })))
 		return reconcile.Result{RequeueAfter: time.Minute * 10}, nil // periodically fire the event
 	}
-	// Instance profile cleanup should be skipped in isolated VPCs to avoid IAM calls.
-	if !options.FromContext(ctx).IsolatedVPC {
-		// Deletes karpenter managed instance profiles for this nodeclass
-		if err := c.cleanupInstanceProfiles(ctx, nodeClass); err != nil {
-			return reconcile.Result{}, err
-		}
-		// Ensure to clean up instance profile that may have been created pre-upgrade
-		legacyProfileName := nodeClass.LegacyInstanceProfileName(options.FromContext(ctx).ClusterName, c.region)
-		if err := c.instanceProfileProvider.Delete(ctx, legacyProfileName); err != nil {
-			return reconcile.Result{}, serrors.Wrap(fmt.Errorf("deleting instance profile, %w", err), "instance-profile", legacyProfileName)
-		}
+	if err := c.cleanupManagedInstanceProfiles(ctx, nodeClass); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	if err := c.launchTemplateProvider.DeleteAll(ctx, nodeClass); err != nil {
@@ -228,6 +246,10 @@ func (c *Controller) finalize(ctx context.Context, nodeClass *v1.EC2NodeClass) (
 	}
 	c.validation.clearCacheEntries(nodeClass)
 	return reconcile.Result{}, nil
+}
+
+func isValidIAMInstanceProfileName(name string) bool {
+	return len(name) > 0 && len(name) <= 128 && iamInstanceProfileNameRegex.MatchString(name)
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -330,6 +330,23 @@ var _ = Describe("NodeClass Termination", func() {
 		Expect(awsEnv.IAMAPI.DeleteInstanceProfileBehavior.Calls()).To(BeZero())
 		Expect(awsEnv.IAMAPI.RemoveRoleFromInstanceProfileBehavior.Calls()).To(BeZero())
 	})
+	It("should skip legacy instance profile cleanup when the synthesized name is not IAM-valid", func() {
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{ClusterName: lo.ToPtr("aws:12345678910:eu-central-1:kubernetes")}))
+
+		nodeClass.Spec.Role = ""
+		nodeClass.Spec.InstanceProfile = lo.ToPtr("test-instance-profile")
+		controllerutil.AddFinalizer(nodeClass, v1.TerminationFinalizer)
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		Expect(env.Client.Delete(ctx, nodeClass)).To(Succeed())
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+		ExpectNotFound(ctx, env.Client, nodeClass)
+
+		Expect(awsEnv.IAMAPI.GetInstanceProfileBehavior.Calls()).To(BeZero())
+		Expect(awsEnv.IAMAPI.DeleteInstanceProfileBehavior.Calls()).To(BeZero())
+		Expect(awsEnv.IAMAPI.RemoveRoleFromInstanceProfileBehavior.Calls()).To(BeZero())
+	})
 	It("should skip instance profile cleanup in isolated VPCs", func() {
 		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{IsolatedVPC: lo.ToPtr(true)}))
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

When the `CLUSTER_NAME` passed to Karpenter is of a format e.g. like `aws:12345678910:eu-central-1:kubernetes`, deletion of EC2NodeClasses will fail with an error like this:

```
"error":              "deleting instance profile, getting instance profile, operation error IAM: GetInstanceProfile, https response error StatusCode: 400, RequestID: <id>, api error ValidationError: 1 validation error detected: Value at 'instanceProfileName' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w+=,.@-]+ (aws-error-code=ValidationError, aws-operation-name=GetInstanceProfile, aws-request-id=<id>, aws-service-name=IAM, aws-status-code=400) (instance-profile=aws:<account_id>:eu-central-1:kube-1_<num>) (instance-profile=aws:<account_id>:eu-central-1:kube-1_<num>)"
```

This happens because the clusterName is used in [this code path](https://github.com/aws/karpenter-provider-aws/blob/f14587dd1247011d970d9985dc72e51611fe7b57/pkg/controllers/nodeclass/controller.go#L206-L209), and the clusterName, in this case, is invalid as an instanceProfileName because it includes `:`.


The proposed fix is to ignore the legacy instance profile delete if the clusterName is not a valid instanceProfileName as it anyway would fail. That allows the deletion of the ec2nodeclass to continue anyway.


For context this is the:

<details>

<summary>Example EC2NodeClass</summary>

```yaml
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  annotations:
    karpenter.k8s.aws/ec2nodeclass-hash: "15568540281188650589"
    karpenter.k8s.aws/ec2nodeclass-hash-version: v4
  creationTimestamp: "2025-09-17T08:44:23Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2026-04-22T07:40:16Z"
  finalizers:
  - karpenter.k8s.aws/termination
  generation: 5
  name: default-karpenter-12xlarge
  uid: 00000000-0000-0000-0000-000000000000
spec:
  amiFamily: Custom
  amiSelectorTerms:
  - id: ami-00000000000000001
  - id: ami-00000000000000002
  associatePublicIPAddress: true
  blockDeviceMappings:
  - deviceName: /dev/sda1
    ebs:
      deleteOnTermination: true
      volumeSize: 100Gi
      volumeType: gp3
  detailedMonitoring: false
  instanceProfile: aws__ACCOUNT_ID__REGION__CLUSTER_NAME-WorkerKarpenter-InstanceProfile
  instanceStorePolicy: RAID0
  kubelet:
    clusterDNS:
    - 10.0.1.100
    cpuCFSQuota: false
    kubeReserved:
      cpu: 100m
      memory: 282Mi
    maxPods: 32
    systemReserved:
      cpu: 100m
      memory: 164Mi
  metadataOptions:
    httpEndpoint: enabled
    httpProtocolIPv6: disabled
    httpPutResponseHopLimit: 2
    httpTokens: optional
  securityGroupSelectorTerms:
  - tags:
      karpenter.sh/discovery: aws:ACCOUNT_ID:REGION:CLUSTER_NAME/WorkerNodeSecurityGroup
  subnetSelectorTerms:
  - tags:
      kubernetes.io/role/karpenter: enabled
  tags:
    InfrastructureComponent: "true"
    Name: default-karpenter-12xlarge (aws:ACCOUNT_ID:REGION:CLUSTER_NAME)
    application: kubernetes
    component: shared-resource
    environment: production
    node.kubernetes.io/node-pool: default-karpenter-12xlarge
    node.kubernetes.io/role: worker
    zalando.de/cluster-local-id/CLUSTER_NAME: owned
    zalando.org/pod-max-pids: "4096"
  userData: |
    #cloud-config
    mounts:
      - [ephemeral0]
      - [swap]

    write_files:
      - owner: root:root
        path: /etc/kubernetes/secrets.env
        content: |
          NODE_LABELS=node.kubernetes.io/profile=worker-karpenter,lifecycle-status=ready,node.kubernetes.io/distro=ubuntu
          NODEPOOL_NAME=default-karpenter-12xlarge
          KUBELET_ROLE=worker
          ON_DEMAND_WORKER_REPLACEMENT_STRATEGY=none

      - owner: root:root
        path: /etc/kuberuntu/s3-certs.env
        content: |
          S3_CERTS_BUCKET=s3://cluster-lifecycle-manager-ACCOUNT_ID-REGION/CLUSTER_NAME/worker/REDACTED_HASH.userdata
          AWS_DEFAULT_REGION=REGION

      - owner: root:root
        path: /etc/kubernetes/kubeconfig
        content: |
          apiVersion: v1
          kind: Config
          clusters:
          - name: local
            cluster:
              server: https://CLUSTER_NAME.example.com
          users:
          - name: kubelet
            user:
              exec:
                 apiVersion: client.authentication.k8s.io/v1beta1
                 command: aws
                 args:
                   - eks
                   - get-token
                   - --cluster-name
                   - "aws:ACCOUNT_ID:REGION:CLUSTER_NAME"
          contexts:
          - context:
              cluster: local
              user: kubelet
            name: kubelet-context
          current-context: kubelet-context

      - owner: root:root
        path: /etc/kubernetes/config/kubelet.yaml.template
        content: |
          # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
          apiVersion: kubelet.config.k8s.io/v1beta1
          kind: KubeletConfiguration
          containerLogMaxSize: "50Mi"
          containerLogMaxFiles: 2
          imageGCHighThresholdPercent: 50
          imageGCLowThresholdPercent: 40
          clusterDomain: cluster.local
          cpuCFSQuota: false
          featureGates:
          podPidsLimit: 4096
          cpuManagerPolicy: none
          maxPods: 32
          serializeImagePulls: false
          registryPullQPS: 20
          registryBurst: 40
          healthzPort: 10248
          healthzBindAddress: "0.0.0.0"
          tlsCertFile: "/etc/kubernetes/ssl/worker.pem"
          tlsPrivateKeyFile: "/etc/kubernetes/ssl/worker-key.pem"
          eventRecordQPS: 50
          eventBurst: 50
          kubeAPIQPS: 50
          kubeAPIBurst: 50
          systemReserved:
            cpu: "100m"
            memory: "164Mi"
          kubeReserved:
            cpu: "100m"
            memory: "282Mi"
          allowedUnsafeSysctls:
            - net.ipv4.tcp_keepalive_time
            - net.ipv4.tcp_keepalive_intvl
            - net.ipv4.tcp_keepalive_probes
            - net.ipv4.tcp_syn_retries
            - net.ipv4.tcp_retries2
          authentication:
            anonymous:
              enabled: false
            webhook:
              enabled: true
              cacheTTL: "2m"
            x509:
              clientCAFile: "/etc/kubernetes/ssl/ca.pem"
          authorization:
            mode: Webhook
            webhook:
              cacheAuthorizedTTL: "5m"
              cacheUnauthorizedTTL: "30s"
          protectKernelDefaults: true
          # variables are replaced on instance start-up.
          providerID: __PROVIDER_ID__
          clusterDNS: [__CLUSTER_DNS__]
          registerWithTaints:
            - key: karpenter.sh/unregistered
              effect: NoExecute
      - owner: root:root
        path: /etc/sysctl.d/03-vm-dirty-ratios.conf
        content: |
          vm.dirty_background_bytes = 67108864
          vm.dirty_bytes = 134217728
      - owner: root:root
        path: /etc/cni/net.d/10-flannel.conflist
        content: |
          {
            "name": "podnet",
            "cniVersion": "0.3.1",
            "plugins": [
              {
                "type": "flannel",
                "delegate": {
                  "isDefaultGateway": true,
                  "hairpinMode": true
                }
              }
            ]
          }
status:
  amis:
  - id: ami-00000000000000001
    name: ami-name
    requirements:
    - key: kubernetes.io/arch
      operator: In
      values:
      - amd64
  - id: ami-00000000000000002
    name: ami-name
    requirements:
    - key: kubernetes.io/arch
      operator: In
      values:
      - arm64
  conditions:
  - lastTransitionTime: "2025-09-17T08:44:24Z"
    message: ""
    observedGeneration: 4
    reason: AMIsReady
    status: "True"
    type: AMIsReady
  - lastTransitionTime: "2025-09-17T08:44:24Z"
    message: ""
    observedGeneration: 4
    reason: SubnetsReady
    status: "True"
    type: SubnetsReady
  - lastTransitionTime: "2025-09-17T08:44:24Z"
    message: ""
    observedGeneration: 4
    reason: SecurityGroupsReady
    status: "True"
    type: SecurityGroupsReady
  - lastTransitionTime: "2025-09-17T08:44:24Z"
    message: ""
    observedGeneration: 4
    reason: InstanceProfileReady
    status: "True"
    type: InstanceProfileReady
  - lastTransitionTime: "2025-09-17T08:44:24Z"
    message: ""
    observedGeneration: 4
    reason: ValidationSucceeded
    status: "True"
    type: ValidationSucceeded
  - lastTransitionTime: "2025-12-12T10:43:10Z"
    message: ""
    observedGeneration: 4
    reason: CapacityReservationsReady
    status: "True"
    type: CapacityReservationsReady
  - lastTransitionTime: "2026-04-08T11:48:18Z"
    message: ""
    observedGeneration: 4
    reason: Ready
    status: "True"
    type: Ready
  instanceProfile: aws__ACCOUNT_ID__REGION__CLUSTER_NAME-WorkerKarpenter-InstanceProfile
  securityGroups:
  - id: sg-00000001
    name: CLUSTER_NAME-WorkerSecurityGroup-REDACTED
  subnets:
  - id: subnet-00000001
    zone: REGION-a
    zoneID: REGION-az2
  - id: subnet-00000002
    zone: REGION-b
    zoneID: REGION-az3
  - id: subnet-00000003
    zone: REGION-c
    zoneID: REGION-az1
```
</details> 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.