### PR TITLE
cherrypick: fix: skip EC2 API calls for instances in zonally shifted AZs (#9112)

### DIFF
--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -218,7 +218,16 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		launchTemplateProvider,
 		capacityReservationProvider,
 		placementGroupProvider,
-		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
+		zsProvider,
+		// Instance cache entries never expire. The cache is actively refreshed by the garbage
+		// collection controller's List() every 2 minutes, and entries are explicitly removed
+		// when Get() returns NotFound from EC2. NoExpiration ensures cached instances in zonally
+		// shifted AZs remain available for the zonal shift guards in Get(), Delete(), and
+		// CreateTags(), even if List() cannot return instances from the impaired AZ.
+		// TODO: Add a cache garbage collector that reconciles entries against EC2 and the API
+		// server, evicting entries for instances that no longer exist in either. Note: removing
+		// NodeClaim finalizers to bypass Karpenter's lifecycle management is not supported.
+		cache.New(cache.NoExpiration, cache.NoExpiration),
 	)
 
 	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)

--- a/pkg/fake/arczonalshiftapi.go
+++ b/pkg/fake/arczonalshiftapi.go
@@ -1,0 +1,42 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
+
+	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
+)
+
+type ARCZonalShiftAPI struct {
+	sdk.ARCZonalShiftAPI
+	GetManagedResourceBehavior MockedFunction[arczonalshift.GetManagedResourceInput, arczonalshift.GetManagedResourceOutput]
+}
+
+func NewARCZonalShiftAPI() *ARCZonalShiftAPI {
+	return &ARCZonalShiftAPI{}
+}
+
+func (a *ARCZonalShiftAPI) GetManagedResource(ctx context.Context, input *arczonalshift.GetManagedResourceInput, _ ...func(*arczonalshift.Options)) (*arczonalshift.GetManagedResourceOutput, error) {
+	return a.GetManagedResourceBehavior.Invoke(input, func(*arczonalshift.GetManagedResourceInput) (*arczonalshift.GetManagedResourceOutput, error) {
+		return &arczonalshift.GetManagedResourceOutput{}, nil
+	})
+}
+
+func (a *ARCZonalShiftAPI) Reset() {
+	a.GetManagedResourceBehavior.Reset()
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -228,7 +228,16 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		launchTemplateProvider,
 		capacityReservationProvider,
 		placementGroupProvider,
-		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
+		zsProvider,
+		// Instance cache entries never expire. The cache is actively refreshed by the garbage
+		// collection controller's List() every 2 minutes, and entries are explicitly removed
+		// when Get() returns NotFound from EC2. NoExpiration ensures cached instances in zonally
+		// shifted AZs remain available for the zonal shift guards in Get(), Delete(), and
+		// CreateTags(), even if List() cannot return instances from the impaired AZ.
+		// TODO: Add a cache garbage collector that reconciles entries against EC2 and the API
+		// server, evicting entries for instances that no longer exist in either. Note: removing
+		// NodeClaim finalizers to bypass Karpenter's lifecycle management is not supported.
+		cache.New(cache.NoExpiration, cache.NoExpiration),
 	)
 	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)
 

--- a/pkg/providers/arczonalshift/arczonalshift.go
+++ b/pkg/providers/arczonalshift/arczonalshift.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
+	arczonalshifttypes "github.com/aws/aws-sdk-go-v2/service/arczonalshift/types"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -70,7 +71,7 @@ func (p *DefaultProvider) UpdateZonalShifts(ctx context.Context) error {
 	for _, shift := range activeZonalShifts {
 		shiftStatuses[*shift.AwayFrom] = shiftStatus{
 			shiftExpiry: *shift.ExpiryTime,
-			applied:     shift.AppliedStatus == "APPLIED",
+			applied:     shift.AppliedStatus == arczonalshifttypes.AppliedStatusApplied,
 		}
 	}
 	if len(shiftStatuses) == 0 {
@@ -83,6 +84,12 @@ func (p *DefaultProvider) UpdateZonalShifts(ctx context.Context) error {
 	}
 	log.FromContext(ctx).V(1).Info(fmt.Sprintf("successfully updated zonal shifts %#v", shiftStatuses))
 	return nil
+}
+
+func (p *DefaultProvider) Reset() {
+	p.Lock()
+	defer p.Unlock()
+	p.zonalShiftStatuses = make(map[string]shiftStatus)
 }
 
 func (p *DefaultProvider) IsZonalShifted(ctx context.Context, zoneId string) bool {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/utils/resources"
 
 	sdk "github.com/aws/karpenter-provider-aws/pkg/aws"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/arczonalshift"
 	"github.com/aws/karpenter-provider-aws/pkg/utils"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -106,6 +107,7 @@ type DefaultProvider struct {
 	ec2Batcher                  *batcher.EC2API
 	capacityReservationProvider capacityreservation.Provider
 	placementGroupProvider      placementgroup.Provider
+	zonalshiftProvider          arczonalshift.Provider
 	instanceCache               *cache.Cache
 }
 
@@ -119,6 +121,7 @@ func NewDefaultProvider(
 	launchTemplateProvider launchtemplate.Provider,
 	capacityReservationProvider capacityreservation.Provider,
 	placementGroupProvider placementgroup.Provider,
+	zonalshiftProvider arczonalshift.Provider,
 	instanceCache *cache.Cache,
 ) *DefaultProvider {
 	return &DefaultProvider{
@@ -131,6 +134,7 @@ func NewDefaultProvider(
 		ec2Batcher:                  batcher.EC2(ctx, ec2api),
 		capacityReservationProvider: capacityReservationProvider,
 		placementGroupProvider:      placementGroupProvider,
+		zonalshiftProvider:          zonalshiftProvider,
 		instanceCache:               instanceCache,
 	}
 }
@@ -177,9 +181,15 @@ func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1.EC2NodeClass
 
 func (p *DefaultProvider) Get(ctx context.Context, id string, opts ...Options) (*Instance, error) {
 	skipCache := option.Resolve(opts...).SkipCache
-	if !skipCache {
-		if i, ok := p.instanceCache.Get(id); ok {
-			return i.(*Instance), nil
+	if i, ok := p.instanceCache.Get(id); ok {
+		inst := i.(*Instance)
+		// During a zonal shift, return cached data for instances in the shifted zone to avoid
+		// DescribeInstances calls that could cause retry storms against the impaired AZ
+		if inst.ZoneID != "" && p.zonalshiftProvider.IsZonalShifted(ctx, inst.ZoneID) {
+			return inst, nil
+		}
+		if !skipCache {
+			return inst, nil
 		}
 	}
 	out, err := p.ec2Batcher.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
@@ -246,6 +256,11 @@ func (p *DefaultProvider) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
+	// During a zonal shift, Get() returns cached data without calling DescribeInstances.
+	// We also skip TerminateInstances to avoid retry storms against the impaired AZ.
+	if out.ZoneID != "" && p.zonalshiftProvider.IsZonalShifted(ctx, out.ZoneID) {
+		return fmt.Errorf("instance %s is in zonally shifted availability zone %s (%s), skipping termination", id, out.Zone, out.ZoneID)
+	}
 	// Check if the instance is already shutting-down to reduce the number of terminate-instance calls we make thereby
 	// reducing our overall QPS. Due to EC2's eventual consistency model, the result of the terminate-instance or
 	// describe-instance call may return a not found error even when the instance is not terminated -
@@ -262,6 +277,13 @@ func (p *DefaultProvider) Delete(ctx context.Context, id string) error {
 }
 
 func (p *DefaultProvider) CreateTags(ctx context.Context, id string, tags map[string]string) error {
+	// Check the instance cache for zonal shift status before making the API call.
+	// During a zonal shift, CreateTags calls to the impaired AZ can cause retry storms.
+	if i, ok := p.instanceCache.Get(id); ok {
+		if inst := i.(*Instance); inst.ZoneID != "" && p.zonalshiftProvider.IsZonalShifted(ctx, inst.ZoneID) {
+			return fmt.Errorf("instance %s is in zonally shifted availability zone %s (%s), skipping tag creation", id, inst.Zone, inst.ZoneID)
+		}
+	}
 	ec2Tags := lo.MapToSlice(tags, func(key, value string) ec2types.Tag {
 		return ec2types.Tag{Key: aws.String(key), Value: aws.String(value)}
 	})

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -23,6 +23,8 @@ import (
 	testv1alpha1 "sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
+	arczonalshifttypes "github.com/aws/aws-sdk-go-v2/service/arczonalshift/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/awslabs/operatorpkg/object"
@@ -663,6 +665,92 @@ var _ = Describe("InstanceProvider", func() {
 			Expect(err).To(BeNil())
 			Expect(createdInstance).ToNot(BeNil())
 			Expect(createdInstance.EFACount).To(Equal(0))
+		})
+	})
+	Context("Zonal Shift", func() {
+		var instanceID string
+		BeforeEach(func() {
+			// Store an instance in the shifted zone and populate the cache
+			ec2Instance := test.EC2Instance(ec2types.Instance{
+				Placement: &ec2types.Placement{
+					AvailabilityZone:   aws.String("test-zone-1a"),
+					AvailabilityZoneId: aws.String("tstz1-1a"),
+				},
+			})
+			instanceID = aws.ToString(ec2Instance.InstanceId)
+			awsEnv.EC2API.Instances.Store(instanceID, ec2Instance)
+
+			_, err := awsEnv.InstanceProvider.Get(ctx, instanceID)
+			Expect(err).ToNot(HaveOccurred())
+			awsEnv.EC2API.DescribeInstancesBehavior.CalledWithInput.Reset()
+			awsEnv.EC2API.TerminateInstancesBehavior.CalledWithInput.Reset()
+			awsEnv.EC2API.CreateTagsBehavior.CalledWithInput.Reset()
+
+			// Activate a zonal shift for tstz1-1a
+			awsEnv.ARCZonalShiftAPI.GetManagedResourceBehavior.Output.Set(&arczonalshift.GetManagedResourceOutput{
+				ZonalShifts: []arczonalshifttypes.ZonalShiftInResource{
+					{
+						AwayFrom:      aws.String("tstz1-1a"),
+						ExpiryTime:    aws.Time(time.Now().Add(time.Hour)),
+						AppliedStatus: arczonalshifttypes.AppliedStatusApplied,
+					},
+				},
+			})
+			Expect(awsEnv.ZonalShiftProvider.UpdateZonalShifts(ctx)).To(Succeed())
+		})
+		It("should not call DescribeInstances for instances in a zonally shifted AZ", func() {
+			inst, err := awsEnv.InstanceProvider.Get(ctx, instanceID, instance.SkipCache)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inst.ID).To(Equal(instanceID))
+			Expect(inst.ZoneID).To(Equal("tstz1-1a"))
+			Expect(awsEnv.EC2API.DescribeInstancesBehavior.CalledWithInput.Len()).To(Equal(0))
+		})
+		It("should not call TerminateInstances for instances in a zonally shifted AZ", func() {
+			err := awsEnv.InstanceProvider.Delete(ctx, instanceID)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("zonally shifted"))
+			Expect(awsEnv.EC2API.DescribeInstancesBehavior.CalledWithInput.Len()).To(Equal(0))
+			Expect(awsEnv.EC2API.TerminateInstancesBehavior.CalledWithInput.Len()).To(Equal(0))
+		})
+		It("should not call CreateTags for instances in a zonally shifted AZ", func() {
+			err := awsEnv.InstanceProvider.CreateTags(ctx, instanceID, map[string]string{"test-key": "test-value"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("zonally shifted"))
+			Expect(awsEnv.EC2API.CreateTagsBehavior.CalledWithInput.Len()).To(Equal(0))
+		})
+		Context("Cache Miss", func() {
+			// When the instance cache is cold, Get() calls DescribeInstances which populates
+			// the cache with zone information. Delete() benefits from this since it calls Get()
+			// first, so the zonal shift guard still applies. CreateTags() does not call Get(),
+			// so its guard depends on a warm cache.
+			var uncachedInstanceID string
+			BeforeEach(func() {
+				ec2Instance := test.EC2Instance(ec2types.Instance{
+					Placement: &ec2types.Placement{
+						AvailabilityZone:   aws.String("test-zone-1a"),
+						AvailabilityZoneId: aws.String("tstz1-1a"),
+					},
+				})
+				uncachedInstanceID = aws.ToString(ec2Instance.InstanceId)
+				// Store in EC2 but do NOT call Get() to populate the instance cache
+				awsEnv.EC2API.Instances.Store(uncachedInstanceID, ec2Instance)
+				awsEnv.EC2API.DescribeInstancesBehavior.CalledWithInput.Reset()
+				awsEnv.EC2API.TerminateInstancesBehavior.CalledWithInput.Reset()
+				awsEnv.EC2API.CreateTagsBehavior.CalledWithInput.Reset()
+			})
+			It("should not call TerminateInstances even with a cold cache since Delete calls Get first", func() {
+				err := awsEnv.InstanceProvider.Delete(ctx, uncachedInstanceID)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("zonally shifted"))
+				// DescribeInstances is called by Get() inside Delete() to fetch instance data
+				Expect(awsEnv.EC2API.DescribeInstancesBehavior.CalledWithInput.Len()).To(Equal(1))
+				Expect(awsEnv.EC2API.TerminateInstancesBehavior.CalledWithInput.Len()).To(Equal(0))
+			})
+			It("should proceed with CreateTags when instance is not in the cache", func() {
+				err := awsEnv.InstanceProvider.CreateTags(ctx, uncachedInstanceID, map[string]string{"test-key": "test-value"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(awsEnv.EC2API.CreateTagsBehavior.CalledWithInput.Len()).To(Equal(1))
+			})
 		})
 	})
 })

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -41,6 +41,7 @@ type Instance struct {
 	ImageID                    string
 	Type                       ec2types.InstanceType
 	Zone                       string
+	ZoneID                     string
 	CapacityType               string
 	SecurityGroupIDs           []string
 	SubnetID                   string
@@ -76,6 +77,7 @@ func NewInstance(ctx context.Context, instance ec2types.Instance) *Instance {
 		ImageID:    lo.FromPtr(instance.ImageId),
 		Type:       instance.InstanceType,
 		Zone:       lo.FromPtr(instance.Placement.AvailabilityZone),
+		ZoneID:     lo.FromPtr(instance.Placement.AvailabilityZoneId),
 		// NOTE: Only set the capacity type to reserved and assign a reservation ID if the feature gate is enabled. It's
 		// possible for these to be set if the instance launched into an open ODCR, but treating it as reserved would induce
 		// drift.

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -65,11 +65,12 @@ type Environment struct {
 	InstanceTypeStore *nodeoverlay.InstanceTypeStore
 
 	// API
-	EC2API     *fake.EC2API
-	EKSAPI     *fake.EKSAPI
-	SSMAPI     *fake.SSMAPI
-	IAMAPI     *fake.IAMAPI
-	PricingAPI *fake.PricingAPI
+	EC2API           *fake.EC2API
+	EKSAPI           *fake.EKSAPI
+	SSMAPI           *fake.SSMAPI
+	IAMAPI           *fake.IAMAPI
+	PricingAPI       *fake.PricingAPI
+	ARCZonalShiftAPI *fake.ARCZonalShiftAPI
 
 	// Cache
 	AMICache                             *cache.Cache
@@ -110,6 +111,7 @@ type Environment struct {
 	VersionProvider             *version.DefaultProvider
 	LaunchTemplateProvider      *launchtemplate.DefaultProvider
 	SSMProvider                 *ssmp.DefaultProvider
+	ZonalShiftProvider          *arczonalshift.DefaultProvider
 }
 
 func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment {
@@ -122,12 +124,14 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	eksapi := fake.NewEKSAPI()
 	ssmapi := fake.NewSSMAPI()
 	iamapi := fake.NewIAMAPI()
+	arczonalshiftapi := fake.NewARCZonalShiftAPI()
 
 	// cache
 	amiCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	ec2Cache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	instanceTypeCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
-	instanceCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
+	// Instance cache entries never expire. See comment in pkg/operator/operator.go.
+	instanceCache := cache.New(cache.NoExpiration, cache.NoExpiration)
 	offeringCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	discoveredCapacityCache := cache.New(awscache.DiscoveredCapacityCacheTTL, awscache.DefaultCleanupInterval)
 	unavailableOfferingsCache := awscache.NewUnavailableOfferings()
@@ -165,7 +169,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
 	instanceTypesResolver := instancetype.NewDefaultResolver(fake.DefaultRegion)
 	capacityReservationProvider := capacityreservation.NewProvider(ec2api, clock, capacityReservationCache, capacityReservationAvailabilityCache)
-	zonalshiftProvider := arczonalshift.NewNoopProvider()
+	zonalshiftProvider := arczonalshift.NewProvider(arczonalshiftapi, clock, "")
 	instanceTypesProvider := instancetype.NewDefaultProvider(instanceTypeCache, offeringCache, discoveredCapacityCache, ec2api, subnetProvider, pricingProvider, capacityReservationProvider, placementGroupProvider, unavailableOfferingsCache, instanceTypesResolver, zonalshiftProvider)
 	// Ensure we're able to hydrate instance types before starting any reliant controllers.
 	// Instance type updates are hydrated asynchronously after this by controllers.
@@ -200,6 +204,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		launchTemplateProvider,
 		capacityReservationProvider,
 		placementGroupProvider,
+		zonalshiftProvider,
 		instanceCache,
 	)
 
@@ -208,11 +213,12 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		EventRecorder:     eventRecorder,
 		InstanceTypeStore: store,
 
-		EC2API:     ec2api,
-		EKSAPI:     eksapi,
-		SSMAPI:     ssmapi,
-		IAMAPI:     iamapi,
-		PricingAPI: fakePricingAPI,
+		EC2API:           ec2api,
+		EKSAPI:           eksapi,
+		SSMAPI:           ssmapi,
+		IAMAPI:           iamapi,
+		PricingAPI:       fakePricingAPI,
+		ARCZonalShiftAPI: arczonalshiftapi,
 
 		AMICache:          amiCache,
 		EC2Cache:          ec2Cache,
@@ -252,6 +258,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		AMIResolver:                 amiResolver,
 		VersionProvider:             versionProvider,
 		SSMProvider:                 ssmProvider,
+		ZonalShiftProvider:          zonalshiftProvider,
 	}
 }
 
@@ -262,6 +269,8 @@ func (env *Environment) Reset() {
 	env.SSMAPI.Reset()
 	env.IAMAPI.Reset()
 	env.PricingAPI.Reset()
+	env.ARCZonalShiftAPI.Reset()
+	env.ZonalShiftProvider.Reset()
 	env.PricingProvider.Reset()
 	env.InstanceTypesProvider.Reset()
 

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -15,9 +15,15 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/imdario/mergo"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis"
+	"github.com/aws/karpenter-provider-aws/pkg/fake"
 )
 
 func RemoveNodeClassTagValidation(crds []*apiextensionsv1.CustomResourceDefinition) []*apiextensionsv1.CustomResourceDefinition {
@@ -51,4 +57,23 @@ func DisableCapacityReservationIDValidation(crds []*apiextensionsv1.CustomResour
 		crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"].Properties["capacityReservations"].Items.Schema.Properties["id"] = idProps
 	}
 	return crds
+}
+
+// EC2Instance creates an ec2types.Instance with sensible defaults for testing.
+// Defaults: auto-generated instance ID, running state, m5.large, default region zone, and a private DNS name.
+// Pass overrides to customize any fields. Tags are not defaulted since their presence/absence is intentional in tests.
+func EC2Instance(overrides ...ec2types.Instance) ec2types.Instance {
+	instance := ec2types.Instance{
+		InstanceId:     aws.String(fake.InstanceID()),
+		State:          &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+		InstanceType:   "m5.large",
+		Placement:      &ec2types.Placement{AvailabilityZone: aws.String(fake.DefaultRegion)},
+		PrivateDnsName: aws.String(fake.PrivateDNSName()),
+	}
+	for _, override := range overrides {
+		if err := mergo.Merge(&instance, override, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("Failed to merge instance overrides: %s", err))
+		}
+	}
+	return instance
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
* cherrypick https://github.com/aws/karpenter-provider-aws/pull/9112 to 1.12.x branch

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.