### PR TITLE
docs: sync cloudformation reference with cloudformation.yaml

### DIFF
--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -530,7 +530,7 @@ ResourceDiscoveryPolicy:
 
 #### AllowRegionalReadActions
 
-The AllowRegionalReadActions Sid allows [DescribeCapacityReservations](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html), [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribePlacementGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePlacementGroups.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
+The AllowRegionalReadActions Sid allows [DescribeCapacityReservations](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html), [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceStatus](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribePlacementGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePlacementGroups.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
 This allows the Karpenter controller to do any of those read-only actions across all related resources for that AWS region.
 
 ```json
@@ -542,6 +542,7 @@ This allows the Karpenter controller to do any of those read-only actions across
     "ec2:DescribeCapacityReservations",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
+    "ec2:DescribeInstanceStatus",
     "ec2:DescribeInstanceTypeOfferings",
     "ec2:DescribeInstanceTypes",
     "ec2:DescribeLaunchTemplates",
@@ -608,19 +609,6 @@ The AllowInstanceProfileReadActions Sid gives the Karpenter controller permissio
   "Effect": "Allow",
   "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
-}
-```
-
-#### AllowUnscopedEC2DescribeInstanceStatus
-
-The AllowUnscopedEC2DescribeInstanceStatus Sid gives the Karpenter controller permission to perform [`ec2:DescribeInstanceStatus`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html) actions to detect EC2 instance status events for nodes managed by Karpenter, allowing the interruption controller to react to instance status failures.
-
-```json
-{
-  "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
-  "Effect": "Allow",
-  "Resource": "*",
-  "Action": "ec2:DescribeInstanceStatus"
 }
 ```
 

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -25,7 +25,7 @@ Following some header information, the rest of the `cloudformation.yaml` file de
 The sections of that file can be grouped together under the following general headings:
 
 * [**Node Authorization**]({{< relref "#node-authorization" >}}): Creates a NodeInstanceProfile, attaches a NodeRole to it, and connects it to an IAM Identity Mapping used to authorize nodes to the cluster. This defines the permissions each node managed by Karpenter has to access EC2 and other AWS resources. This doesn't actually create the IAM Identity Mapping. That part is orchestrated by `eksctl` in the Getting Started guide.
-* [**Controller Authorization**]({{< relref "#controller-authorization" >}}):  Creates 5 Karpenter controller policies that are attached to the service account's IAM role.
+* [**Controller Authorization**]({{< relref "#controller-authorization" >}}):  Creates 6 Karpenter controller policies that are attached to the service account's IAM role.
 Again, the actual service account creation (`karpenter`), that is combined with these policies, is orchestrated by `eksctl` in the Getting Started guide.
 * [**Interruption Handling**]({{< relref "#interruption-handling" >}}): Allows the Karpenter controller to see and respond to interruptions that occur with the nodes that Karpenter is managing. See the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page for details.
 
@@ -89,8 +89,8 @@ The controller permissions are split across 6 managed IAM policies:
 * [KarpenterControllerIAMIntegrationPolicy]({{< relref "#karpentercontrolleriamintegrationpolicy" >}}) - IAM instance profile management
 * [KarpenterControllerEKSIntegrationPolicy]({{< relref "#karpentercontrollereksintegrationpolicy" >}}) - EKS cluster discovery
 * [KarpenterControllerInterruptionPolicy]({{< relref "#karpentercontrollerinterruptionpolicy" >}}) - SQS interruption queue access
-* [KarpenterControllerResourceDiscoveryPolicy]({{< relref "#karpentercontrollerresourcediscoverypolicy" >}}) - Read-only resource discovery
 * [KarpenterControllerZonalShiftPolicy]({{< relref "#karpentercontrollerzonalshiftpolicy" >}}) - Zonal Shift status access
+* [KarpenterControllerResourceDiscoveryPolicy]({{< relref "#karpentercontrollerresourcediscoverypolicy" >}}) - Read-only resource discovery
 
 Someone wanting to add Karpenter to an existing cluster, instead of using `cloudformation.yaml`, would need to create these IAM policies directly and assign them to the role leveraged by the service account using IRSA or EKS Pod Identity.
 
@@ -126,7 +126,7 @@ For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read 
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:placement-group/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:placement-group/*"
   ],
   "Action": [
     "ec2:RunInstances",
@@ -186,7 +186,7 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
   ],
   "Condition": {
     "StringEquals": {
-      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
       "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
     },
     "StringLike": {
@@ -218,7 +218,7 @@ Conditions that must be met include that `aws:RequestTag/kubernetes.io/cluster/$
   "Condition": {
     "StringEquals": {
       "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
       "ec2:CreateAction": [
         "RunInstances",
         "CreateFleet",
@@ -608,6 +608,19 @@ The AllowInstanceProfileReadActions Sid gives the Karpenter controller permissio
   "Effect": "Allow",
   "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
+}
+```
+
+#### AllowUnscopedEC2DescribeInstanceStatus
+
+The AllowUnscopedEC2DescribeInstanceStatus Sid gives the Karpenter controller permission to perform [`ec2:DescribeInstanceStatus`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html) actions to detect EC2 instance status events for nodes managed by Karpenter, allowing the interruption controller to react to instance status failures.
+
+```json
+{
+  "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": "ec2:DescribeInstanceStatus"
 }
 ```
 

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -530,7 +530,7 @@ ResourceDiscoveryPolicy:
 
 #### AllowRegionalReadActions
 
-The AllowRegionalReadActions Sid allows [DescribeCapacityReservations](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html), [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribePlacementGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePlacementGroups.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
+The AllowRegionalReadActions Sid allows [DescribeCapacityReservations](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html), [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceStatus](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribePlacementGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePlacementGroups.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
 This allows the Karpenter controller to do any of those read-only actions across all related resources for that AWS region.
 
 ```json
@@ -542,6 +542,7 @@ This allows the Karpenter controller to do any of those read-only actions across
     "ec2:DescribeCapacityReservations",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
+    "ec2:DescribeInstanceStatus",
     "ec2:DescribeInstanceTypeOfferings",
     "ec2:DescribeInstanceTypes",
     "ec2:DescribeLaunchTemplates",
@@ -608,19 +609,6 @@ The AllowInstanceProfileReadActions Sid gives the Karpenter controller permissio
   "Effect": "Allow",
   "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
-}
-```
-
-#### AllowUnscopedEC2DescribeInstanceStatus
-
-The AllowUnscopedEC2DescribeInstanceStatus Sid gives the Karpenter controller permission to perform [`ec2:DescribeInstanceStatus`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html) actions to detect EC2 instance status events for nodes managed by Karpenter, allowing the interruption controller to react to instance status failures.
-
-```json
-{
-  "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
-  "Effect": "Allow",
-  "Resource": "*",
-  "Action": "ec2:DescribeInstanceStatus"
 }
 ```
 

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -25,7 +25,7 @@ Following some header information, the rest of the `cloudformation.yaml` file de
 The sections of that file can be grouped together under the following general headings:
 
 * [**Node Authorization**]({{< relref "#node-authorization" >}}): Creates a NodeInstanceProfile, attaches a NodeRole to it, and connects it to an IAM Identity Mapping used to authorize nodes to the cluster. This defines the permissions each node managed by Karpenter has to access EC2 and other AWS resources. This doesn't actually create the IAM Identity Mapping. That part is orchestrated by `eksctl` in the Getting Started guide.
-* [**Controller Authorization**]({{< relref "#controller-authorization" >}}):  Creates 5 Karpenter controller policies that are attached to the service account's IAM role.
+* [**Controller Authorization**]({{< relref "#controller-authorization" >}}):  Creates 6 Karpenter controller policies that are attached to the service account's IAM role.
 Again, the actual service account creation (`karpenter`), that is combined with these policies, is orchestrated by `eksctl` in the Getting Started guide.
 * [**Interruption Handling**]({{< relref "#interruption-handling" >}}): Allows the Karpenter controller to see and respond to interruptions that occur with the nodes that Karpenter is managing. See the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page for details.
 
@@ -89,8 +89,8 @@ The controller permissions are split across 6 managed IAM policies:
 * [KarpenterControllerIAMIntegrationPolicy]({{< relref "#karpentercontrolleriamintegrationpolicy" >}}) - IAM instance profile management
 * [KarpenterControllerEKSIntegrationPolicy]({{< relref "#karpentercontrollereksintegrationpolicy" >}}) - EKS cluster discovery
 * [KarpenterControllerInterruptionPolicy]({{< relref "#karpentercontrollerinterruptionpolicy" >}}) - SQS interruption queue access
-* [KarpenterControllerResourceDiscoveryPolicy]({{< relref "#karpentercontrollerresourcediscoverypolicy" >}}) - Read-only resource discovery
 * [KarpenterControllerZonalShiftPolicy]({{< relref "#karpentercontrollerzonalshiftpolicy" >}}) - Zonal Shift status access
+* [KarpenterControllerResourceDiscoveryPolicy]({{< relref "#karpentercontrollerresourcediscoverypolicy" >}}) - Read-only resource discovery
 
 Someone wanting to add Karpenter to an existing cluster, instead of using `cloudformation.yaml`, would need to create these IAM policies directly and assign them to the role leveraged by the service account using IRSA or EKS Pod Identity.
 
@@ -126,7 +126,7 @@ For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read 
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:placement-group/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:placement-group/*"
   ],
   "Action": [
     "ec2:RunInstances",
@@ -186,7 +186,7 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
   ],
   "Condition": {
     "StringEquals": {
-      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
       "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
     },
     "StringLike": {
@@ -218,7 +218,7 @@ Conditions that must be met include that `aws:RequestTag/kubernetes.io/cluster/$
   "Condition": {
     "StringEquals": {
       "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
       "ec2:CreateAction": [
         "RunInstances",
         "CreateFleet",
@@ -608,6 +608,19 @@ The AllowInstanceProfileReadActions Sid gives the Karpenter controller permissio
   "Effect": "Allow",
   "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
+}
+```
+
+#### AllowUnscopedEC2DescribeInstanceStatus
+
+The AllowUnscopedEC2DescribeInstanceStatus Sid gives the Karpenter controller permission to perform [`ec2:DescribeInstanceStatus`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html) actions to detect EC2 instance status events for nodes managed by Karpenter, allowing the interruption controller to react to instance status failures.
+
+```json
+{
+  "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": "ec2:DescribeInstanceStatus"
 }
 ```
 

--- a/website/content/en/v1.12/reference/cloudformation.md
+++ b/website/content/en/v1.12/reference/cloudformation.md
@@ -530,7 +530,7 @@ ResourceDiscoveryPolicy:
 
 #### AllowRegionalReadActions
 
-The AllowRegionalReadActions Sid allows [DescribeCapacityReservations](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html), [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribePlacementGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePlacementGroups.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
+The AllowRegionalReadActions Sid allows [DescribeCapacityReservations](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html), [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceStatus](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribePlacementGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePlacementGroups.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
 This allows the Karpenter controller to do any of those read-only actions across all related resources for that AWS region.
 
 ```json
@@ -542,6 +542,7 @@ This allows the Karpenter controller to do any of those read-only actions across
     "ec2:DescribeCapacityReservations",
     "ec2:DescribeImages",
     "ec2:DescribeInstances",
+    "ec2:DescribeInstanceStatus",
     "ec2:DescribeInstanceTypeOfferings",
     "ec2:DescribeInstanceTypes",
     "ec2:DescribeLaunchTemplates",
@@ -608,19 +609,6 @@ The AllowInstanceProfileReadActions Sid gives the Karpenter controller permissio
   "Effect": "Allow",
   "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
-}
-```
-
-#### AllowUnscopedEC2DescribeInstanceStatus
-
-The AllowUnscopedEC2DescribeInstanceStatus Sid gives the Karpenter controller permission to perform [`ec2:DescribeInstanceStatus`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html) actions to detect EC2 instance status events for nodes managed by Karpenter, allowing the interruption controller to react to instance status failures.
-
-```json
-{
-  "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
-  "Effect": "Allow",
-  "Resource": "*",
-  "Action": "ec2:DescribeInstanceStatus"
 }
 ```
 

--- a/website/content/en/v1.12/reference/cloudformation.md
+++ b/website/content/en/v1.12/reference/cloudformation.md
@@ -25,7 +25,7 @@ Following some header information, the rest of the `cloudformation.yaml` file de
 The sections of that file can be grouped together under the following general headings:
 
 * [**Node Authorization**]({{< relref "#node-authorization" >}}): Creates a NodeInstanceProfile, attaches a NodeRole to it, and connects it to an IAM Identity Mapping used to authorize nodes to the cluster. This defines the permissions each node managed by Karpenter has to access EC2 and other AWS resources. This doesn't actually create the IAM Identity Mapping. That part is orchestrated by `eksctl` in the Getting Started guide.
-* [**Controller Authorization**]({{< relref "#controller-authorization" >}}):  Creates 5 Karpenter controller policies that are attached to the service account's IAM role.
+* [**Controller Authorization**]({{< relref "#controller-authorization" >}}):  Creates 6 Karpenter controller policies that are attached to the service account's IAM role.
 Again, the actual service account creation (`karpenter`), that is combined with these policies, is orchestrated by `eksctl` in the Getting Started guide.
 * [**Interruption Handling**]({{< relref "#interruption-handling" >}}): Allows the Karpenter controller to see and respond to interruptions that occur with the nodes that Karpenter is managing. See the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page for details.
 
@@ -89,8 +89,8 @@ The controller permissions are split across 6 managed IAM policies:
 * [KarpenterControllerIAMIntegrationPolicy]({{< relref "#karpentercontrolleriamintegrationpolicy" >}}) - IAM instance profile management
 * [KarpenterControllerEKSIntegrationPolicy]({{< relref "#karpentercontrollereksintegrationpolicy" >}}) - EKS cluster discovery
 * [KarpenterControllerInterruptionPolicy]({{< relref "#karpentercontrollerinterruptionpolicy" >}}) - SQS interruption queue access
-* [KarpenterControllerResourceDiscoveryPolicy]({{< relref "#karpentercontrollerresourcediscoverypolicy" >}}) - Read-only resource discovery
 * [KarpenterControllerZonalShiftPolicy]({{< relref "#karpentercontrollerzonalshiftpolicy" >}}) - Zonal Shift status access
+* [KarpenterControllerResourceDiscoveryPolicy]({{< relref "#karpentercontrollerresourcediscoverypolicy" >}}) - Read-only resource discovery
 
 Someone wanting to add Karpenter to an existing cluster, instead of using `cloudformation.yaml`, would need to create these IAM policies directly and assign them to the role leveraged by the service account using IRSA or EKS Pod Identity.
 
@@ -126,7 +126,7 @@ For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read 
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*",
-    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:placement-group/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:placement-group/*"
   ],
   "Action": [
     "ec2:RunInstances",
@@ -186,7 +186,7 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
   ],
   "Condition": {
     "StringEquals": {
-      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
       "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
     },
     "StringLike": {
@@ -218,7 +218,7 @@ Conditions that must be met include that `aws:RequestTag/kubernetes.io/cluster/$
   "Condition": {
     "StringEquals": {
       "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
       "ec2:CreateAction": [
         "RunInstances",
         "CreateFleet",
@@ -608,6 +608,19 @@ The AllowInstanceProfileReadActions Sid gives the Karpenter controller permissio
   "Effect": "Allow",
   "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
   "Action": "iam:GetInstanceProfile"
+}
+```
+
+#### AllowUnscopedEC2DescribeInstanceStatus
+
+The AllowUnscopedEC2DescribeInstanceStatus Sid gives the Karpenter controller permission to perform [`ec2:DescribeInstanceStatus`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html) actions to detect EC2 instance status events for nodes managed by Karpenter, allowing the interruption controller to react to instance status failures.
+
+```json
+{
+  "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": "ec2:DescribeInstanceStatus"
 }
 ```
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #9064

**Description**

The CloudFormation reference markdown drifted from the YAML template. Most notably, PR #9064 added the `ec2:DescribeInstanceStatus` permission to the YAML for the new instance-status interruption controller, but the corresponding documentation was not updated. This change syncs the two:

- Document the `AllowUnscopedEC2DescribeInstanceStatus` statement under `KarpenterControllerResourceDiscoveryPolicy`.
- Update the controller-policy count from 5 to 6 (the section already lists six policies further down — the count had been stale since the Zonal Shift policy was added).
- Reorder the policy bullet list so it matches the order of the sections in the document and the YAML (ZonalShift before ResourceDiscovery).
- Fix three JSON syntax errors in the inline policy snippets so readers can copy/paste them directly: a stray trailing comma in `AllowScopedEC2InstanceAccessActions` and missing commas in `AllowScopedEC2InstanceActionsWithTags` and `AllowScopedResourceCreationTagging`.

**How was this change tested?**

N/A

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.