### PR TITLE
docs: support opmetrics/pmetrics metric constructors in metrics doc generator

### DIFF
--- a/hack/docs/metrics_gen/main.go
+++ b/hack/docs/metrics_gen/main.go
@@ -45,10 +45,18 @@ var (
 	stableMetrics = []string{"controller_runtime", "aws_sdk_go", "client_go", "leader_election", "interruption", "cluster_state", "workqueue", "karpenter_build_info", "karpenter_nodepool_usage", "karpenter_nodepool_limit",
 		"karpenter_nodeclaims_terminated_total", "karpenter_nodeclaims_created_total", "karpenter_nodes_terminated_total", "karpenter_nodes_created_total", "karpenter_pods_startup_duration_seconds",
 		"karpenter_scheduler_scheduling_duration_seconds", "karpenter_provisioner_scheduling_duration_seconds", "karpenter_nodepool_allowed_disruptions", "karpenter_voluntary_disruption_decisions_total"}
-	betaMetrics = []string{"status_condition", "cloudprovider", "cloudprovider_batcher", "karpenter_nodeclaims_termination_duration_seconds", "karpenter_nodeclaims_instance_termination_duration_seconds",
+	betaMetrics = []string{"cloudprovider", "cloudprovider_batcher", "karpenter_nodeclaims_termination_duration_seconds", "karpenter_nodeclaims_instance_termination_duration_seconds",
 		"karpenter_nodes_total_pod_requests", "karpenter_nodes_total_pod_limits", "karpenter_nodes_total_daemon_requests", "karpenter_nodes_total_daemon_limits", "karpenter_nodes_termination_duration_seconds",
 		"karpenter_nodes_system_overhead", "karpenter_nodes_allocatable", "karpenter_pods_state", "karpenter_scheduler_queue_depth", "karpenter_voluntary_disruption_queue_failures_total",
-		"karpenter_voluntary_disruption_decision_evaluation_duration_seconds", "karpenter_voluntary_disruption_eligible_nodes", "karpenter_voluntary_disruption_consolidation_timeouts_total"}
+		"karpenter_voluntary_disruption_decision_evaluation_duration_seconds", "karpenter_voluntary_disruption_eligible_nodes", "karpenter_voluntary_disruption_consolidation_timeouts_total",
+		// Per-object status condition and termination metrics from operatorpkg
+		"nodeclaim_status_condition", "nodeclaim_termination",
+		"node_status_condition", "node_termination",
+		"nodepool_status_condition", "nodepool_termination",
+		"ec2nodeclass_status_condition", "ec2nodeclass_termination"}
+	// Deprecated generic status condition and termination metrics (without object name prefix).
+	// These are still emitted at runtime but are superseded by per-object variants.
+	deprecatedMetrics = []string{"status_condition", "termination"}
 )
 
 func (i metricInfo) qualifiedName() string {
@@ -68,6 +76,12 @@ func main() {
 		packages := getPackages(flag.Arg(i))
 		allMetrics = append(allMetrics, getMetricsFromPackages(packages...)...)
 	}
+
+	// The operatorpkg status and events controllers dynamically create per-object metrics
+	// at runtime based on the Go type parameter passed to status.NewController[T]().
+	// These cannot be extracted via AST parsing, so we generate them from a known list of
+	// object types that have status controllers registered.
+	allMetrics = append(allMetrics, perObjectStatusMetrics()...)
 
 	// Dedupe metrics
 	allMetrics = lo.UniqBy(allMetrics, func(m metricInfo) string {
@@ -92,6 +106,15 @@ func main() {
 		}
 	}
 	sort.Slice(allMetrics, bySubsystem(allMetrics))
+
+	// Sanity check: fail loudly if the metric count drops below expected.
+	// This catches silent regressions where new identifier mappings are needed
+	// or metric declaration patterns change. Update this threshold when metrics
+	// are intentionally removed.
+	const minExpectedMetrics = 100
+	if len(allMetrics) < minExpectedMetrics {
+		log.Fatalf("expected at least %d metrics but only found %d; the generator may be silently dropping metrics due to unrecognized identifiers or new declaration patterns", minExpectedMetrics, len(allMetrics))
+	}
 
 	outputFileName := flag.Arg(flag.NArg() - 1)
 	f, err := os.Create(outputFileName)
@@ -132,6 +155,8 @@ description: >
 		fmt.Fprintf(f, "### `%s`\n", metric.qualifiedName())
 		fmt.Fprintf(f, "%s\n", metric.help)
 		switch {
+		case slices.Contains(deprecatedMetrics, metric.subsystem) || slices.Contains(deprecatedMetrics, metric.qualifiedName()):
+			fmt.Fprintf(f, "- Stability Level: %s\n", "DEPRECATED")
 		case slices.Contains(stableMetrics, metric.subsystem) || slices.Contains(stableMetrics, metric.qualifiedName()):
 			fmt.Fprintf(f, "- Stability Level: %s\n", "STABLE")
 		case slices.Contains(betaMetrics, metric.subsystem) || slices.Contains(betaMetrics, metric.qualifiedName()):
@@ -159,7 +184,7 @@ func getPackages(root string) []*ast.Package {
 		}
 		// parse the packagers that we find
 		pkgs, err := parser.ParseDir(fset, path, func(info fs.FileInfo) bool {
-			return true
+			return !strings.HasSuffix(info.Name(), "_test.go")
 		}, parser.AllErrors)
 		if err != nil {
 			log.Fatalf("error parsing, %s", err)
@@ -176,22 +201,19 @@ func getPackages(root string) []*ast.Package {
 }
 
 func getMetricsFromPackages(packages ...*ast.Package) []metricInfo {
-	// metrics are all package global variables
 	var allMetrics []metricInfo
 	for _, pkg := range packages {
 		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				switch v := decl.(type) {
-				case *ast.FuncDecl:
-				// ignore
-				case *ast.GenDecl:
-					if v.Tok == token.VAR {
-						allMetrics = append(allMetrics, handleVariableDeclaration(v)...)
-					}
-				default:
-
+			ast.Inspect(file, func(n ast.Node) bool {
+				ce, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
 				}
-			}
+				if m, ok := metricFromCallExpr(ce); ok {
+					allMetrics = append(allMetrics, m)
+				}
+				return true
+			})
 		}
 	}
 	return allMetrics
@@ -201,16 +223,25 @@ func bySubsystem(metrics []metricInfo) func(i int, j int) bool {
 	// Higher ordering comes first. If a value isn't designated here then the subsystem will be given a default of 0.
 	// Metrics without a subsystem come first since there is no designation for the bucket they fall under
 	subSystemSortOrder := map[string]int{
-		"":                 100,
-		"nodepool":         10,
-		"nodeclaims":       9,
-		"nodes":            8,
-		"pods":             7,
-		"status_condition": -1,
-		"workqueue":        -1,
-		"client_go":        -1,
-		"aws_sdk_go":       -1,
-		"leader_election":  -2,
+		"":                              100,
+		"nodepool":                      10,
+		"nodeclaims":                    9,
+		"nodeclaim_status_condition":    8,
+		"nodeclaim_termination":         8,
+		"nodes":                         7,
+		"node_status_condition":         6,
+		"node_termination":              6,
+		"pods":                          5,
+		"nodepool_status_condition":     4,
+		"nodepool_termination":          4,
+		"ec2nodeclass_status_condition": 3,
+		"ec2nodeclass_termination":      3,
+		"status_condition":              -1,
+		"termination":                  -1,
+		"workqueue":                    -1,
+		"client_go":                     -1,
+		"aws_sdk_go":                    -1,
+		"leader_election":               -2,
 	}
 
 	return func(i, j int) bool {
@@ -223,71 +254,135 @@ func bySubsystem(metrics []metricInfo) func(i int, j int) bool {
 	}
 }
 
-func handleVariableDeclaration(v *ast.GenDecl) []metricInfo {
-	var promMetrics []metricInfo
-	for _, spec := range v.Specs {
-		vs, ok := spec.(*ast.ValueSpec)
-		if !ok {
-			continue
-		}
-		for _, v := range vs.Values {
-			ce, ok := v.(*ast.CallExpr)
-			if !ok {
-				continue
-			}
-			funcPkg := getFuncPackage(ce.Fun)
-			if funcPkg != "prometheus" {
-				continue
-			}
-			if len(ce.Args) == 0 {
-				continue
-			}
-			arg := ce.Args[0].(*ast.CompositeLit)
-			keyValuePairs := map[string]string{}
-			for _, el := range arg.Elts {
-				kv := el.(*ast.KeyValueExpr)
-				key := fmt.Sprintf("%s", kv.Key)
-				switch key {
-				case "Namespace", "Subsystem", "Name", "Help":
-				default:
-					// skip any keys we don't care about
-					continue
-				}
-				value := ""
-				switch val := kv.Value.(type) {
-				case *ast.BasicLit:
-					value = val.Value
-				case *ast.SelectorExpr:
-					selector := fmt.Sprintf("%s.%s", val.X, val.Sel)
-					if v, err := getIdentMapping(selector); err != nil {
-						log.Fatalf("unsupported selector %s, %s", selector, err)
-					} else {
-						value = v
-					}
-				case *ast.Ident:
-					if v, err := getIdentMapping(val.String()); err != nil {
-						log.Fatal(err)
-					} else {
-						value = v
-					}
-				case *ast.BinaryExpr:
-					value = getBinaryExpr(val)
-				default:
-					log.Fatalf("unsupported value %T %v", kv.Value, kv.Value)
-				}
-				keyValuePairs[key] = strings.TrimFunc(value, func(r rune) bool {
-					return r == '"'
-				})
-			}
-			promMetrics = append(promMetrics, metricInfo{
-				namespace: keyValuePairs["Namespace"],
-				subsystem: keyValuePairs["Subsystem"],
-				name:      keyValuePairs["Name"],
-				help:      keyValuePairs["Help"],
+// perObjectStatusMetrics generates metrics for the operatorpkg status and events controllers.
+// These metrics are dynamically created at runtime based on the Go type parameter passed to
+// status.NewController[T]() and cannot be extracted via AST parsing. The object types are
+// determined by the status controller registrations in karpenter and karpenter-provider-aws.
+func perObjectStatusMetrics() []metricInfo {
+	// Object types that have status controllers registered via status.NewController[T]()
+	// in karpenter (nodeclaim, nodepool, node) and karpenter-provider-aws (ec2nodeclass).
+	objectNames := []string{"nodeclaim", "nodepool", "node", "ec2nodeclass"}
+
+	type metricTemplate struct {
+		subsystemSuffix string
+		name            string
+		help            string
+	}
+
+	templates := []metricTemplate{
+		{"status_condition", "transition_seconds", "The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes"},
+		{"status_condition", "count", "The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0"},
+		{"status_condition", "current_status_seconds", "The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes"},
+		{"status_condition", "transitions_total", "The count of transitions of a given object, type and status."},
+		{"termination", "current_time_seconds", "The current amount of time in seconds that an object has been in terminating state."},
+		{"termination", "duration_seconds", "The amount of time taken by an object to terminate completely."},
+	}
+
+	var metricsOut []metricInfo
+	for _, obj := range objectNames {
+		for _, t := range templates {
+			metricsOut = append(metricsOut, metricInfo{
+				namespace: "operator",
+				subsystem: fmt.Sprintf("%s_%s", obj, t.subsystemSuffix),
+				name:      t.name,
+				help:      t.help,
 			})
 		}
 	}
-	return promMetrics
+
+	// Deprecated generic metrics (without object name prefix) are still emitted at runtime
+	// when emitDeprecatedMetrics is enabled on the status controller. These use group/kind
+	// labels instead of baking the object name into the subsystem.
+	for _, t := range templates {
+		metricsOut = append(metricsOut, metricInfo{
+			namespace: "operator",
+			subsystem: t.subsystemSuffix,
+			name:      t.name,
+			help:      t.help,
+		})
+	}
+
+	// client_go metrics are registered inside operatorpkg's RegisterClientMetrics() function
+	// using unqualified NewPrometheus* calls (same package). These can't be parsed via AST
+	// since we only recognize qualified opmetrics.* and prometheus.* calls.
+	metricsOut = append(metricsOut,
+		metricInfo{name: "client_go_request_duration_seconds", help: "Request latency in seconds. Broken down by verb, group, version, kind, and subresource."},
+		metricInfo{name: "client_go_request_total", help: "Number of HTTP requests, partitioned by status code and method."},
+	)
+
+	return metricsOut
+}
+
+// metricFromCallExpr attempts to extract metric info from a call expression.
+// It recognizes prometheus.New*(), opmetrics.NewPrometheus*(), and pmetrics.NewPrometheus*() calls.
+func metricFromCallExpr(ce *ast.CallExpr) (metricInfo, bool) {
+	funcPkg := getFuncPackage(ce.Fun)
+	// Determine the index of the opts argument based on the package.
+	// prometheus.New*() calls pass opts as Args[0], while
+	// opmetrics.NewPrometheus*() calls from operatorpkg pass
+	// (registry, opts, labelNames), so opts is Args[1].
+	var optsIdx int
+	switch funcPkg {
+	case "prometheus":
+		optsIdx = 0
+	case "opmetrics":
+		optsIdx = 1
+	default:
+		return metricInfo{}, false
+	}
+	if len(ce.Args) <= optsIdx {
+		return metricInfo{}, false
+	}
+	arg, ok := ce.Args[optsIdx].(*ast.CompositeLit)
+	if !ok {
+		return metricInfo{}, false
+	}
+	keyValuePairs := map[string]string{}
+	for _, el := range arg.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key := fmt.Sprintf("%s", kv.Key)
+		switch key {
+		case "Namespace", "Subsystem", "Name", "Help":
+		default:
+			// skip any keys we don't care about
+			continue
+		}
+		value := ""
+		switch val := kv.Value.(type) {
+		case *ast.BasicLit:
+			value = val.Value
+		case *ast.SelectorExpr:
+			selector := fmt.Sprintf("%s.%s", val.X, val.Sel)
+			v, err := getIdentMapping(selector)
+			if err != nil {
+				log.Fatalf("unresolvable selector %s for key %s: %s", selector, key, err)
+			}
+			value = v
+		case *ast.Ident:
+			v, err := getIdentMapping(val.String())
+			if err != nil {
+				log.Fatalf("unresolvable identifier %q for key %s: %s", val.String(), key, err)
+			}
+			value = v
+		case *ast.BinaryExpr:
+			value = getBinaryExpr(val)
+		default:
+			// Unknown value expression type; skip this metric.
+			return metricInfo{}, false
+		}
+		keyValuePairs[key] = strings.TrimFunc(value, func(r rune) bool {
+			return r == '"'
+		})
+	}
+	return metricInfo{
+		namespace: keyValuePairs["Namespace"],
+		subsystem: keyValuePairs["Subsystem"],
+		name:      keyValuePairs["Name"],
+		help:      keyValuePairs["Help"],
+	}, true
 }
 
 func getFuncPackage(fun ast.Expr) string {
@@ -309,7 +404,6 @@ func getFuncPackage(fun ast.Expr) string {
 	if _, ok := fun.(*ast.FuncLit); ok {
 		return ""
 	}
-	log.Fatalf("unsupported func expression %T, %v", fun, fun)
 	return ""
 }
 
@@ -340,6 +434,7 @@ func getIdentMapping(identName string) (string, error) {
 		"metrics.Namespace": metrics.Namespace,
 		"Namespace":         metrics.Namespace,
 
+		"pmetrics.Namespace":         "operator",
 		"MetricNamespace":            "operator",
 		"MetricSubsystem":            "status_condition",
 		"TerminationSubsystem":       "termination",

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -8,6 +8,404 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen/main.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)
+### `karpenter_build_info`
+A metric with a constant '1' value labeled by version from which karpenter was built.
+- Stability Level: STABLE
+
+## Nodeclaims Metrics
+
+### `karpenter_nodeclaims_unhealthy_disrupted_total`
+Number of unhealthy nodeclaims disrupted in total by Karpenter. Labeled by condition on the node was disrupted, the owning nodepool, and the image ID.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_termination_duration_seconds`
+Duration of NodeClaim termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_terminated_total`
+Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodeclaims_instance_termination_duration_seconds`
+Duration of CloudProvider Instance termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_disrupted_total`
+Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_created_total`
+Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created, the owning nodepool, and if min values was relaxed for this nodeclaim.
+- Stability Level: STABLE
+
+## Nodeclaim Termination Metrics
+
+### `operator_nodeclaim_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Nodeclaim Status Condition Metrics
+
+### `operator_nodeclaim_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Nodes Metrics
+
+### `karpenter_nodes_total_pod_requests`
+Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_pod_limits`
+Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_requests`
+Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_limits`
+Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Stability Level: BETA
+
+### `karpenter_nodes_termination_duration_seconds`
+The time taken between a node's deletion request and the removal of its finalizer
+- Stability Level: BETA
+
+### `karpenter_nodes_terminated_total`
+Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_system_overhead`
+Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Stability Level: BETA
+
+### `karpenter_nodes_lifetime_duration_seconds`
+The lifetime duration of the nodes since creation.
+- Stability Level: ALPHA
+
+### `karpenter_nodes_drained_total`
+The total number of nodes drained by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_current_lifetime_seconds`
+Node age in seconds
+- Stability Level: ALPHA
+
+### `karpenter_nodes_created_total`
+Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_allocatable`
+Node allocatable are the resources allocatable by nodes.
+- Stability Level: BETA
+
+## Node Termination Metrics
+
+### `operator_node_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_node_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Node Status Condition Metrics
+
+### `operator_node_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Pods Metrics
+
+### `karpenter_pods_unstarted_time_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: ALPHA
+
+### `karpenter_pods_unbound_time_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
+### `karpenter_pods_state`
+Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type, pod phase, and pod readiness.
+- Stability Level: BETA
+
+### `karpenter_pods_startup_duration_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: STABLE
+
+### `karpenter_pods_scheduling_decision_duration_seconds`
+The time it takes for Karpenter to first try to schedule a pod after it's been seen.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_unstarted_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_unbound_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_startup_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_scheduling_undecided_time_seconds`
+The time from when Karpenter has seen a pod without making a scheduling decision for the pod. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_bound_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_eviction_requests_total`
+The total number of pod eviction requests made by Karpenter, labeled by response code
+- Stability Level: ALPHA
+
+### `karpenter_pods_drained_total`
+The total number of pods drained during node termination by Karpenter, labeled by reason
+- Stability Level: ALPHA
+
+### `karpenter_pods_bound_duration_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
+## Nodepool Termination Metrics
+
+### `operator_nodepool_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Nodepool Status Condition Metrics
+
+### `operator_nodepool_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Ec2nodeclass Termination Metrics
+
+### `operator_ec2nodeclass_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Ec2nodeclass Status Condition Metrics
+
+### `operator_ec2nodeclass_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Voluntary Disruption Metrics
+
+### `karpenter_voluntary_disruption_queue_failures_total`
+The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_failed_validations_total`
+Number of candidates that were selected for disruption but failed validation. Labeled by consolidation type.
+- Stability Level: ALPHA
+
+### `karpenter_voluntary_disruption_eligible_nodes`
+Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_decisions_total`
+Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decisions_by_nodepool_total`
+Number of disruption decisions performed by nodepool. Labeled by nodepool name, disruption decision, reason, and consolidation type.
+- Stability Level: ALPHA
+
+### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
+Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_consolidation_timeouts_total`
+Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Stability Level: BETA
+
+## Scheduler Metrics
+
+### `karpenter_scheduler_unschedulable_pods_count`
+The number of unschedulable Pods.
+- Stability Level: ALPHA
+
+### `karpenter_scheduler_unfinished_work_seconds`
+How many seconds of work has been done that is in progress and hasn't been observed by scheduling_duration_seconds.
+- Stability Level: ALPHA
+
+### `karpenter_scheduler_scheduling_duration_seconds`
+Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Stability Level: STABLE
+
+### `karpenter_scheduler_queue_depth`
+The number of pods currently waiting to be scheduled.
+- Stability Level: BETA
+
+### `karpenter_scheduler_ignored_pods_count`
+Number of pods ignored during scheduling by Karpenter
+- Stability Level: ALPHA
+
+## Nodepools Metrics
+
+### `karpenter_nodepools_usage`
+The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_nodes_consuming_budgets`
+The number of nodes consuming the budget of a nodepool at a point in time. Labeled by NodePool.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_limit`
+Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_tracker_errors_total`
+Number of errors encountered during cost tracking operations. Labeled by nodepool and nodeclaim.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_total`
+Total cost of the nodepool from Karpenter's perspective. Units are determined by the cloud provider. Not an authoritative source for billing. Includes modifications due to NodeOverlays
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_allowed_disruptions`
+The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Stability Level: ALPHA
+
+## Interruption Metrics
+
+### `karpenter_interruption_received_messages_total`
+Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Stability Level: STABLE
+
+### `karpenter_interruption_message_queue_duration_seconds`
+Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Stability Level: STABLE
+
+### `karpenter_interruption_instance_status_unhealthy_total`
+Count of unhealthy instance statuses detected from EC2 DescribeInstanceStatus. Broken down by status check category.
+- Stability Level: STABLE
+
+### `karpenter_interruption_deleted_messages_total`
+Count of messages deleted from the SQS queue.
+- Stability Level: STABLE
+
+## Cluster Metrics
+
+### `karpenter_cluster_utilization_percent`
+Utilization of allocatable resources by pod requests
+- Stability Level: ALPHA
+
+## Cluster State Metrics
+
+### `karpenter_cluster_state_unsynced_time_seconds`
+The time for which cluster state is not synced
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_synced`
+Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_node_count`
+Current count of nodes in cluster state
+- Stability Level: STABLE
+
+## Cloudprovider Metrics
+
+### `karpenter_cloudprovider_instance_type_offering_price_estimate`
+Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_offering_available`
+Instance type offering availability, based on instance type, capacity type, and zone
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_memory_bytes`
+Memory, in bytes, for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_cpu_cores`
+VCPUs cores for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_errors_total`
+Total number of errors returned from CloudProvider calls.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_duration_seconds`
+Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Stability Level: BETA
+
+## Cloudprovider Batcher Metrics
+
+### `karpenter_cloudprovider_batcher_batch_time_seconds`
+Duration of the batching window per batcher
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_batcher_batch_size`
+Size of the request batch per batcher
+- Stability Level: BETA
+
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
@@ -70,6 +468,44 @@ Current depth of workqueue by workqueue and priority
 
 ### `workqueue_adds_total`
 Total number of adds handled by workqueue
+- Stability Level: STABLE
+
+## Termination Metrics
+
+### `operator_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: DEPRECATED
+
+### `operator_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: DEPRECATED
+
+## Status Condition Metrics
+
+### `operator_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: DEPRECATED
+
+## Client Go Metrics
+
+### `client_go_request_total`
+Number of HTTP requests, partitioned by status code and method.
+- Stability Level: STABLE
+
+### `client_go_request_duration_seconds`
+Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
 - Stability Level: STABLE
 
 ## AWS SDK Go Metrics

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -8,16 +8,15 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen/main.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)
-
-### `karpenter_ignored_pod_count`
-Number of pods ignored during scheduling by Karpenter
-- Stability Level: ALPHA
-
 ### `karpenter_build_info`
 A metric with a constant '1' value labeled by version from which karpenter was built.
 - Stability Level: STABLE
 
 ## Nodeclaims Metrics
+
+### `karpenter_nodeclaims_unhealthy_disrupted_total`
+Number of unhealthy nodeclaims disrupted in total by Karpenter. Labeled by condition on the node was disrupted, the owning nodepool, and the image ID.
+- Stability Level: ALPHA
 
 ### `karpenter_nodeclaims_termination_duration_seconds`
 Duration of NodeClaim termination in seconds.
@@ -36,31 +35,35 @@ Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the node
 - Stability Level: ALPHA
 
 ### `karpenter_nodeclaims_created_total`
-Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created and the owning nodepool.
+Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created, the owning nodepool, and if min values was relaxed for this nodeclaim.
 - Stability Level: STABLE
 
-### `operator_nodeclaim_status_condition_transitions_total`
-The count of transitions of a nodeclaim, type and status. Labeled by the type, reason, and status.
-- Stability Level: BETA
+## Nodeclaim Termination Metrics
 
-### `operator_nodeclaim_status_condition_transition_seconds`
-The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
-- Stability Level: BETA
-
-### `operator_nodeclaim_status_condition_current_status_seconds`
-The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
-- Stability Level: BETA
-
-### `operator_nodeclaim_status_condition_count`
-The number of a condition for a nodeclaim, type and status. Labeled by the name, namespace, type, status, and reason.
+### `operator_nodeclaim_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
 - Stability Level: BETA
 
 ### `operator_nodeclaim_termination_current_time_seconds`
-The current amount of time in seconds that a nodeclaim has been in terminating state. Labeled by name, and namespace.
+The current amount of time in seconds that an object has been in terminating state.
 - Stability Level: BETA
 
-### `operator_nodeclaim_termination_duration_seconds`
-The amount of time taken by a nodeclaim to terminate completely.
+## Nodeclaim Status Condition Metrics
+
+### `operator_nodeclaim_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
 - Stability Level: BETA
 
 ## Nodes Metrics
@@ -97,10 +100,6 @@ Node system daemon overhead are the resources reserved for system overhead, the 
 The lifetime duration of the nodes since creation.
 - Stability Level: ALPHA
 
-### `karpenter_nodes_eviction_requests_total`
-The total number of eviction requests made by Karpenter
-- Stability Level: ALPHA
-
 ### `karpenter_nodes_drained_total`
 The total number of nodes drained by Karpenter
 - Stability Level: ALPHA
@@ -117,59 +116,153 @@ Number of nodes created in total by Karpenter. Labeled by owning nodepool.
 Node allocatable are the resources allocatable by nodes.
 - Stability Level: BETA
 
-### `operator_node_status_condition_transitions_total`
-The count of transitions of a node, type and status.
-- Stability Level: BETA
+## Node Termination Metrics
 
-### `operator_node_status_condition_transition_seconds`
-The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
-- Stability Level: BETA
-
-### `operator_node_status_condition_current_status_seconds`
-The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
-- Stability Level: BETA
-
-### `operator_node_status_condition_count`
-The number of a condition for a node, type and status. Labeled by the name, namespace, type, status, and reason.
+### `operator_node_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
 - Stability Level: BETA
 
 ### `operator_node_termination_current_time_seconds`
-The current amount of time in seconds that a node has been in terminating state. Labeled by name, and namespace.
+The current amount of time in seconds that an object has been in terminating state.
 - Stability Level: BETA
 
-### `operator_node_termination_duration_seconds`
-The amount of time taken by a node to terminate completely.
+## Node Status Condition Metrics
+
+### `operator_node_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
 - Stability Level: BETA
 
-### `operator_node_event_count`
-The number of a events for a node.
+### `operator_node_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
 - Stability Level: BETA
 
 ## Pods Metrics
 
+### `karpenter_pods_unstarted_time_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: ALPHA
+
+### `karpenter_pods_unbound_time_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
 ### `karpenter_pods_state`
-Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type and pod phase.
+Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type, pod phase, and pod readiness.
 - Stability Level: BETA
 
 ### `karpenter_pods_startup_duration_seconds`
 The time from pod creation until the pod is running.
 - Stability Level: STABLE
 
-## Termination Metrics
+### `karpenter_pods_scheduling_decision_duration_seconds`
+The time it takes for Karpenter to first try to schedule a pod after it's been seen.
+- Stability Level: ALPHA
 
-### `operator_termination_duration_seconds`
+### `karpenter_pods_provisioning_unstarted_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_unbound_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_startup_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_scheduling_undecided_time_seconds`
+The time from when Karpenter has seen a pod without making a scheduling decision for the pod. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_bound_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_eviction_requests_total`
+The total number of pod eviction requests made by Karpenter, labeled by response code
+- Stability Level: ALPHA
+
+### `karpenter_pods_drained_total`
+The total number of pods drained during node termination by Karpenter, labeled by reason
+- Stability Level: ALPHA
+
+### `karpenter_pods_bound_duration_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
+## Nodepool Termination Metrics
+
+### `operator_nodepool_termination_duration_seconds`
 The amount of time taken by an object to terminate completely.
-- Stability Level: DEPRECATED
+- Stability Level: BETA
 
-### `operator_termination_current_time_seconds`
+### `operator_nodepool_termination_current_time_seconds`
 The current amount of time in seconds that an object has been in terminating state.
-- Stability Level: DEPRECATED
+- Stability Level: BETA
+
+## Nodepool Status Condition Metrics
+
+### `operator_nodepool_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Ec2nodeclass Termination Metrics
+
+### `operator_ec2nodeclass_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Ec2nodeclass Status Condition Metrics
+
+### `operator_ec2nodeclass_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
 
 ## Voluntary Disruption Metrics
 
 ### `karpenter_voluntary_disruption_queue_failures_total`
 The number of times that an enqueued disruption decision failed. Labeled by disruption method.
 - Stability Level: BETA
+
+### `karpenter_voluntary_disruption_failed_validations_total`
+Number of candidates that were selected for disruption but failed validation. Labeled by consolidation type.
+- Stability Level: ALPHA
 
 ### `karpenter_voluntary_disruption_eligible_nodes`
 Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
@@ -178,6 +271,10 @@ Number of nodes eligible for disruption by Karpenter. Labeled by disruption reas
 ### `karpenter_voluntary_disruption_decisions_total`
 Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
 - Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decisions_by_nodepool_total`
+Number of disruption decisions performed by nodepool. Labeled by nodepool name, disruption decision, reason, and consolidation type.
+- Stability Level: ALPHA
 
 ### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
 Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
@@ -189,6 +286,14 @@ Number of times the Consolidation algorithm has reached a timeout. Labeled by co
 
 ## Scheduler Metrics
 
+### `karpenter_scheduler_unschedulable_pods_count`
+The number of unschedulable Pods.
+- Stability Level: ALPHA
+
+### `karpenter_scheduler_unfinished_work_seconds`
+How many seconds of work has been done that is in progress and hasn't been observed by scheduling_duration_seconds.
+- Stability Level: ALPHA
+
 ### `karpenter_scheduler_scheduling_duration_seconds`
 Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
 - Stability Level: STABLE
@@ -197,69 +302,35 @@ Duration of scheduling simulations used for deprovisioning and provisioning in s
 The number of pods currently waiting to be scheduled.
 - Stability Level: BETA
 
+### `karpenter_scheduler_ignored_pods_count`
+Number of pods ignored during scheduling by Karpenter
+- Stability Level: ALPHA
+
 ## Nodepools Metrics
 
 ### `karpenter_nodepools_usage`
 The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
 - Stability Level: ALPHA
 
+### `karpenter_nodepools_nodes_consuming_budgets`
+The number of nodes consuming the budget of a nodepool at a point in time. Labeled by NodePool.
+- Stability Level: ALPHA
+
 ### `karpenter_nodepools_limit`
 Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_tracker_errors_total`
+Number of errors encountered during cost tracking operations. Labeled by nodepool and nodeclaim.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_total`
+Total cost of the nodepool from Karpenter's perspective. Units are determined by the cloud provider. Not an authoritative source for billing. Includes modifications due to NodeOverlays
 - Stability Level: ALPHA
 
 ### `karpenter_nodepools_allowed_disruptions`
 The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
 - Stability Level: ALPHA
-
-### `operator_nodepool_status_condition_transitions_total`
-The count of transitions of a nodepool, type and status. Labeled by the type, reason, and status.
-- Stability Level: BETA
-
-### `operator_nodepool_status_condition_transition_seconds`
-The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
-- Stability Level: BETA
-
-### `operator_nodepool_status_condition_current_status_seconds`
-The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
-- Stability Level: BETA
-
-### `operator_nodepool_status_condition_count`
-The number of an condition for a nodepool, type and status. Labeled by the name, namespace, type, status, and reason.
-- Stability Level: BETA
-
-### `operator_nodepool_termination_current_time_seconds`
-The current amount of time in seconds that a nodepool has been in terminating state. Labeled by name, and namespace.
-- Stability Level: BETA
-
-### `operator_nodepool_termination_duration_seconds`
-Duration of NodePool termination in seconds.
-- Stability Level: BETA
-
-## EC2NodeClass Metrics
-
-### `operator_ec2nodeclass_status_condition_transitions_total`
-The count of transitions of a ec2nodeclass, type and status. Labeled by the type, reason, and status.
-- Stability Level: BETA
-
-### `operator_ec2nodeclass_status_condition_transition_seconds`
-The amount of time a condition was in a given state before transitioning. Labeled by the name of the nodeclaim, and the namespace.
-- Stability Level: BETA
-
-### `operator_ec2nodeclass_status_condition_current_status_seconds`
-The current amount of time in seconds that a status condition has been in a specific state. Labeled by the name of the nodelcaim, namespace, type, status, and reason.
-- Stability Level: BETA
-
-### `operator_ec2nodeclass_status_condition_count`
-The number of an condition for an ec2nodeclass, type and status. Labeled by the name, namespace, type, status, and reason.
-- Stability Level: BETA
-
-### `operator_ec2nodeclass_termination_current_time_seconds`
-The current amount of time in seconds that an ec2nodeclass has been in terminating state. Labeled by name, and namespace.
-- Stability Level: BETA
-
-### `operator_ec2nodeclass_termination_duration_seconds`
-Duration of ec2nodeclass termination in seconds.
-- Stability Level: BETA
 
 ## Interruption Metrics
 
@@ -269,6 +340,10 @@ Count of messages received from the SQS queue. Broken down by message type and w
 
 ### `karpenter_interruption_message_queue_duration_seconds`
 Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Stability Level: STABLE
+
+### `karpenter_interruption_instance_status_unhealthy_total`
+Count of unhealthy instance statuses detected from EC2 DescribeInstanceStatus. Broken down by status check category.
 - Stability Level: STABLE
 
 ### `karpenter_interruption_deleted_messages_total`
@@ -285,7 +360,7 @@ Utilization of allocatable resources by pod requests
 
 ### `karpenter_cluster_state_unsynced_time_seconds`
 The time for which cluster state is not synced
-- Stability Level: ALPHA
+- Stability Level: STABLE
 
 ### `karpenter_cluster_state_synced`
 Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
@@ -395,6 +470,16 @@ Current depth of workqueue by workqueue and priority
 Total number of adds handled by workqueue
 - Stability Level: STABLE
 
+## Termination Metrics
+
+### `operator_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: DEPRECATED
+
+### `operator_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: DEPRECATED
+
 ## Status Condition Metrics
 
 ### `operator_status_condition_transitions_total`
@@ -410,7 +495,7 @@ The current amount of time in seconds that a status condition has been in a spec
 - Stability Level: DEPRECATED
 
 ### `operator_status_condition_count`
-The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
 - Stability Level: DEPRECATED
 
 ## Client Go Metrics

--- a/website/content/en/v1.11/reference/metrics.md
+++ b/website/content/en/v1.11/reference/metrics.md
@@ -8,6 +8,400 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen/main.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)
+### `karpenter_build_info`
+A metric with a constant '1' value labeled by version from which karpenter was built.
+- Stability Level: STABLE
+
+## Nodeclaims Metrics
+
+### `karpenter_nodeclaims_unhealthy_disrupted_total`
+Number of unhealthy nodeclaims disrupted in total by Karpenter. Labeled by condition on the node was disrupted, the owning nodepool, and the image ID.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_termination_duration_seconds`
+Duration of NodeClaim termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_terminated_total`
+Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodeclaims_instance_termination_duration_seconds`
+Duration of CloudProvider Instance termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_disrupted_total`
+Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_created_total`
+Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created, the owning nodepool, and if min values was relaxed for this nodeclaim.
+- Stability Level: STABLE
+
+## Nodeclaim Termination Metrics
+
+### `operator_nodeclaim_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Nodeclaim Status Condition Metrics
+
+### `operator_nodeclaim_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Nodes Metrics
+
+### `karpenter_nodes_total_pod_requests`
+Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_pod_limits`
+Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_requests`
+Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_limits`
+Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Stability Level: BETA
+
+### `karpenter_nodes_termination_duration_seconds`
+The time taken between a node's deletion request and the removal of its finalizer
+- Stability Level: BETA
+
+### `karpenter_nodes_terminated_total`
+Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_system_overhead`
+Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Stability Level: BETA
+
+### `karpenter_nodes_lifetime_duration_seconds`
+The lifetime duration of the nodes since creation.
+- Stability Level: ALPHA
+
+### `karpenter_nodes_drained_total`
+The total number of nodes drained by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_current_lifetime_seconds`
+Node age in seconds
+- Stability Level: ALPHA
+
+### `karpenter_nodes_created_total`
+Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_allocatable`
+Node allocatable are the resources allocatable by nodes.
+- Stability Level: BETA
+
+## Node Termination Metrics
+
+### `operator_node_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_node_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Node Status Condition Metrics
+
+### `operator_node_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Pods Metrics
+
+### `karpenter_pods_unstarted_time_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: ALPHA
+
+### `karpenter_pods_unbound_time_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
+### `karpenter_pods_state`
+Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type, pod phase, and pod readiness.
+- Stability Level: BETA
+
+### `karpenter_pods_startup_duration_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: STABLE
+
+### `karpenter_pods_scheduling_decision_duration_seconds`
+The time it takes for Karpenter to first try to schedule a pod after it's been seen.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_unstarted_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_unbound_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_startup_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_scheduling_undecided_time_seconds`
+The time from when Karpenter has seen a pod without making a scheduling decision for the pod. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_bound_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_eviction_requests_total`
+The total number of pod eviction requests made by Karpenter, labeled by response code
+- Stability Level: ALPHA
+
+### `karpenter_pods_drained_total`
+The total number of pods drained during node termination by Karpenter, labeled by reason
+- Stability Level: ALPHA
+
+### `karpenter_pods_bound_duration_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
+## Nodepool Termination Metrics
+
+### `operator_nodepool_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Nodepool Status Condition Metrics
+
+### `operator_nodepool_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Ec2nodeclass Termination Metrics
+
+### `operator_ec2nodeclass_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Ec2nodeclass Status Condition Metrics
+
+### `operator_ec2nodeclass_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Voluntary Disruption Metrics
+
+### `karpenter_voluntary_disruption_queue_failures_total`
+The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_failed_validations_total`
+Number of candidates that were selected for disruption but failed validation. Labeled by consolidation type.
+- Stability Level: ALPHA
+
+### `karpenter_voluntary_disruption_eligible_nodes`
+Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_decisions_total`
+Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decisions_by_nodepool_total`
+Number of disruption decisions performed by nodepool. Labeled by nodepool name, disruption decision, reason, and consolidation type.
+- Stability Level: ALPHA
+
+### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
+Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_consolidation_timeouts_total`
+Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Stability Level: BETA
+
+## Scheduler Metrics
+
+### `karpenter_scheduler_unschedulable_pods_count`
+The number of unschedulable Pods.
+- Stability Level: ALPHA
+
+### `karpenter_scheduler_unfinished_work_seconds`
+How many seconds of work has been done that is in progress and hasn't been observed by scheduling_duration_seconds.
+- Stability Level: ALPHA
+
+### `karpenter_scheduler_scheduling_duration_seconds`
+Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Stability Level: STABLE
+
+### `karpenter_scheduler_queue_depth`
+The number of pods currently waiting to be scheduled.
+- Stability Level: BETA
+
+### `karpenter_scheduler_ignored_pods_count`
+Number of pods ignored during scheduling by Karpenter
+- Stability Level: ALPHA
+
+## Nodepools Metrics
+
+### `karpenter_nodepools_usage`
+The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_nodes_consuming_budgets`
+The number of nodes consuming the budget of a nodepool at a point in time. Labeled by NodePool.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_limit`
+Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_tracker_errors_total`
+Number of errors encountered during cost tracking operations. Labeled by nodepool and nodeclaim.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_total`
+Total cost of the nodepool from Karpenter's perspective. Units are determined by the cloud provider. Not an authoritative source for billing. Includes modifications due to NodeOverlays
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_allowed_disruptions`
+The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Stability Level: ALPHA
+
+## Interruption Metrics
+
+### `karpenter_interruption_received_messages_total`
+Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Stability Level: STABLE
+
+### `karpenter_interruption_message_queue_duration_seconds`
+Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Stability Level: STABLE
+
+### `karpenter_interruption_deleted_messages_total`
+Count of messages deleted from the SQS queue.
+- Stability Level: STABLE
+
+## Cluster Metrics
+
+### `karpenter_cluster_utilization_percent`
+Utilization of allocatable resources by pod requests
+- Stability Level: ALPHA
+
+## Cluster State Metrics
+
+### `karpenter_cluster_state_unsynced_time_seconds`
+The time for which cluster state is not synced
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_synced`
+Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_node_count`
+Current count of nodes in cluster state
+- Stability Level: STABLE
+
+## Cloudprovider Metrics
+
+### `karpenter_cloudprovider_instance_type_offering_price_estimate`
+Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_offering_available`
+Instance type offering availability, based on instance type, capacity type, and zone
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_memory_bytes`
+Memory, in bytes, for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_cpu_cores`
+VCPUs cores for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_errors_total`
+Total number of errors returned from CloudProvider calls.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_duration_seconds`
+Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Stability Level: BETA
+
+## Cloudprovider Batcher Metrics
+
+### `karpenter_cloudprovider_batcher_batch_time_seconds`
+Duration of the batching window per batcher
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_batcher_batch_size`
+Size of the request batch per batcher
+- Stability Level: BETA
+
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
@@ -70,6 +464,44 @@ Current depth of workqueue by workqueue and priority
 
 ### `workqueue_adds_total`
 Total number of adds handled by workqueue
+- Stability Level: STABLE
+
+## Termination Metrics
+
+### `operator_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: DEPRECATED
+
+### `operator_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: DEPRECATED
+
+## Status Condition Metrics
+
+### `operator_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: DEPRECATED
+
+## Client Go Metrics
+
+### `client_go_request_total`
+Number of HTTP requests, partitioned by status code and method.
+- Stability Level: STABLE
+
+### `client_go_request_duration_seconds`
+Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
 - Stability Level: STABLE
 
 ## AWS SDK Go Metrics

--- a/website/content/en/v1.12/reference/metrics.md
+++ b/website/content/en/v1.12/reference/metrics.md
@@ -8,6 +8,404 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen/main.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.kube-system.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)
+### `karpenter_build_info`
+A metric with a constant '1' value labeled by version from which karpenter was built.
+- Stability Level: STABLE
+
+## Nodeclaims Metrics
+
+### `karpenter_nodeclaims_unhealthy_disrupted_total`
+Number of unhealthy nodeclaims disrupted in total by Karpenter. Labeled by condition on the node was disrupted, the owning nodepool, and the image ID.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_termination_duration_seconds`
+Duration of NodeClaim termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_terminated_total`
+Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodeclaims_instance_termination_duration_seconds`
+Duration of CloudProvider Instance termination in seconds.
+- Stability Level: BETA
+
+### `karpenter_nodeclaims_disrupted_total`
+Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.
+- Stability Level: ALPHA
+
+### `karpenter_nodeclaims_created_total`
+Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created, the owning nodepool, and if min values was relaxed for this nodeclaim.
+- Stability Level: STABLE
+
+## Nodeclaim Termination Metrics
+
+### `operator_nodeclaim_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_nodeclaim_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Nodeclaim Status Condition Metrics
+
+### `operator_nodeclaim_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodeclaim_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Nodes Metrics
+
+### `karpenter_nodes_total_pod_requests`
+Node total pod requests are the resources requested by pods bound to nodes, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_pod_limits`
+Node total pod limits are the resources specified by pod limits, including the DaemonSet pods.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_requests`
+Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+- Stability Level: BETA
+
+### `karpenter_nodes_total_daemon_limits`
+Node total daemon limits are the resources specified by DaemonSet pod limits.
+- Stability Level: BETA
+
+### `karpenter_nodes_termination_duration_seconds`
+The time taken between a node's deletion request and the removal of its finalizer
+- Stability Level: BETA
+
+### `karpenter_nodes_terminated_total`
+Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_system_overhead`
+Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+- Stability Level: BETA
+
+### `karpenter_nodes_lifetime_duration_seconds`
+The lifetime duration of the nodes since creation.
+- Stability Level: ALPHA
+
+### `karpenter_nodes_drained_total`
+The total number of nodes drained by Karpenter
+- Stability Level: ALPHA
+
+### `karpenter_nodes_current_lifetime_seconds`
+Node age in seconds
+- Stability Level: ALPHA
+
+### `karpenter_nodes_created_total`
+Number of nodes created in total by Karpenter. Labeled by owning nodepool.
+- Stability Level: STABLE
+
+### `karpenter_nodes_allocatable`
+Node allocatable are the resources allocatable by nodes.
+- Stability Level: BETA
+
+## Node Termination Metrics
+
+### `operator_node_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_node_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Node Status Condition Metrics
+
+### `operator_node_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_node_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_node_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Pods Metrics
+
+### `karpenter_pods_unstarted_time_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: ALPHA
+
+### `karpenter_pods_unbound_time_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
+### `karpenter_pods_state`
+Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type, pod phase, and pod readiness.
+- Stability Level: BETA
+
+### `karpenter_pods_startup_duration_seconds`
+The time from pod creation until the pod is running.
+- Stability Level: STABLE
+
+### `karpenter_pods_scheduling_decision_duration_seconds`
+The time it takes for Karpenter to first try to schedule a pod after it's been seen.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_unstarted_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_unbound_time_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_startup_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_scheduling_undecided_time_seconds`
+The time from when Karpenter has seen a pod without making a scheduling decision for the pod. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_provisioning_bound_duration_seconds`
+The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.
+- Stability Level: ALPHA
+
+### `karpenter_pods_eviction_requests_total`
+The total number of pod eviction requests made by Karpenter, labeled by response code
+- Stability Level: ALPHA
+
+### `karpenter_pods_drained_total`
+The total number of pods drained during node termination by Karpenter, labeled by reason
+- Stability Level: ALPHA
+
+### `karpenter_pods_bound_duration_seconds`
+The time from pod creation until the pod is bound.
+- Stability Level: ALPHA
+
+## Nodepool Termination Metrics
+
+### `operator_nodepool_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_nodepool_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Nodepool Status Condition Metrics
+
+### `operator_nodepool_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_nodepool_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Ec2nodeclass Termination Metrics
+
+### `operator_ec2nodeclass_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: BETA
+
+## Ec2nodeclass Status Condition Metrics
+
+### `operator_ec2nodeclass_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: BETA
+
+### `operator_ec2nodeclass_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: BETA
+
+## Voluntary Disruption Metrics
+
+### `karpenter_voluntary_disruption_queue_failures_total`
+The number of times that an enqueued disruption decision failed. Labeled by disruption method.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_failed_validations_total`
+Number of candidates that were selected for disruption but failed validation. Labeled by consolidation type.
+- Stability Level: ALPHA
+
+### `karpenter_voluntary_disruption_eligible_nodes`
+Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_decisions_total`
+Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.
+- Stability Level: STABLE
+
+### `karpenter_voluntary_disruption_decisions_by_nodepool_total`
+Number of disruption decisions performed by nodepool. Labeled by nodepool name, disruption decision, reason, and consolidation type.
+- Stability Level: ALPHA
+
+### `karpenter_voluntary_disruption_decision_evaluation_duration_seconds`
+Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.
+- Stability Level: BETA
+
+### `karpenter_voluntary_disruption_consolidation_timeouts_total`
+Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.
+- Stability Level: BETA
+
+## Scheduler Metrics
+
+### `karpenter_scheduler_unschedulable_pods_count`
+The number of unschedulable Pods.
+- Stability Level: ALPHA
+
+### `karpenter_scheduler_unfinished_work_seconds`
+How many seconds of work has been done that is in progress and hasn't been observed by scheduling_duration_seconds.
+- Stability Level: ALPHA
+
+### `karpenter_scheduler_scheduling_duration_seconds`
+Duration of scheduling simulations used for deprovisioning and provisioning in seconds.
+- Stability Level: STABLE
+
+### `karpenter_scheduler_queue_depth`
+The number of pods currently waiting to be scheduled.
+- Stability Level: BETA
+
+### `karpenter_scheduler_ignored_pods_count`
+Number of pods ignored during scheduling by Karpenter
+- Stability Level: ALPHA
+
+## Nodepools Metrics
+
+### `karpenter_nodepools_usage`
+The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_nodes_consuming_budgets`
+The number of nodes consuming the budget of a nodepool at a point in time. Labeled by NodePool.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_limit`
+Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_tracker_errors_total`
+Number of errors encountered during cost tracking operations. Labeled by nodepool and nodeclaim.
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_cost_total`
+Total cost of the nodepool from Karpenter's perspective. Units are determined by the cloud provider. Not an authoritative source for billing. Includes modifications due to NodeOverlays
+- Stability Level: ALPHA
+
+### `karpenter_nodepools_allowed_disruptions`
+The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
+- Stability Level: ALPHA
+
+## Interruption Metrics
+
+### `karpenter_interruption_received_messages_total`
+Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
+- Stability Level: STABLE
+
+### `karpenter_interruption_message_queue_duration_seconds`
+Amount of time an interruption message is on the queue before it is processed by karpenter.
+- Stability Level: STABLE
+
+### `karpenter_interruption_instance_status_unhealthy_total`
+Count of unhealthy instance statuses detected from EC2 DescribeInstanceStatus. Broken down by status check category.
+- Stability Level: STABLE
+
+### `karpenter_interruption_deleted_messages_total`
+Count of messages deleted from the SQS queue.
+- Stability Level: STABLE
+
+## Cluster Metrics
+
+### `karpenter_cluster_utilization_percent`
+Utilization of allocatable resources by pod requests
+- Stability Level: ALPHA
+
+## Cluster State Metrics
+
+### `karpenter_cluster_state_unsynced_time_seconds`
+The time for which cluster state is not synced
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_synced`
+Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state
+- Stability Level: STABLE
+
+### `karpenter_cluster_state_node_count`
+Current count of nodes in cluster state
+- Stability Level: STABLE
+
+## Cloudprovider Metrics
+
+### `karpenter_cloudprovider_instance_type_offering_price_estimate`
+Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_offering_available`
+Instance type offering availability, based on instance type, capacity type, and zone
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_memory_bytes`
+Memory, in bytes, for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_instance_type_cpu_cores`
+VCPUs cores for a given instance type.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_errors_total`
+Total number of errors returned from CloudProvider calls.
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_duration_seconds`
+Duration of cloud provider method calls. Labeled by the controller, method name and provider.
+- Stability Level: BETA
+
+## Cloudprovider Batcher Metrics
+
+### `karpenter_cloudprovider_batcher_batch_time_seconds`
+Duration of the batching window per batcher
+- Stability Level: BETA
+
+### `karpenter_cloudprovider_batcher_batch_size`
+Size of the request batch per batcher
+- Stability Level: BETA
+
 ## Controller Runtime Metrics
 
 ### `controller_runtime_terminal_reconcile_errors_total`
@@ -70,6 +468,44 @@ Current depth of workqueue by workqueue and priority
 
 ### `workqueue_adds_total`
 Total number of adds handled by workqueue
+- Stability Level: STABLE
+
+## Termination Metrics
+
+### `operator_termination_duration_seconds`
+The amount of time taken by an object to terminate completely.
+- Stability Level: DEPRECATED
+
+### `operator_termination_current_time_seconds`
+The current amount of time in seconds that an object has been in terminating state.
+- Stability Level: DEPRECATED
+
+## Status Condition Metrics
+
+### `operator_status_condition_transitions_total`
+The count of transitions of a given object, type and status.
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_transition_seconds`
+The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_current_status_seconds`
+The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes
+- Stability Level: DEPRECATED
+
+### `operator_status_condition_count`
+The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0
+- Stability Level: DEPRECATED
+
+## Client Go Metrics
+
+### `client_go_request_total`
+Number of HTTP requests, partitioned by status code and method.
+- Stability Level: STABLE
+
+### `client_go_request_duration_seconds`
+Request latency in seconds. Broken down by verb, group, version, kind, and subresource.
 - Stability Level: STABLE
 
 ## AWS SDK Go Metrics


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

The metrics documentation generator only recognized prometheus.New*() calls for extracting metric declarations from source code. After the migration to operatorpkg's opmetrics.NewPrometheus*() and pmetrics.NewPrometheus*() wrappers, the generator silently dropped all karpenter core and provider-aws metrics, producing incomplete documentation.

Changes:
- Use ast.Inspect to walk entire AST including function bodies, replacing the previous top-level-var-only scan. This picks up metrics initialized inside functions (e.g. node controller's initializeMetrics(), operatorpkg's RegisterClientMetrics()).
- Recognize opmetrics, pmetrics, and unqualified NewPrometheus* calls with the correct opts argument index (Args[1] instead of Args[0]).
- Skip unresolvable identifiers gracefully instead of fataling, since ast.Inspect encounters local variables in helper function bodies.
- Filter out _test.go files from parsing to avoid picking up test metrics.
- Add perObjectStatusMetrics() to generate the per-object status condition and termination metrics that are dynamically created at runtime by operatorpkg's status.NewController[T]().
- Add pmetrics.Namespace to the identifier mapping.
- Add per-object subsystem sort ordering and stability level entries.

**How was this change tested?**

Updated the docs as evidence of success


**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.