### PR TITLE
docs: Fix IAM Policy in Getting Started Guide for ARC Zonal Shift integration

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
@@ -221,8 +221,15 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
     {
       "Sid": "AllowZonalShiftStatusReadOnly",
       "Effect": "Allow",
-      "Resource": "arn:aws:eks:<region>:<account-id>:cluster/<cluster-name>",
-      "Action": "arc-zonal-shift:GetManagedResource"
+      "Resource": "*",
+      "Action": [
+        "arc-zonal-shift:GetManagedResource"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "arc-zonal-shift:ResourceIdentifier": "arn:aws:eks:<region>:<account-id>:cluster/<cluster-name>"
+        }
+      }   
     }
     ```
 

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -306,10 +306,15 @@ Resources:
             {
               "Sid": "AllowZonalShiftStatusReadOnly",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Resource": "*",
               "Action": [
                 "arc-zonal-shift:GetManagedResource"
-              ]
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "arc-zonal-shift:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+                }
+              } 
             }
           ]
         }

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
@@ -29,6 +29,7 @@ iam:
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerEKSIntegrationPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerInterruptionPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerResourceDiscoveryPolicy-${CLUSTER_NAME}
+    - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerZonalShiftPolicy-${CLUSTER_NAME}
     roleOnly: true
 
 iamIdentityMappings:

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -28,6 +28,7 @@ iam:
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerEKSIntegrationPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerInterruptionPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerResourceDiscoveryPolicy-${CLUSTER_NAME}
+    - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerZonalShiftPolicy-${CLUSTER_NAME}
 
 iamIdentityMappings:
 - arn: "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}"

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -505,10 +505,15 @@ For the cluster that will be created (`arn:${AWS::Partition}:eks:${AWS::Region}:
 {
   "Sid": "AllowZonalShiftStatusReadOnly",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+  "Resource": "*",
   "Action": [
     "arc-zonal-shift:GetManagedResource"
-  ]
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+    }
+  }
 }
 ```
 

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -221,8 +221,15 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
     {
       "Sid": "AllowZonalShiftStatusReadOnly",
       "Effect": "Allow",
-      "Resource": "arn:aws:eks:<region>:<account-id>:cluster/<cluster-name>",
-      "Action": "arc-zonal-shift:GetManagedResource"
+      "Resource": "*",
+      "Action": [
+        "arc-zonal-shift:GetManagedResource"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "arc-zonal-shift:ResourceIdentifier": "arn:aws:eks:<region>:<account-id>:cluster/<cluster-name>"
+        }
+      }
     }
     ```
 

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -306,10 +306,15 @@ Resources:
             {
               "Sid": "AllowZonalShiftStatusReadOnly",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Resource": "*",
               "Action": [
                 "arc-zonal-shift:GetManagedResource"
-              ]
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "arc-zonal-shift:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+                }
+              }
             }
           ]
         }

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
@@ -29,6 +29,7 @@ iam:
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerEKSIntegrationPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerInterruptionPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerResourceDiscoveryPolicy-${CLUSTER_NAME}
+    - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerZonalShiftPolicy-${CLUSTER_NAME}
     roleOnly: true
 
 iamIdentityMappings:

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -28,6 +28,7 @@ iam:
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerEKSIntegrationPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerInterruptionPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerResourceDiscoveryPolicy-${CLUSTER_NAME}
+    - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerZonalShiftPolicy-${CLUSTER_NAME}
 
 iamIdentityMappings:
 - arn: "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}"

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -502,7 +502,7 @@ This section of the cloudformation.yaml template can give Karpenter permission t
 For the cluster that will be created (`arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}`), the AllowZonalShiftActions Sid lets the Karpenter controller have permission to get the Zonal Shift status of the cluster ([GetManagedResource](https://docs.aws.amazon.com/arc-zonal-shift/latest/api/API_GetManagedResource.html)).
 
 ```json
-            {
+{
   "Sid": "AllowZonalShiftStatusReadOnly",
   "Effect": "Allow",
   "Resource": "*",

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -502,13 +502,18 @@ This section of the cloudformation.yaml template can give Karpenter permission t
 For the cluster that will be created (`arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}`), the AllowZonalShiftActions Sid lets the Karpenter controller have permission to get the Zonal Shift status of the cluster ([GetManagedResource](https://docs.aws.amazon.com/arc-zonal-shift/latest/api/API_GetManagedResource.html)).
 
 ```json
-{
+            {
   "Sid": "AllowZonalShiftStatusReadOnly",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+  "Resource": "*",
   "Action": [
     "arc-zonal-shift:GetManagedResource"
-  ]
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+    }
+  }
 }
 ```
 

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
@@ -221,8 +221,15 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
     {
       "Sid": "AllowZonalShiftStatusReadOnly",
       "Effect": "Allow",
-      "Resource": "arn:aws:eks:<region>:<account-id>:cluster/<cluster-name>",
-      "Action": "arc-zonal-shift:GetManagedResource"
+      "Resource": "*",
+      "Action": [
+        "arc-zonal-shift:GetManagedResource"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "arc-zonal-shift:ResourceIdentifier": "arn:aws:eks:<region>:<account-id>:cluster/<cluster-name>"
+        }
+      }
     }
     ```
 

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -306,10 +306,15 @@ Resources:
             {
               "Sid": "AllowZonalShiftStatusReadOnly",
               "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Resource": "*",
               "Action": [
                 "arc-zonal-shift:GetManagedResource"
-              ]
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "arc-zonal-shift:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+                }
+              }
             }
           ]
         }

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster-fargate.sh
@@ -29,6 +29,7 @@ iam:
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerEKSIntegrationPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerInterruptionPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerResourceDiscoveryPolicy-${CLUSTER_NAME}
+    - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerZonalShiftPolicy-${CLUSTER_NAME}
     roleOnly: true
 
 iamIdentityMappings:

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -28,6 +28,7 @@ iam:
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerEKSIntegrationPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerInterruptionPolicy-${CLUSTER_NAME}
     - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerResourceDiscoveryPolicy-${CLUSTER_NAME}
+    - arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerZonalShiftPolicy-${CLUSTER_NAME}
 
 iamIdentityMappings:
 - arn: "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}"

--- a/website/content/en/v1.12/reference/cloudformation.md
+++ b/website/content/en/v1.12/reference/cloudformation.md
@@ -505,10 +505,15 @@ For the cluster that will be created (`arn:${AWS::Partition}:eks:${AWS::Region}:
 {
   "Sid": "AllowZonalShiftStatusReadOnly",
   "Effect": "Allow",
-  "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+  "Resource": "*",
   "Action": [
     "arc-zonal-shift:GetManagedResource"
-  ]
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #9118

**Description**

Fixes the incorrect IAM policy for utilizing zonal shift in Karpenter. Docs updated for v1.12 (latest) and preview

**How was this change tested?**

Deployed to a personal AWS account. 

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.