### PR TITLE
chore: make instancestatus metric unique per instance/category

### DIFF
--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -103,30 +103,11 @@ func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Re
 		if !found {
 			return
 		}
-
-		log.FromContext(ctx).Info("detected unhealthy instance owned by cluster",
-			"instance-id", instanceStatuses[i].InstanceID,
-			"details", len(instanceStatuses[i].Details))
-
-		categories := map[string]bool{}
-		for _, d := range instanceStatuses[i].Details {
-			categories[string(d.Category)] = true
-		}
-		for cat := range categories {
-			key := unhealthyKey{instanceID: instanceStatuses[i].InstanceID, category: cat}
-			c.mu.Lock()
-			currentKeys[key] = struct{}{}
-			if _, already := c.seen[key]; !already {
-				c.seen[key] = struct{}{}
-				c.mu.Unlock()
-				InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
-			} else {
-				c.mu.Unlock()
-			}
-		}
+		c.recordUnhealthyInstance(ctx, instanceStatuses[i], currentKeys)
 	})
 
-	// Prune entries for instances that are no longer reported as unhealthy
+	// Prune entries for instances that are no longer reported as unhealthy,
+	// so that if the same instance becomes unhealthy again later it gets counted again.
 	c.mu.Lock()
 	for key := range c.seen {
 		if _, ok := currentKeys[key]; !ok {
@@ -139,6 +120,29 @@ func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Re
 		return reconciler.Result{}, err
 	}
 	return reconciler.Result{RequeueAfter: InstanceStatusInterval}, nil
+}
+
+func (c *InstanceStatusController) recordUnhealthyInstance(ctx context.Context, status instancestatus.HealthStatus, currentKeys map[unhealthyKey]struct{}) {
+	categories := map[string]bool{}
+	for _, d := range status.Details {
+		categories[string(d.Category)] = true
+	}
+	for cat := range categories {
+		key := unhealthyKey{instanceID: status.InstanceID, category: cat}
+		c.mu.Lock()
+		currentKeys[key] = struct{}{}
+		_, already := c.seen[key]
+		if !already {
+			c.seen[key] = struct{}{}
+		}
+		c.mu.Unlock()
+		if !already {
+			log.FromContext(ctx).Info("detected unhealthy instance owned by cluster",
+				"instance-id", status.InstanceID,
+				"category", cat)
+			InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
+		}
+	}
 }
 
 func (c *InstanceStatusController) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/controllers/interruption/instancestatus_controller.go
+++ b/pkg/controllers/interruption/instancestatus_controller.go
@@ -17,6 +17,7 @@ package interruption
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/awslabs/operatorpkg/reconciler"
@@ -36,6 +37,13 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instancestatus"
 )
 
+// unhealthyKey uniquely identifies an unhealthy status check for deduplication.
+// The metric is only incremented the first time a given instance+category is observed.
+type unhealthyKey struct {
+	instanceID string
+	category   string
+}
+
 var (
 	// InstanceStatusInterval is the polling interval for the EC2 DescribeInstanceStatus API.
 	InstanceStatusInterval = 1 * time.Minute
@@ -50,6 +58,8 @@ var (
 type InstanceStatusController struct {
 	InterruptionHandler
 	instanceStatusProvider instancestatus.Provider
+	seen                   map[unhealthyKey]struct{}
+	mu                     sync.Mutex
 }
 
 func NewInstanceStatusController(
@@ -65,6 +75,7 @@ func NewInstanceStatusController(
 			recorder:      recorder,
 		},
 		instanceStatusProvider: instanceStatusProvider,
+		seen:                   map[unhealthyKey]struct{}{},
 	}
 }
 
@@ -80,6 +91,8 @@ func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Re
 		return reconciler.Result{}, fmt.Errorf("getting instance statuses, %w", err)
 	}
 
+	// Build the set of keys observed in this poll cycle for pruning stale entries.
+	currentKeys := make(map[unhealthyKey]struct{})
 	errs := make([]error, len(instanceStatuses))
 	workqueue.ParallelizeUntil(ctx, 10, len(instanceStatuses), func(i int) {
 		msg := instancestatusfailure.Message(instanceStatuses[i])
@@ -90,14 +103,38 @@ func (c *InstanceStatusController) Reconcile(ctx context.Context) (reconciler.Re
 		if !found {
 			return
 		}
+
+		log.FromContext(ctx).Info("detected unhealthy instance owned by cluster",
+			"instance-id", instanceStatuses[i].InstanceID,
+			"details", len(instanceStatuses[i].Details))
+
 		categories := map[string]bool{}
 		for _, d := range instanceStatuses[i].Details {
 			categories[string(d.Category)] = true
 		}
 		for cat := range categories {
-			InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
+			key := unhealthyKey{instanceID: instanceStatuses[i].InstanceID, category: cat}
+			c.mu.Lock()
+			currentKeys[key] = struct{}{}
+			if _, already := c.seen[key]; !already {
+				c.seen[key] = struct{}{}
+				c.mu.Unlock()
+				InstanceStatusUnhealthy.Inc(map[string]string{categoryLabel: cat})
+			} else {
+				c.mu.Unlock()
+			}
 		}
 	})
+
+	// Prune entries for instances that are no longer reported as unhealthy
+	c.mu.Lock()
+	for key := range c.seen {
+		if _, ok := currentKeys[key]; !ok {
+			delete(c.seen, key)
+		}
+	}
+	c.mu.Unlock()
+
 	if err = multierr.Combine(errs...); err != nil {
 		return reconciler.Result{}, err
 	}

--- a/pkg/controllers/interruption/metrics.go
+++ b/pkg/controllers/interruption/metrics.go
@@ -66,7 +66,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: interruptionSubsystem,
 			Name:      "instance_status_unhealthy_total",
-			Help:      "Count of unhealthy instance statuses detected from EC2 DescribeInstanceStatus. Broken down by status check category.",
+			Help:      "Count of unique unhealthy instance statuses detected from EC2 DescribeInstanceStatus. Broken down by status check category.",
 		},
 		[]string{categoryLabel},
 	)

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -450,6 +450,135 @@ var _ = Describe("InterruptionHandling", func() {
 				"category": "InstanceStatus",
 			})
 		})
+		It("should emit the metric for each unique unhealthy instance", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
+			interruption.InstanceStatusDryRun = true
+			DeferCleanup(func() {
+				interruption.InstanceStatusDryRun = false
+			})
+
+			// Create a second nodeclaim/node pair
+			nodeClaim2, node2 := coretest.NodeClaimAndNode(karpv1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						karpv1.NodePoolLabelKey: "default",
+					},
+				},
+				Status: karpv1.NodeClaimStatus{
+					ProviderID: fake.RandomProviderID(),
+				},
+			})
+
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+					},
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim2.Status.ProviderID))),
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+					},
+				},
+			})
+			awsEnv.Clock.Step(time.Hour)
+			ExpectApplied(ctx, env.Client, nodeClaim, node, nodeClaim2, node2)
+
+			// First reconcile should count both instances
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 2, map[string]string{
+				"category": "InstanceStatus",
+			})
+
+			// Second reconcile should not increment further
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 2, map[string]string{
+				"category": "InstanceStatus",
+			})
+		})
+		It("should re-emit the metric when an instance recovers and becomes unhealthy again", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
+			interruption.InstanceStatusDryRun = true
+			DeferCleanup(func() {
+				interruption.InstanceStatusDryRun = false
+			})
+
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+					},
+				},
+			})
+			awsEnv.Clock.Step(time.Hour)
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+
+			// First reconcile detects the unhealthy instance
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 1, map[string]string{
+				"category": "InstanceStatus",
+			})
+
+			// Instance recovers (no longer in DescribeInstanceStatus response)
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{},
+			})
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+
+			// Instance becomes unhealthy again
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+					},
+				},
+			})
+			awsEnv.Clock.Step(time.Hour)
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+
+			// Metric should now be 2 (counted once for each occurrence)
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 2, map[string]string{
+				"category": "InstanceStatus",
+			})
+		})
 	})
 })
 

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -414,6 +414,42 @@ var _ = Describe("InterruptionHandling", func() {
 			})
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
+		It("should only emit the metric once across multiple reconciles for the same unhealthy instance", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{InterruptionQueue: lo.ToPtr("")}))
+			interruption.InstanceStatusDryRun = true
+			DeferCleanup(func() {
+				interruption.InstanceStatusDryRun = false
+			})
+			awsEnv.EC2API.DescribeInstanceStatusOutput.Set(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []ec2types.InstanceStatus{
+					{
+						InstanceId: lo.ToPtr(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))),
+						InstanceStatus: &ec2types.InstanceStatusSummary{
+							Status: ec2types.SummaryStatusImpaired,
+							Details: []ec2types.InstanceStatusDetails{
+								{
+									Status:        ec2types.StatusTypeFailed,
+									Name:          ec2types.StatusNameReachability,
+									ImpairedSince: lo.ToPtr(awsEnv.Clock.Now()),
+								},
+							},
+						},
+					},
+				},
+			})
+			awsEnv.Clock.Step(time.Hour)
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+
+			// Reconcile multiple times with the same unhealthy instance
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+			ExpectSingletonReconciled(ctx, instanceStatusController)
+
+			// Metric should only have been incremented once despite three reconciles
+			ExpectMetricCounterValue(interruption.InstanceStatusUnhealthy, 1, map[string]string{
+				"category": "InstanceStatus",
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Changes the InstanceStatusUnhealthy metric to only emit once for each unique instance/category combination, instead of on every poll.


**How was this change tested?**
Added a unit test

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.