### PR TITLE
chore: Add filters to describeinstancestatus calls

### DIFF
--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -109,7 +109,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 			return
 		}
 		ReceivedMessages.Inc(map[string]string{messageTypeLabel: string(msg.Kind())})
-		if e = c.handleMessage(ctx, msg); e != nil {
+		if _, e = c.handleMessage(ctx, msg, false); e != nil {
 			errs[i] = fmt.Errorf("handling message, %w", e)
 			return
 		}

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -39,6 +39,10 @@ import (
 var (
 	// InstanceStatusInterval is the polling interval for the EC2 DescribeInstanceStatus API.
 	InstanceStatusInterval = 1 * time.Minute
+	// InstanceStatusDryRun controls whether the instance status controller takes action on
+	// unhealthy instances. When true, the controller only emits metrics without cordoning
+	// and draining affected nodes. Default is false (full remediation enabled).
+	InstanceStatusDryRun = false
 )
 
 // InstanceStatusController polls EC2 DescribeInstanceStatus to detect unhealthy instances
@@ -84,6 +88,9 @@ func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Re
 		}
 		for cat := range categories {
 			InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
+		}
+		if InstanceStatusDryRun {
+			return
 		}
 		if err := c.handleMessage(ctx, instancestatusfailure.Message(instanceStatuses[i])); err != nil {
 			errs[i] = fmt.Errorf("handling instance status check message, %w", err)

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -82,18 +82,20 @@ func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Re
 
 	errs := make([]error, len(instanceStatuses))
 	workqueue.ParallelizeUntil(ctx, 10, len(instanceStatuses), func(i int) {
+		msg := instancestatusfailure.Message(instanceStatuses[i])
+		found, err := c.handleMessage(ctx, msg, InstanceStatusDryRun)
+		if err != nil {
+			errs[i] = fmt.Errorf("handling instance status check message, %w", err)
+		}
+		if !found {
+			return
+		}
 		categories := map[string]bool{}
 		for _, d := range instanceStatuses[i].Details {
 			categories[string(d.Category)] = true
 		}
 		for cat := range categories {
 			InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
-		}
-		if InstanceStatusDryRun {
-			return
-		}
-		if err := c.handleMessage(ctx, instancestatusfailure.Message(instanceStatuses[i])); err != nil {
-			errs[i] = fmt.Errorf("handling instance status check message, %w", err)
 		}
 	})
 	if err = multierr.Combine(errs...); err != nil {

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -383,6 +383,37 @@ var _ = Describe("InterruptionHandling", func() {
 			})
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 		})
+		It("should NOT delete the NodeClaim when dry run is enabled but should still emit the metric", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
+			interruption.InstanceStatusDryRun = true
+			DeferCleanup(func() {
+				interruption.InstanceStatusDryRun = false
+			})
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+					},
+				},
+			})
+			awsEnv.Clock.Step(time.Hour)
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 1, map[string]string{
+				"category": "InstanceStatus",
+			})
+			ExpectExists(ctx, env.Client, nodeClaim)
+		})
 	})
 })
 

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -383,30 +383,6 @@ var _ = Describe("InterruptionHandling", func() {
 			})
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 		})
-		It("should NOT delete the NodeClaim when an instance is unhealthy due to EBS Status only", func() {
-			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
-			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
-				InstanceStatuses: []ec2types.InstanceStatus{
-					{
-						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
-						AttachedEbsStatus: &ec2types.EbsStatusSummary{
-							Status: ec2types.SummaryStatusImpaired,
-							Details: []ec2types.EbsStatusDetails{
-								{
-									Status:        ec2types.StatusTypeFailed,
-									Name:          ec2types.StatusNameReachability,
-									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
-								},
-							},
-						},
-					},
-				},
-			})
-			awsEnv.Clock.Step(time.Hour)
-			ExpectApplied(ctx, env.Client, nodeClaim, node)
-			ExpectSingletonReconciled(ctx, instanceStatusController)
-			ExpectExists(ctx, env.Client, nodeClaim)
-		})
 	})
 })
 

--- a/pkg/controllers/interruption/utils.go
+++ b/pkg/controllers/interruption/utils.go
@@ -53,12 +53,14 @@ type InterruptionHandler struct {
 	capacityReservationProvider capacityreservation.Provider
 }
 
-// handleMessage takes an action against every node involved in the message that is owned by a NodePool
-func (h *InterruptionHandler) handleMessage(ctx context.Context, msg messages.Message) (err error) {
+// handleMessage takes an action against every node involved in the message that is owned by a NodePool.
+// When dryRun is true, it resolves NodeClaims but skips the actual cordon/drain action.
+// Returns true if at least one matching NodeClaim was found in the cluster.
+func (h *InterruptionHandler) handleMessage(ctx context.Context, msg messages.Message, dryRun bool) (found bool, err error) {
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("messageKind", msg.Kind()))
 
 	if msg.Kind() == messages.NoOpKind {
-		return nil
+		return false, nil
 	}
 	for _, instanceID := range msg.EC2InstanceIDs() {
 		nodeClaimList := &karpv1.NodeClaimList{}
@@ -67,6 +69,10 @@ func (h *InterruptionHandler) handleMessage(ctx context.Context, msg messages.Me
 			continue
 		}
 		if len(nodeClaimList.Items) == 0 {
+			continue
+		}
+		found = true
+		if dryRun {
 			continue
 		}
 		for _, nodeClaim := range nodeClaimList.Items {
@@ -85,9 +91,9 @@ func (h *InterruptionHandler) handleMessage(ctx context.Context, msg messages.Me
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("acting on NodeClaims, %w", err)
+		return found, fmt.Errorf("acting on NodeClaims, %w", err)
 	}
-	return nil
+	return found, nil
 }
 
 // handleNodeClaim retrieves the action for the message and then performs the appropriate action against the node

--- a/pkg/providers/instancestatus/instancestatus.go
+++ b/pkg/providers/instancestatus/instancestatus.go
@@ -82,10 +82,14 @@ func (p DefaultProvider) List(ctx context.Context) ([]HealthStatus, error) {
 	// and scheduled maintenance events.
 	// EBS status check failures are ignored for now.
 	filterSets := [][]ec2types.Filter{
-		{{Name: lo.ToPtr("instance-status.reachability"), Values: []string{"failed"}}},
-		{{Name: lo.ToPtr("system-status.reachability"), Values: []string{"failed"}}},
+		{{Name: lo.ToPtr("instance-status.status"), Values: []string{string(ec2types.SummaryStatusImpaired)}}},
+		{{Name: lo.ToPtr("system-status.status"), Values: []string{string(ec2types.SummaryStatusImpaired)}}},
 		{{Name: lo.ToPtr("event.code"), Values: []string{
-			"instance-reboot", "system-reboot", "system-maintenance", "instance-retirement", "instance-stop",
+			string(ec2types.EventCodeInstanceReboot),
+			string(ec2types.EventCodeSystemReboot),
+			string(ec2types.EventCodeSystemMaintenance),
+			string(ec2types.EventCodeInstanceRetirement),
+			string(ec2types.EventCodeInstanceStop),
 		}}},
 	}
 

--- a/pkg/providers/instancestatus/instancestatus.go
+++ b/pkg/providers/instancestatus/instancestatus.go
@@ -76,15 +76,37 @@ func NewDefaultProvider(ec2API sdk.EC2API, clk clock.Clock) *DefaultProvider {
 }
 
 func (p DefaultProvider) List(ctx context.Context) ([]HealthStatus, error) {
-	var statuses []ec2types.InstanceStatus
-	pager := ec2.NewDescribeInstanceStatusPaginator(p.ec2api, &ec2.DescribeInstanceStatusInput{})
+	// Use server-side filters to avoid paging through all running instances in the account.
+	// We make three separate calls because DescribeInstanceStatus ANDs filters across different
+	// filter names, and we need to OR across instance status failures, system status failures,
+	// and scheduled maintenance events.
+	// EBS status check failures are ignored for now.
+	filterSets := [][]ec2types.Filter{
+		{{Name: lo.ToPtr("instance-status.reachability"), Values: []string{"failed"}}},
+		{{Name: lo.ToPtr("system-status.reachability"), Values: []string{"failed"}}},
+		{{Name: lo.ToPtr("event.code"), Values: []string{
+			"instance-reboot", "system-reboot", "system-maintenance", "instance-retirement", "instance-stop",
+		}}},
+	}
 
-	for pager.HasMorePages() {
-		out, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed describing ec2 instance status checks, %w", err)
+	seen := map[string]struct{}{}
+	var statuses []ec2types.InstanceStatus
+	for _, filters := range filterSets {
+		pager := ec2.NewDescribeInstanceStatusPaginator(p.ec2api, &ec2.DescribeInstanceStatusInput{
+			Filters: filters,
+		})
+		for pager.HasMorePages() {
+			out, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed describing ec2 instance status checks, %w", err)
+			}
+			for _, s := range out.InstanceStatuses {
+				if _, ok := seen[*s.InstanceId]; !ok {
+					seen[*s.InstanceId] = struct{}{}
+					statuses = append(statuses, s)
+				}
+			}
 		}
-		statuses = append(statuses, out.InstanceStatuses...)
 	}
 
 	var healthStatuses []HealthStatus
@@ -93,10 +115,6 @@ func (p DefaultProvider) List(ctx context.Context) ([]HealthStatus, error) {
 		// Filter out statuses that we do not consider unhealthy or do not want to handle right now
 		healthStatus.Details = lo.Filter(healthStatus.Details, func(details Details, _ int) bool {
 			if details.Status != ec2types.StatusTypeFailed {
-				return false
-			}
-			// ignore EBS health checks for now
-			if details.Category == EBSStatus {
 				return false
 			}
 			// Do not evaluate against the unhealthy threshold when its a scheduled maintenance event.

--- a/pkg/providers/instancestatus/instancestatus.go
+++ b/pkg/providers/instancestatus/instancestatus.go
@@ -43,6 +43,23 @@ const (
 
 var (
 	UnhealthyThreshold = 120 * time.Second
+
+	// instanceStatusFilters are the server-side filters used to scope DescribeInstanceStatus calls.
+	// We use separate filter sets because DescribeInstanceStatus ANDs filters across different
+	// filter names, and we need to OR across instance status failures, system status failures,
+	// and scheduled maintenance events.
+	// EBS status check failures are ignored for now.
+	instanceStatusFilters = [][]ec2types.Filter{
+		{{Name: lo.ToPtr("instance-status.status"), Values: []string{string(ec2types.SummaryStatusImpaired)}}},
+		{{Name: lo.ToPtr("system-status.status"), Values: []string{string(ec2types.SummaryStatusImpaired)}}},
+		{{Name: lo.ToPtr("event.code"), Values: []string{
+			string(ec2types.EventCodeInstanceReboot),
+			string(ec2types.EventCodeSystemReboot),
+			string(ec2types.EventCodeSystemMaintenance),
+			string(ec2types.EventCodeInstanceRetirement),
+			string(ec2types.EventCodeInstanceStop),
+		}}},
+	}
 )
 
 type Provider interface {
@@ -76,26 +93,9 @@ func NewDefaultProvider(ec2API sdk.EC2API, clk clock.Clock) *DefaultProvider {
 }
 
 func (p DefaultProvider) List(ctx context.Context) ([]HealthStatus, error) {
-	// Use server-side filters to avoid paging through all running instances in the account.
-	// We make three separate calls because DescribeInstanceStatus ANDs filters across different
-	// filter names, and we need to OR across instance status failures, system status failures,
-	// and scheduled maintenance events.
-	// EBS status check failures are ignored for now.
-	filterSets := [][]ec2types.Filter{
-		{{Name: lo.ToPtr("instance-status.status"), Values: []string{string(ec2types.SummaryStatusImpaired)}}},
-		{{Name: lo.ToPtr("system-status.status"), Values: []string{string(ec2types.SummaryStatusImpaired)}}},
-		{{Name: lo.ToPtr("event.code"), Values: []string{
-			string(ec2types.EventCodeInstanceReboot),
-			string(ec2types.EventCodeSystemReboot),
-			string(ec2types.EventCodeSystemMaintenance),
-			string(ec2types.EventCodeInstanceRetirement),
-			string(ec2types.EventCodeInstanceStop),
-		}}},
-	}
-
 	seen := map[string]struct{}{}
 	var statuses []ec2types.InstanceStatus
-	for _, filters := range filterSets {
+	for _, filters := range instanceStatusFilters {
 		pager := ec2.NewDescribeInstanceStatusPaginator(p.ec2api, &ec2.DescribeInstanceStatusInput{
 			Filters: filters,
 		})

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -332,6 +332,7 @@ Resources:
                 "ec2:DescribeCapacityReservations",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
                 "ec2:DescribeInstanceTypeOfferings",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeLaunchTemplates",
@@ -369,12 +370,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
-            },
-            {
-              "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": "ec2:DescribeInstanceStatus"
             }
           ]
         }

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -332,6 +332,7 @@ Resources:
                 "ec2:DescribeCapacityReservations",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
                 "ec2:DescribeInstanceTypeOfferings",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeLaunchTemplates",
@@ -369,12 +370,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
-            },
-            {
-              "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": "ec2:DescribeInstanceStatus"
             }
           ]
         }

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -332,6 +332,7 @@ Resources:
                 "ec2:DescribeCapacityReservations",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
                 "ec2:DescribeInstanceTypeOfferings",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeLaunchTemplates",
@@ -369,12 +370,6 @@ Resources:
               "Effect": "Allow",
               "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
               "Action": "iam:GetInstanceProfile"
-            },
-            {
-              "Sid": "AllowUnscopedEC2DescribeInstanceStatus",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": "ec2:DescribeInstanceStatus"
             }
           ]
         }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds filters to the instancestatus provider's DescribeInstanceStatus calls to get only the instances we care about.

**How was this change tested?**
[E2E run](https://github.com/aws/karpenter-provider-aws/actions/runs/25021481324/job/73282750391), manually tested same as in #9064


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.