### PR TITLE
ci: update ami test suite to latest pinned versions

### DIFF
--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -230,9 +230,9 @@ var _ = Describe("AMI", func() {
 				env.ExpectCreatedNodeCount("==", 1)
 			},
 			Entry("AL2023 (latest)", "al2023@latest"),
-			Entry("AL2023 (pinned)", "al2023@v20250116"),
+			Entry("AL2023 (pinned)", "al2023@v20260505"),
 			Entry("AL2 (latest)", "al2@latest"),
-			Entry("AL2 (pinned)", "al2@v20250116"),
+			Entry("AL2 (pinned)", "al2@v20251209"),
 			Entry("Bottlerocket (latest)", "bottlerocket@latest"),
 			Entry("Bottlerocket (pinned with v prefix)", "bottlerocket@v1.53.0"),
 			Entry("Bottlerocket (pinned without v prefix)", "bottlerocket@1.53.0"),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
ami e2e test suites were failing with `"error":"getting amis, getting AMI queries, failed to discover any AMIs for alias (alias=al2023@v20250116)"}` so bump to latest version

https://github.com/aws/karpenter-provider-aws/actions/runs/25759071783/job/75655374707

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.