### PR TITLE
test: clean up temp security group created by drift test

### DIFF
--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -768,6 +768,15 @@ func (env *Environment) ExpectNodeRoleDeleted(roleName string) {
 	Expect(awserrors.IgnoreNotFound(err)).ToNot(HaveOccurred())
 }
 
+func (env *Environment) ExpectSecurityGroupDeleted(groupID *string) {
+	GinkgoHelper()
+	By("deleting security group created for test")
+	_, err := env.EC2API.DeleteSecurityGroup(env.Context, &ec2.DeleteSecurityGroupInput{
+		GroupId: groupID,
+	})
+	Expect(awserrors.IgnoreNotFound(err)).ToNot(HaveOccurred())
+}
+
 func (env *Environment) ExpectEFADevicePluginCreated() {
 	GinkgoHelper()
 	env.ExpectCreated(&appsv1.DaemonSet{

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -213,6 +213,13 @@ var _ = Describe("Drift", Ordered, func() {
 			g.Expect(testSecurityGroup).ToNot(BeNil())
 		}).Should(Succeed())
 
+		// Clean up the temporary security group we created for these tests
+		DeferCleanup(func() {
+			_, _ = env.EC2API.DeleteSecurityGroup(env.Context, &ec2.DeleteSecurityGroupInput{
+				GroupId: testSecurityGroup.GroupId,
+			})
+		})
+
 		By("creating a new provider with the new securitygroup")
 		awsIDs := lo.FilterMap(securitygroups, func(sg aws.SecurityGroup, _ int) (string, bool) {
 			if awssdk.ToString(sg.GroupId) != awssdk.ToString(testSecurityGroup.GroupId) {

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -215,9 +215,7 @@ var _ = Describe("Drift", Ordered, func() {
 
 		// Clean up the temporary security group we created for these tests
 		DeferCleanup(func() {
-			_, _ = env.EC2API.DeleteSecurityGroup(env.Context, &ec2.DeleteSecurityGroupInput{
-				GroupId: testSecurityGroup.GroupId,
-			})
+			env.ExpectSecurityGroupDeleted(testSecurityGroup.GroupId)
 		})
 
 		By("creating a new provider with the new securitygroup")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The E2E drift test suite creates a temporary security group but does not clean it up. This subsequently leads to the integration test suite's security group test to fail. Cleaning up the temporary security group will fix this. This failure is only seen in local testing where all the test suites are executed with `make e2etests`. The `E2EMatrixTrigger` executed via GitHub actions does not fail since it executes test suites one at a time and calls a cleanup script in between.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.