### PR TITLE
fix: zonal shift changes shouldn't hit stale offerings cache

### DIFF
--- a/pkg/providers/arczonalshift/arczonalshift.go
+++ b/pkg/providers/arczonalshift/arczonalshift.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
 	arczonalshifttypes "github.com/aws/aws-sdk-go-v2/service/arczonalshift/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -31,6 +32,7 @@ import (
 type Provider interface {
 	IsZonalShifted(context.Context, string) bool
 	UpdateZonalShifts(context.Context) error
+	ShiftedZones() sets.Set[string]
 }
 
 type DefaultProvider struct {
@@ -103,4 +105,16 @@ func (p *DefaultProvider) IsZonalShifted(ctx context.Context, zoneId string) boo
 	}
 
 	return false
+}
+
+func (p *DefaultProvider) ShiftedZones() sets.Set[string] {
+	p.RLock()
+	defer p.RUnlock()
+	shifted := sets.New[string]()
+	for zoneID, status := range p.zonalShiftStatuses {
+		if status.shiftExpiry.After(p.clk.Now()) && status.applied {
+			shifted.Insert(zoneID)
+		}
+	}
+	return shifted
 }

--- a/pkg/providers/arczonalshift/arczonalshiftnoop.go
+++ b/pkg/providers/arczonalshift/arczonalshiftnoop.go
@@ -16,11 +16,14 @@ package arczonalshift
 
 import (
 	"context"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type NoopProvider interface {
 	IsZonalShifted(context.Context, string) bool
 	UpdateZonalShifts(context.Context) error
+	ShiftedZones() sets.Set[string]
 }
 
 type DefaultNoopProvider struct {
@@ -36,4 +39,8 @@ func (p *DefaultNoopProvider) UpdateZonalShifts(ctx context.Context) error {
 
 func (p *DefaultNoopProvider) IsZonalShifted(ctx context.Context, zoneId string) bool {
 	return false
+}
+
+func (p *DefaultNoopProvider) ShiftedZones() sets.Set[string] {
+	return sets.New[string]()
 }

--- a/pkg/providers/instancetype/offering/offering.go
+++ b/pkg/providers/instancetype/offering/offering.go
@@ -95,6 +95,8 @@ func (p *DefaultProvider) InjectOfferings(
 		pg, _ = p.placementGroupProvider.Get(ctx, nodeClass)
 	}
 	var its []*cloudprovider.InstanceType
+	shiftedZones := p.zonalshiftProvider.ShiftedZones()
+
 	for _, it := range instanceTypes {
 		info := instanceTypeInfo[ec2types.InstanceType(it.Name)]
 		offerings := p.createOfferings(
@@ -104,6 +106,7 @@ func (p *DefaultProvider) InjectOfferings(
 			nodeClass,
 			pg,
 			allZones,
+			shiftedZones,
 		)
 		// For partition placement groups, expand each offering into N offerings (one per partition)
 		offerings = p.expandPartitionOfferings(offerings, pg)
@@ -144,6 +147,7 @@ func (p *DefaultProvider) createOfferings(
 	nodeClass NodeClass,
 	pg *placementgroup.PlacementGroup,
 	allZones sets.Set[string],
+	shiftedZones sets.Set[string],
 ) cloudprovider.Offerings {
 	var offerings []*cloudprovider.Offering
 	itZones := sets.New(it.Requirements.Get(corev1.LabelTopologyZone).Values()...)
@@ -158,7 +162,7 @@ func (p *DefaultProvider) createOfferings(
 		lastSeqNum = 0
 	}
 	seqNum := p.unavailableOfferings.SeqNum(ec2types.InstanceType(it.Name))
-	if ofs, ok := p.cache.Get(p.cacheKeyFromInstanceType(it, nodeClass)); ok && lastSeqNum == seqNum {
+	if ofs, ok := p.cache.Get(p.cacheKeyFromInstanceType(it, nodeClass, shiftedZones)); ok && lastSeqNum == seqNum {
 		offerings = append(offerings, ofs.([]*cloudprovider.Offering)...)
 	} else {
 		var pgOpts []awscache.UnavailableOfferingsOption
@@ -214,7 +218,7 @@ func (p *DefaultProvider) createOfferings(
 				cachedOfferings = append(cachedOfferings, offering)
 			}
 		}
-		p.cache.SetDefault(p.cacheKeyFromInstanceType(it, nodeClass), cachedOfferings)
+		p.cache.SetDefault(p.cacheKeyFromInstanceType(it, nodeClass, shiftedZones), cachedOfferings)
 		p.lastUnavailableOfferingsSeqNum.Store(ec2types.InstanceType(it.Name), seqNum)
 		offerings = append(offerings, cachedOfferings...)
 	}
@@ -288,7 +292,7 @@ func (p *DefaultProvider) expandPartitionOfferings(offerings cloudprovider.Offer
 	return expanded
 }
 
-func (p *DefaultProvider) cacheKeyFromInstanceType(it *cloudprovider.InstanceType, nodeClass NodeClass) string {
+func (p *DefaultProvider) cacheKeyFromInstanceType(it *cloudprovider.InstanceType, nodeClass NodeClass, shiftedZones sets.Set[string]) string {
 	zonesHash, _ := hashstructure.Hash(
 		it.Requirements.Get(corev1.LabelTopologyZone).Values(),
 		hashstructure.FormatV2,
@@ -312,13 +316,19 @@ func (p *DefaultProvider) cacheKeyFromInstanceType(it *cloudprovider.InstanceTyp
 		hashstructure.FormatV2,
 		&hashstructure.HashOptions{SlicesAsSets: true},
 	)
+	shiftedZonesHash, _ := hashstructure.Hash(
+		shiftedZones,
+		hashstructure.FormatV2,
+		&hashstructure.HashOptions{SlicesAsSets: true},
+	)
 	return fmt.Sprintf(
-		"%s-%016x-%016x-%016x-%016x-%016x",
+		"%s-%016x-%016x-%016x-%016x-%016x-%016x",
 		it.Name,
 		zonesHash,
 		capacityTypesHash,
 		networkInterfaceHash,
 		subnetsHash,
 		placementGroupPartitionsHash,
+		shiftedZonesHash,
 	)
 }

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
+	arczonalshifttypes "github.com/aws/aws-sdk-go-v2/service/arczonalshift/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/awslabs/operatorpkg/object"
@@ -3037,6 +3039,41 @@ var _ = Describe("InstanceTypeProvider", func() {
 			Entry("when the capacity block is active", v1.CapacityReservationStateActive),
 			Entry("when the capacity block is expiring", v1.CapacityReservationStateExpiring),
 		)
+	})
+	It("should mark offerings as unavailable for zones shifted away from", func() {
+		ExpectApplied(ctx, env.Client, nodeClass)
+
+		// before zonal shift, all offerings should be avaialble
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+		m5InstanceType, ok := lo.Find(instanceTypes, func(it *corecloudprovider.InstanceType) bool {
+			return it.Name == string(ec2types.InstanceTypeM5Large)
+		})
+		Expect(ok).To(BeTrue())
+		Expect(m5InstanceType.Offerings.Available()).To(HaveLen(6)) // 3 zones x 2 capacity types
+
+		awsEnv.ARCZonalShiftAPI.GetManagedResourceBehavior.Output.Set(&arczonalshift.GetManagedResourceOutput{
+			ZonalShifts: []arczonalshifttypes.ZonalShiftInResource{
+				{
+					AwayFrom:      aws.String("tstz1-1a"),
+					ExpiryTime:    aws.Time(time.Now().Add(time.Hour)),
+					AppliedStatus: arczonalshifttypes.AppliedStatusApplied,
+				},
+			},
+		})
+		Expect(awsEnv.ZonalShiftProvider.UpdateZonalShifts(ctx)).To(Succeed())
+
+		// after zonal shift, 2 offerings should be unavaialble
+		instanceTypes, err = cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+		m5InstanceType, ok = lo.Find(instanceTypes, func(it *corecloudprovider.InstanceType) bool {
+			return it.Name == string(ec2types.InstanceTypeM5Large)
+		})
+		Expect(ok).To(BeTrue())
+		Expect(m5InstanceType.Offerings.Available()).To(HaveLen(4))
+		for _, offering := range m5InstanceType.Offerings.Available() {
+			Expect(offering.Zone()).ToNot(Equal("test-zone-1a"))
+		}
 	})
 	Context("Instance Type and NodeClass Compatibility", func() {
 		Context("AMI Compatibility", func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3043,7 +3043,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 	It("should mark offerings as unavailable for zones shifted away from", func() {
 		ExpectApplied(ctx, env.Client, nodeClass)
 
-		// before zonal shift, all offerings should be avaialble
+		// before zonal shift, all offerings should be available
 		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
 		Expect(err).ToNot(HaveOccurred())
 		m5InstanceType, ok := lo.Find(instanceTypes, func(it *corecloudprovider.InstanceType) bool {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3074,6 +3074,19 @@ var _ = Describe("InstanceTypeProvider", func() {
 		for _, offering := range m5InstanceType.Offerings.Available() {
 			Expect(offering.Zone()).ToNot(Equal("test-zone-1a"))
 		}
+
+		// shift back into the zone, all offerings should be available again
+		awsEnv.ARCZonalShiftAPI.GetManagedResourceBehavior.Output.Set(&arczonalshift.GetManagedResourceOutput{
+			ZonalShifts: []arczonalshifttypes.ZonalShiftInResource{},
+		})
+		Expect(awsEnv.ZonalShiftProvider.UpdateZonalShifts(ctx)).To(Succeed())
+		instanceTypes, err = cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+		m5InstanceType, ok = lo.Find(instanceTypes, func(it *corecloudprovider.InstanceType) bool {
+			return it.Name == string(ec2types.InstanceTypeM5Large)
+		})
+		Expect(ok).To(BeTrue())
+		Expect(m5InstanceType.Offerings.Available()).To(HaveLen(6))
 	})
 	Context("Instance Type and NodeClass Compatibility", func() {
 		Context("AMI Compatibility", func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3063,7 +3063,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 		})
 		Expect(awsEnv.ZonalShiftProvider.UpdateZonalShifts(ctx)).To(Succeed())
 
-		// after zonal shift, 2 offerings should be unavaialble
+		// after zonal shift, 2 offerings should be available
 		instanceTypes, err = cloudProvider.GetInstanceTypes(ctx, nodePool)
 		Expect(err).ToNot(HaveOccurred())
 		m5InstanceType, ok = lo.Find(instanceTypes, func(it *corecloudprovider.InstanceType) bool {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Previously during a zonal shift, Karpenter would used cached offerings which could include outdated availability information (since zonal shift is reflected in availability). This could result in instance launches into the zone that is shifted away.

e.g.
1. ListOfferings is called (during provisioning or consolidation) -> offerings cache is hydrated
2. Zonal Shift is Triggered
3. On attempt to provision new instances, offerings which should be marked unavailable due to the zonal shift stay available. This could result in instance launches into the impaired AZ.

This PR fixes that by reflected zonal shifts in the offerings cache key.

**How was this change tested?**
* `make presubmit` and a unit tests which exercises caching path

**Unit Test Before**
```
InstanceTypeProvider should mark offerings as unavailable for zones shifted away from
/Users/ryanmist/desktop/karp/karpenter-provider-aws/pkg/providers/instancetype/suite_test.go:3043
  [FAILED] in [It] - /Users/ryanmist/desktop/karp/karpenter-provider-aws/pkg/providers/instancetype/suite_test.go:3073 @ 05/01/26 10:09:24.847
• [FAILED] [3.105 seconds]
InstanceTypeProvider [It] should mark offerings as unavailable for zones shifted away from
/Users/ryanmist/desktop/karp/karpenter-provider-aws/pkg/providers/instancetype/suite_test.go:3043

  [FAILED] Expected
      <cloudprovider.Offerings | len:6, cap:8>: [
          {
...
  to have length 4
  In [It] at: /Users/ryanmist/desktop/karp/karpenter-provider-aws/pkg/providers/instancetype/suite_test.go:3073 @ 05/01/26 10:09:24.847
```

**Unit Test After**
```
------------------------------
InstanceTypeProvider should mark offerings as unavailable for zones shifted away from
/Users/ryanmist/desktop/karp/karpenter-provider-aws/pkg/providers/instancetype/suite_test.go:3043
• [3.139 seconds]
------------------------------
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.