### PR TITLE
feat: allow callers to specify custom IAM path for instance profiles

### DIFF
--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -169,7 +169,8 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 }
 
 func (c *Controller) cleanupInstanceProfiles(ctx context.Context, nodeClass *v1.EC2NodeClass) error {
-	out, err := c.instanceProfileProvider.ListNodeClassProfiles(ctx, nodeClass)
+	pathPrefix := instanceprofile.FormatPath("karpenter", c.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID))
+	out, err := c.instanceProfileProvider.ListProfiles(ctx, pathPrefix)
 
 	if err != nil {
 		return fmt.Errorf("listing instance profiles, %w", err)

--- a/pkg/controllers/nodeclass/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclass/garbagecollection/controller.go
@@ -32,6 +32,7 @@ import (
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
 )
 
@@ -111,7 +112,8 @@ func (c *Controller) cleanupInactiveProfiles(ctx context.Context) error {
 		return err
 	}
 
-	profiles, err := c.instanceProfileProvider.ListClusterProfiles(ctx)
+	clusterPathPrefix := instanceprofile.FormatPath("karpenter", c.region, options.FromContext(ctx).ClusterName)
+	profiles, err := c.instanceProfileProvider.ListProfiles(ctx, clusterPathPrefix)
 	if err != nil {
 		return fmt.Errorf("listing instance profiles, %w", err)
 	}

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -84,8 +84,7 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 				newProfileName,
 				nodeClass.InstanceProfileRole(),
 				nodeClass.InstanceProfileTags(options.FromContext(ctx).ClusterName, ip.region),
-				string(nodeClass.UID),
-				true,
+				instanceprofile.FormatPath("karpenter", ip.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID)),
 			); err != nil {
 				// If we failed Create, we may have successfully created the instance profile but failed to either attach the new
 				// role or remove the existing role. To prevent runaway instance profile creation, we'll attempt to delete the

--- a/pkg/providers/instanceprofile/instanceprofile.go
+++ b/pkg/providers/instanceprofile/instanceprofile.go
@@ -26,9 +26,6 @@ import (
 	cache "github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 
-	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
-
-	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
 	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/aws/karpenter-provider-aws/pkg/utils"
@@ -36,10 +33,9 @@ import (
 
 type Provider interface {
 	Get(context.Context, string) (*iamtypes.InstanceProfile, error)
-	Create(context.Context, string, string, map[string]string, string, bool) error
+	Create(context.Context, string, string, map[string]string, string) error
 	Delete(context.Context, string) error
-	ListClusterProfiles(context.Context) ([]*iamtypes.InstanceProfile, error)
-	ListNodeClassProfiles(context.Context, *v1.EC2NodeClass) ([]*iamtypes.InstanceProfile, error)
+	ListProfiles(context.Context, string) ([]*iamtypes.InstanceProfile, error)
 	IsProtected(string) bool
 	SetProtectedState(string, bool)
 }
@@ -72,6 +68,15 @@ func GetProfileCacheKey(profileName string) string {
 	return "instance-profile:" + profileName
 }
 
+// FormatPath builds an IAM path from segments, e.g. FormatPath("karpenter", region, clusterName, nodeClassUID)
+// returns "/karpenter/{region}/{clusterName}/{nodeClassUID}/".
+func FormatPath(segments ...string) string {
+	if len(segments) == 0 {
+		return "/"
+	}
+	return "/" + strings.Join(segments, "/") + "/"
+}
+
 func (p *DefaultProvider) Get(ctx context.Context, instanceProfileName string) (*iamtypes.InstanceProfile, error) {
 	profileCacheKey := GetProfileCacheKey(instanceProfileName)
 	if instanceProfile, ok := p.instanceProfileCache.Get(profileCacheKey); ok {
@@ -92,8 +97,7 @@ func (p *DefaultProvider) Create(
 	instanceProfileName string,
 	roleName string,
 	tags map[string]string,
-	nodeClassUID string,
-	usePath bool,
+	path string,
 ) error {
 	// Don't attempt to create an instance profile if the role hasn't been found. This prevents runaway instance profile
 	// creation by the NodeClass controller when there's a missing role.
@@ -112,8 +116,8 @@ func (p *DefaultProvider) Create(
 			InstanceProfileName: lo.ToPtr(instanceProfileName),
 			Tags:                utils.IAMMergeTags(tags),
 		}
-		if usePath {
-			input.Path = lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/%s/", p.region, options.FromContext(ctx).ClusterName, nodeClassUID))
+		if path != "" {
+			input.Path = lo.ToPtr(path)
 		}
 		o, err := p.iamapi.CreateInstanceProfile(ctx, input)
 		if err != nil {
@@ -209,27 +213,9 @@ func (p *DefaultProvider) Delete(ctx context.Context, instanceProfileName string
 	return nil
 }
 
-func (p *DefaultProvider) ListClusterProfiles(ctx context.Context) ([]*iamtypes.InstanceProfile, error) {
+func (p *DefaultProvider) ListProfiles(ctx context.Context, pathPrefix string) ([]*iamtypes.InstanceProfile, error) {
 	input := &iam.ListInstanceProfilesInput{
-		PathPrefix: lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/", p.region, options.FromContext(ctx).ClusterName)),
-	}
-
-	paginator := iam.NewListInstanceProfilesPaginator(p.iamapi, input)
-
-	var profiles []*iamtypes.InstanceProfile
-	for paginator.HasMorePages() {
-		out, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("listing instance profiles, %w", err)
-		}
-		profiles = append(profiles, lo.ToSlicePtr(out.InstanceProfiles)...)
-	}
-	return profiles, nil
-}
-
-func (p *DefaultProvider) ListNodeClassProfiles(ctx context.Context, nodeClass *v1.EC2NodeClass) ([]*iamtypes.InstanceProfile, error) {
-	input := &iam.ListInstanceProfilesInput{
-		PathPrefix: lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/%s/", p.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
+		PathPrefix: lo.ToPtr(pathPrefix),
 	}
 
 	paginator := iam.NewListInstanceProfilesPaginator(p.iamapi, input)

--- a/pkg/providers/instanceprofile/suite_test.go
+++ b/pkg/providers/instanceprofile/suite_test.go
@@ -109,12 +109,15 @@ var _ = AfterEach(func() {
 })
 
 var _ = Describe("InstanceProfileProvider", func() {
+	karpenterPath := func(nodeClassUID string) string {
+		return instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, nodeClassUID)
+	}
 	DescribeTable(
 		"should support IAM roles",
 		func(roleWithPath, role string) {
 			const profileName = "profile-A"
 			nodeClass.Spec.Role = roleWithPath
-			Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, role, nil, string(nodeClass.UID), true)).To(Succeed())
+			Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, role, nil, karpenterPath(string(nodeClass.UID)))).To(Succeed())
 			Expect(profileName).ToNot(BeNil())
 			Expect(awsEnv.IAMAPI.InstanceProfiles[profileName].Roles).To(HaveLen(1))
 			Expect(aws.ToString(awsEnv.IAMAPI.InstanceProfiles[profileName].Roles[0].RoleName)).To(Equal(role))
@@ -122,6 +125,17 @@ var _ = Describe("InstanceProfileProvider", func() {
 		Entry("with custom paths", fmt.Sprintf("CustomPath/%s", nodeRole), nodeRole),
 		Entry("without custom paths", nodeRole, nodeRole),
 	)
+
+	It("should create an instance profile without a path when path is empty", func() {
+		const profileName = "profile-no-path"
+		Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, nodeRole, nil, "")).To(Succeed())
+
+		profile, err := awsEnv.InstanceProfileProvider.Get(ctx, profileName)
+		Expect(err).To(BeNil())
+		Expect(aws.ToString(profile.InstanceProfileName)).To(Equal(profileName))
+		// When path is empty, the profile should not have a custom path set
+		Expect(profile.Path).To(BeNil())
+	})
 
 	It("should list all instance profiles for a NodeClass", func() {
 		// Create and apply first NodeClass
@@ -161,7 +175,7 @@ var _ = Describe("InstanceProfileProvider", func() {
 						RoleName: aws.String("role-1"),
 					},
 				},
-				Path: lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/%s/", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass1.UID))),
+				Path: lo.ToPtr(karpenterPath(string(nodeClass1.UID))),
 			},
 			profile2: {
 				InstanceProfileName: lo.ToPtr(profile2),
@@ -171,12 +185,12 @@ var _ = Describe("InstanceProfileProvider", func() {
 						RoleName: aws.String("role-2"),
 					},
 				},
-				Path: lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/%s/", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass2.UID))),
+				Path: lo.ToPtr(karpenterPath(string(nodeClass2.UID))),
 			},
 		}
 
 		// List profiles for first NodeClass
-		profiles, err := awsEnv.InstanceProfileProvider.ListNodeClassProfiles(ctx, &nodeClass1.EC2NodeClass)
+		profiles, err := awsEnv.InstanceProfileProvider.ListProfiles(ctx, karpenterPath(string(nodeClass1.UID)))
 		Expect(err).To(BeNil())
 
 		// Should only get profiles for first NodeClass
@@ -227,7 +241,7 @@ var _ = Describe("InstanceProfileProvider", func() {
 						RoleName: aws.String("role-1"),
 					},
 				},
-				Path: lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/%s/", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass1.UID))),
+				Path: lo.ToPtr(karpenterPath(string(nodeClass1.UID))),
 			},
 			profile2: {
 				InstanceProfileName: lo.ToPtr(profile2),
@@ -237,7 +251,7 @@ var _ = Describe("InstanceProfileProvider", func() {
 						RoleName: aws.String("role-2"),
 					},
 				},
-				Path: lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/%s/", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass2.UID))),
+				Path: lo.ToPtr(karpenterPath(string(nodeClass2.UID))),
 			},
 			profile3: {
 				InstanceProfileName: lo.ToPtr(profile3),
@@ -247,12 +261,13 @@ var _ = Describe("InstanceProfileProvider", func() {
 						RoleName: aws.String("role-3"),
 					},
 				},
-				Path: lo.ToPtr(fmt.Sprintf("/karpenter/%s/%s/%s/", fake.DefaultRegion, options.FromContext(otherClusterCtx).ClusterName, "some-uid")),
+				Path: lo.ToPtr(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(otherClusterCtx).ClusterName, "some-uid")),
 			},
 		}
 
 		// List all cluster profiles
-		profiles, err := awsEnv.InstanceProfileProvider.ListClusterProfiles(ctx)
+		clusterPath := instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName)
+		profiles, err := awsEnv.InstanceProfileProvider.ListProfiles(ctx, clusterPath)
 		Expect(err).To(BeNil())
 
 		// Should get both profiles in first cluster and not the other one
@@ -269,9 +284,9 @@ var _ = Describe("InstanceProfileProvider", func() {
 		// Create instance profile
 		profileName := "profile-A"
 		nodeClassUID := "test-uid"
-		expectedPath := fmt.Sprintf("/karpenter/%s/%s/%s/", fake.DefaultRegion, options.FromContext(ctx).ClusterName, nodeClassUID)
+		expectedPath := karpenterPath(nodeClassUID)
 
-		Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, nodeRole, nil, nodeClassUID, true)).To(Succeed())
+		Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, nodeRole, nil, expectedPath)).To(Succeed())
 
 		// Get the created profile
 		profile, err := awsEnv.InstanceProfileProvider.Get(ctx, profileName)
@@ -289,7 +304,7 @@ var _ = Describe("InstanceProfileProvider", func() {
 		profileName := "profile-A"
 		nodeClassUID := "test-uid"
 
-		Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, nodeRole, nil, nodeClassUID, true)).To(Succeed())
+		Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, nodeRole, nil, karpenterPath(nodeClassUID))).To(Succeed())
 
 		// Verify profile exists
 		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveKey(profileName))
@@ -310,7 +325,7 @@ var _ = Describe("InstanceProfileProvider", func() {
 	It("should reflect IsProtected updates", func() {
 		// Create a profile
 		profileName := "profile-A"
-		Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, nodeRole, nil, "test-uid", true)).To(Succeed())
+		Expect(awsEnv.InstanceProfileProvider.Create(ctx, profileName, nodeRole, nil, karpenterPath("test-uid"))).To(Succeed())
 
 		// Initially should not be protected (protection is set in instance profile reconciler)
 		Expect(awsEnv.InstanceProfileProvider.IsProtected(profileName)).To(BeFalse())
@@ -327,13 +342,13 @@ var _ = Describe("InstanceProfileProvider", func() {
 	It("should not update instance profile cache item on multiple create calls", func() {
 		roleName := "test-role"
 		profileName := "test-profile"
-		err := awsEnv.InstanceProfileProvider.Create(ctx, profileName, roleName, nil, "test-uid", true)
+		err := awsEnv.InstanceProfileProvider.Create(ctx, profileName, roleName, nil, karpenterPath("test-uid"))
 		_, initialExpirationTime, found := awsEnv.InstanceProfileCache.GetWithExpiration(instanceprofile.GetProfileCacheKey(profileName))
 		Expect(found).To(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 		time.Sleep(time.Second)
 
-		err = awsEnv.InstanceProfileProvider.Create(ctx, profileName, roleName, nil, "test-uid", true)
+		err = awsEnv.InstanceProfileProvider.Create(ctx, profileName, roleName, nil, karpenterPath("test-uid"))
 		Expect(err).ToNot(HaveOccurred())
 		_, expirationTime, found := awsEnv.InstanceProfileCache.GetWithExpiration(instanceprofile.GetProfileCacheKey(profileName))
 		Expect(found).To(BeTrue())
@@ -349,14 +364,14 @@ var _ = Describe("InstanceProfileProvider", func() {
 			}
 		})
 		It("should not cache role not found errors when the role exists", func() {
-			err := awsEnv.InstanceProfileProvider.Create(ctx, "test-profile", roleName, nil, "test-uid", true)
+			err := awsEnv.InstanceProfileProvider.Create(ctx, "test-profile", roleName, nil, karpenterPath("test-uid"))
 			Expect(err).ToNot(HaveOccurred())
 			_, ok := awsEnv.RoleCache.Get(roleName)
 			Expect(ok).To(BeFalse())
 		})
 		It("should cache role not found errors when the role does not", func() {
 			missingRoleName := "non-existent-role"
-			err := awsEnv.InstanceProfileProvider.Create(ctx, "test-profile", missingRoleName, nil, "test-uid", true)
+			err := awsEnv.InstanceProfileProvider.Create(ctx, "test-profile", missingRoleName, nil, karpenterPath("test-uid"))
 			Expect(err).To(HaveOccurred())
 			_, ok := awsEnv.RoleCache.Get(missingRoleName)
 			Expect(ok).To(BeTrue())
@@ -365,11 +380,24 @@ var _ = Describe("InstanceProfileProvider", func() {
 			missingRoleName := "non-existent-role"
 			awsEnv.RoleCache.SetDefault(missingRoleName, errors.New("role not found"))
 
-			err := awsEnv.InstanceProfileProvider.Create(ctx, "test-profile", missingRoleName, nil, "test-uid", true)
+			err := awsEnv.InstanceProfileProvider.Create(ctx, "test-profile", missingRoleName, nil, karpenterPath("test-uid"))
 			Expect(err).To(HaveOccurred())
 
 			Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(0))
 			Expect(awsEnv.IAMAPI.CreateInstanceProfileBehavior.Calls()).To(BeZero())
 		})
 	})
+})
+
+var _ = Describe("FormatPath", func() {
+	DescribeTable("should format IAM paths",
+		func(expected string, segments ...string) {
+			Expect(instanceprofile.FormatPath(segments...)).To(Equal(expected))
+		},
+		Entry("no segments", "/"),
+		Entry("single segment", "/eks/", "eks"),
+		Entry("two segments", "/eks/us-west-2/", "eks", "us-west-2"),
+		Entry("three segments", "/karpenter/us-west-2/my-cluster/", "karpenter", "us-west-2", "my-cluster"),
+		Entry("four segments", "/karpenter/us-west-2/my-cluster/uid/", "karpenter", "us-west-2", "my-cluster", "uid"),
+	)
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Changes `instanceprofile.Provider.Create()` to accept a `path string` parameter instead of `usePath bool`
- When `path` is non-empty, it is set directly on the `CreateInstanceProfile` input, allowing downstream consumers to specify custom IAM path prefixes
- The upstream karpenter-provider-aws caller now explicitly passes the `/karpenter/{region}/{clusterName}/{nodeClassUID}/` path string

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.