### PR TITLE
feat: enrich NodeClass validation condition message with specific denial reason

### DIFF
--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -64,6 +64,13 @@ var ValidationConditionMessages = map[string]string{
 	ConditionReasonRunInstancesAuthFailed:         "Controller isn't authorized to call ec2:RunInstances",
 }
 
+// validationCacheEntry stores a failed validation result with both the condition reason and the
+// enriched message derived from the AWS error, so cached results can reproduce the same condition.
+type validationCacheEntry struct {
+	reason  string
+	message string
+}
+
 type Validation struct {
 	kubeClient             client.Client
 	cloudProvider          cloudprovider.CloudProvider
@@ -155,13 +162,14 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 
 	if val, ok := v.cache.Get(v.cacheKey(nodeClass, tags)); ok {
 		// We still update the status condition even if it's cached since we may have had a conflict error previously
-		if val == "" {
+		entry := val.(validationCacheEntry)
+		if entry.reason == "" {
 			nodeClass.StatusConditions().SetTrue(v1.ConditionTypeValidationSucceeded)
 		} else {
 			nodeClass.StatusConditions().SetFalse(
 				v1.ConditionTypeValidationSucceeded,
-				val.(string),
-				ValidationConditionMessages[val.(string)],
+				entry.reason,
+				entry.message,
 			)
 		}
 		return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
@@ -169,7 +177,7 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 
 	if v.dryRunDisabled {
 		nodeClass.StatusConditions().SetTrue(v1.ConditionTypeValidationSucceeded)
-		v.cache.SetDefault(v.cacheKey(nodeClass, tags), "")
+		v.cache.SetDefault(v.cacheKey(nodeClass, tags), validationCacheEntry{})
 		return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}
 
@@ -188,17 +196,21 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 		return result, err
 	}
 
-	v.cache.SetDefault(v.cacheKey(nodeClass, tags), "")
+	v.cache.SetDefault(v.cacheKey(nodeClass, tags), validationCacheEntry{})
 	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeValidationSucceeded)
 	return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 }
 
-func (v *Validation) updateCacheOnFailure(nodeClass *v1.EC2NodeClass, tags map[string]string, failureReason string) {
-	v.cache.SetDefault(v.cacheKey(nodeClass, tags), failureReason)
+func (v *Validation) updateCacheOnFailure(nodeClass *v1.EC2NodeClass, tags map[string]string, failureReason string, reasonMessage string) {
+	message := fmt.Sprintf("%s: %s", ValidationConditionMessages[failureReason], reasonMessage)
+	v.cache.SetDefault(v.cacheKey(nodeClass, tags), validationCacheEntry{
+		reason:  failureReason,
+		message: message,
+	})
 	nodeClass.StatusConditions().SetFalse(
 		v1.ConditionTypeValidationSucceeded,
 		failureReason,
-		ValidationConditionMessages[failureReason],
+		message,
 	)
 }
 
@@ -229,7 +241,8 @@ func (v *Validation) validateCreateLaunchTemplateAuthorization(
 			return nil, reconcile.Result{}, fmt.Errorf("validating ec2:CreateLaunchTemplate authorization, %w", err)
 		}
 		log.FromContext(ctx).Error(err, "unauthorized to call ec2:CreateLaunchTemplate")
-		v.updateCacheOnFailure(nodeClass, tags, ConditionReasonCreateLaunchTemplateAuthFailed)
+		_, reasonMessage := awserrors.ToReasonMessage(err)
+		v.updateCacheOnFailure(nodeClass, tags, ConditionReasonCreateLaunchTemplateAuthFailed, reasonMessage)
 		return nil, reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}
 	// this case should never occur as we ensure instance types are compatible with AMI
@@ -261,7 +274,8 @@ func (v *Validation) validateCreateFleetAuthorization(
 			return reconcile.Result{}, fmt.Errorf("validating ec2:CreateFleet authorization, %w", err)
 		}
 		log.FromContext(ctx).Error(err, "unauthorized to call ec2:CreateFleet")
-		v.updateCacheOnFailure(nodeClass, tags, ConditionReasonCreateFleetAuthFailed)
+		_, reasonMessage := awserrors.ToReasonMessage(err)
+		v.updateCacheOnFailure(nodeClass, tags, ConditionReasonCreateFleetAuthFailed, reasonMessage)
 		return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}
 	return reconcile.Result{}, nil
@@ -303,7 +317,8 @@ func (v *Validation) validateRunInstancesAuthorization(
 		return reconcile.Result{}, fmt.Errorf("validating ec2:RunInstances authorization, %w", firstSubnetErr)
 	}
 	log.FromContext(ctx).Error(firstSubnetErr, "unauthorized to call ec2:RunInstances")
-	v.updateCacheOnFailure(nodeClass, tags, ConditionReasonRunInstancesAuthFailed)
+	_, reasonMessage := awserrors.ToReasonMessage(firstSubnetErr)
+	v.updateCacheOnFailure(nodeClass, tags, ConditionReasonRunInstancesAuthFailed, reasonMessage)
 	return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 }
 

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -234,13 +234,14 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 	Context("Authorization Validation", func() {
 		DescribeTable(
 			"NodeClass validation failure conditions",
-			func(setupFn func(), reason string) {
+			func(setupFn func(), reason string, expectedMessage string) {
 				ExpectApplied(ctx, env.Client, nodeClass)
 				setupFn()
 				ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 				nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
 				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(reason))
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Message).To(Equal(expectedMessage))
 				Expect(awsEnv.ValidationCache.Items()).To(HaveLen(1))
 
 				// Even though we would succeed on the subsequent call, we should fail here because we hit the cache
@@ -248,6 +249,7 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 				nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
 				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(reason))
+				Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Message).To(Equal(expectedMessage))
 
 				// After flushing the cache, we should succeed
 				awsEnv.ValidationCache.Flush()
@@ -259,17 +261,34 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 				awsEnv.EC2API.CreateFleetBehavior.Error.Set(&smithy.GenericAPIError{
 					Code: "UnauthorizedOperation",
 				}, fake.MaxCalls(1))
-			}, nodeclass.ConditionReasonCreateFleetAuthFailed),
+			}, nodeclass.ConditionReasonCreateFleetAuthFailed,
+				"Controller isn't authorized to call ec2:CreateFleet: User is not authorized to perform this operation because no identity-based policy allows it"),
 			Entry("should update status condition as NotReady when RunInstances unauthorized", func() {
 				awsEnv.EC2API.RunInstancesBehavior.Error.Set(&smithy.GenericAPIError{
 					Code: "UnauthorizedOperation",
 				}, fake.MaxCalls(4))
-			}, nodeclass.ConditionReasonRunInstancesAuthFailed),
+			}, nodeclass.ConditionReasonRunInstancesAuthFailed,
+				"Controller isn't authorized to call ec2:RunInstances: User is not authorized to perform this operation because no identity-based policy allows it"),
 			Entry("should update status condition as NotReady when CreateLaunchTemplate unauthorized", func() {
 				awsEnv.EC2API.CreateLaunchTemplateBehavior.Error.Set(&smithy.GenericAPIError{
 					Code: "UnauthorizedOperation",
 				}, fake.MaxCalls(1))
-			}, nodeclass.ConditionReasonCreateLaunchTemplateAuthFailed),
+			}, nodeclass.ConditionReasonCreateLaunchTemplateAuthFailed,
+				"Controller isn't authorized to call ec2:CreateLaunchTemplate: User is not authorized to perform this operation because no identity-based policy allows it"),
+			Entry("should include permission boundary detail in condition message when denied by permission boundary", func() {
+				awsEnv.EC2API.CreateFleetBehavior.Error.Set(&smithy.GenericAPIError{
+					Code:    "UnauthorizedOperation",
+					Message: "You are not authorized to perform this operation with an explicit deny in a permissions boundary",
+				}, fake.MaxCalls(1))
+			}, nodeclass.ConditionReasonCreateFleetAuthFailed,
+				"Controller isn't authorized to call ec2:CreateFleet: User is not authorized to perform this operation due to a permission boundary"),
+			Entry("should include SCP detail in condition message when denied by service control policy", func() {
+				awsEnv.EC2API.RunInstancesBehavior.Error.Set(&smithy.GenericAPIError{
+					Code:    "UnauthorizedOperation",
+					Message: "You are not authorized to perform this operation with an explicit deny in a service control policy",
+				}, fake.MaxCalls(4))
+			}, nodeclass.ConditionReasonRunInstancesAuthFailed,
+				"Controller isn't authorized to call ec2:RunInstances: User is not authorized to perform this operation due to a service control policy"),
 		)
 		It("should succeed RunInstances validation when first subnet returns 500 but another subnet succeeds", func() {
 			// Fail the first RunInstances call (first subnet) with a server error,


### PR DESCRIPTION




<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Use ToReasonMessage() to extract specific authorization failure details (permission boundary, SCP, identity-based policy) from AWS errors and include them in the ValidationSucceeded condition message on EC2NodeClass, improving observability for DryRun RunInstances/CreateFleet/CreateLaunchTemplate authorization failures.

**How was this change tested?**

unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.