### PR TITLE
fix: isolate PR checkout in website-preview workflow

### DIFF
--- a/.github/actions/deploy-website/action.yml
+++ b/.github/actions/deploy-website/action.yml
@@ -24,13 +24,17 @@ inputs:
     description: 'Base URL for Hugo build'
     required: false
     default: ''
+  content-path:
+    description: 'Path to the checked-out content (relative to workspace root)'
+    required: false
+    default: '.'
 runs:
   using: 'composite'
   steps:
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version-file: hack/docs/parse-redirects/go.mod
+        go-version-file: ${{ inputs.content-path }}/hack/docs/parse-redirects/go.mod
         check-latest: true
     - name: Install Hugo
       uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2.6.0
@@ -38,7 +42,7 @@ runs:
         hugo-version: '0.120.3'
         extended: true
     - name: Build Hugo site (preview)
-      working-directory: website
+      working-directory: ${{ inputs.content-path }}/website
       shell: bash
       env:
         HUGO_ENV: production
@@ -51,7 +55,7 @@ runs:
         npm ci --prefer-offline
         hugo --gc --minify --buildFuture -b "${{ inputs.hugo-base-url }}"
     - name: Build Hugo site (production) 
-      working-directory: website
+      working-directory: ${{ inputs.content-path }}/website
       shell: bash
       env:
         HUGO_ENV: production
@@ -72,7 +76,7 @@ runs:
       shell: bash
       run: |
         S3_PATH="s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}"
-        aws s3 sync website/public/ "$S3_PATH" --delete
+        aws s3 sync ${{ inputs.content-path }}/website/public/ "$S3_PATH" --delete
     - name: Create Amplify branch (if preview and doesn't exist)
       shell: bash
       if: github.event_name == 'workflow_run'
@@ -85,7 +89,7 @@ runs:
     - name: Configure redirects
       shell: bash
       run: |
-        REDIRECT_RULES=$(go run hack/docs/parse-redirects/main.go)
+        REDIRECT_RULES=$(go run ${{ inputs.content-path }}/hack/docs/parse-redirects/main.go)
         aws amplify update-app \
           --app-id ${{ inputs.amplify-app-id }} \
           --custom-rules "$REDIRECT_RULES"

--- a/.github/workflows/website-preview.yaml
+++ b/.github/workflows/website-preview.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ env.PR_COMMIT }}
+          path: pr-content
       - uses: ./.github/actions/commit-status/start
         with:
           name: "${{ github.workflow }} / ${{ github.job }} (pull_request_review)"
@@ -50,6 +51,7 @@ jobs:
           s3-bucket: ${{ vars.AMPLIFY_S3_BUCKET_BETA }}
           s3-prefix: pr-${{ env.PR_NUMBER }}/
           hugo-base-url: ${{ env.PREVIEW_URL }}
+          content-path: pr-content
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PREVIEW_URL: ${{ env.PREVIEW_URL }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Isolates the PR checkout in the `website-preview` workflow to prevent untrusted fork code from overwriting local actions at the workspace root.

Previously, the `actions/checkout` for the PR commit replaced the entire workspace, including `.github/actions/`. Any subsequent `uses: ./.github/actions/...` steps would execute code from the PR rather than from main. Now the PR content is checked out into a `pr-content/ `subdirectory, and the `deploy-website` action reads website files from there via a new `content-path` input.

**How was this change tested?**
The verification step in the workflow below confirms the fix by logging which commit is at the workspace root vs the `pr-content/` subdirectory. It prints the latest commit and action file contents at the root (should be main), and the latest commit and website files in `pr-content/` (should be the PR). If the two commits differ, the isolation is working, local actions resolve from main's trusted code, not the PR's.
https://github.com/ryan-mist/karpenter-provider-aws/actions/runs/25344424639/job/74309768926

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.