### PR TITLE
ci: scope website preview deploys to PRs with website changes

### DIFF
--- a/.github/workflows/website-preview-trigger.yaml
+++ b/.github/workflows/website-preview-trigger.yaml
@@ -2,6 +2,7 @@ name: WebsitePreviewTrigger
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths: [ website/** ]
 jobs:
   preview-trigger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `paths: [ website/** ]` filter to the `WebsitePreviewTrigger` workflow so Amplify preview branches are only created for PRs that modify website content.
- This matches the path filter already used by the production `website-deploy` workflow.

## Problem

The preview trigger fires on every PR open/sync/reopen, creating an Amplify branch regardless of whether the PR touches the website. With ~100 open PRs and a default Amplify branch limit of 50, this causes `CreateBranch` failures:

```
BadRequestException: Failed to create branch. You have reached the maximum number of branches in this app.
```

Example failure: https://github.com/aws/karpenter-provider-aws/actions/runs/25075922219/job/73468339435

## Follow-up

A separate PR will add a scheduled sweeper workflow to clean up orphaned Amplify preview branches for PRs that have already closed.