### PR TITLE
test: prevent AL2023 AMI tests from being incorrectly skipped on K8s > 1.32

### DIFF
--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -220,7 +220,7 @@ var _ = Describe("AMI", func() {
 		DescribeTable(
 			"should provision a node using an alias",
 			func(alias string) {
-				if strings.Contains(alias, "al2") && env.K8sMinorVersion() > 32 {
+				if strings.HasPrefix(alias, "al2@") && env.K8sMinorVersion() > 32 {
 					Skip("AL2 is not supported on versions > 1.32")
 				}
 				pod := coretest.Pod()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The AMI test at
https://github.com/aws/karpenter-provider-aws/blob/a777942fbefc645fdadc80784ded852f5527c9cf/test/suites/ami/suite_test.go#L223
has an incorrect check for AL2 AMIs. It checks whether the alias contains the substring `al2` but this also matches for `al2023` AMIs resulting in them being incorrectly skipped.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.