### PR TITLE
feat: Add AWS Outposts support for Karpenter

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -300,6 +300,13 @@ spec:
                 detailedMonitoring:
                   description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
                   type: boolean
+                outpostArn:
+                  description: |-
+                    OutpostArn is the ARN of the AWS Outpost on which to launch instances.
+                    When specified, Karpenter will only discover instance types available on the Outpost,
+                    filter subnets to those on the Outpost, and restrict capacity to on-demand only.
+                  pattern: ^arn:aws[a-zA-Z-]*:outposts:[a-z0-9-]+:[0-9]{12}:outpost/op-[0-9a-f]{17}$
+                  type: string
                 instanceProfile:
                   description: |-
                     InstanceProfile is the AWS entity that instances use.

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -155,6 +155,12 @@ type EC2NodeClassSpec struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
 	// +optional
 	Context *string `json:"context,omitempty"`
+	// OutpostArn is the ARN of the AWS Outpost on which to launch instances.
+	// When specified, Karpenter will only discover instance types available on the Outpost,
+	// filter subnets to those on the Outpost, and restrict capacity to on-demand only.
+	// +kubebuilder:validation:Pattern=`^arn:aws[a-zA-Z-]*:outposts:[a-z0-9-]+:[0-9]{12}:outpost/op-[0-9a-f]{17}$`
+	// +optional
+	OutpostArn *string `json:"outpostArn,omitempty"`
 }
 
 // SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
@@ -585,6 +591,10 @@ func (in *EC2NodeClass) NetworkInterfaces() []*NetworkInterface {
 
 func (in *EC2NodeClass) PlacementGroupSelector() *PlacementGroupSelector {
 	return in.Spec.PlacementGroupSelector
+}
+
+func (in *EC2NodeClass) OutpostArn() *string {
+	return in.Spec.OutpostArn
 }
 
 func (in *EC2NodeClass) KubeletConfiguration() *KubeletConfiguration {

--- a/pkg/apis/v1/ec2nodeclass_status.go
+++ b/pkg/apis/v1/ec2nodeclass_status.go
@@ -52,6 +52,9 @@ type Subnet struct {
 	// The associated availability zone ID
 	// +optional
 	ZoneID string `json:"zoneID,omitempty"`
+	// The associated Outpost ARN, if the subnet is on an Outpost
+	// +optional
+	OutpostArn string `json:"outpostArn,omitempty"`
 }
 
 // SecurityGroup contains resolved SecurityGroup selector values utilized for node launch

--- a/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
@@ -1424,4 +1424,14 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(env.Client.Update(ctx, nc)).To(Succeed())
 		})
 	})
+	Context("OutpostArn", func() {
+		It("should succeed with a valid outpostArn", func() {
+			nc.Spec.OutpostArn = lo.ToPtr("arn:aws:outposts:us-west-2:123456789012:outpost/op-01234567890abcdef")
+			Expect(env.Client.Create(ctx, nc)).To(Succeed())
+		})
+		It("should fail with an invalid outpostArn", func() {
+			nc.Spec.OutpostArn = lo.ToPtr("arn:aws:outposts:us-west-2:123456789012:outpost/invalid")
+			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
+		})
+	})
 })

--- a/pkg/controllers/nodeclass/subnet.go
+++ b/pkg/controllers/nodeclass/subnet.go
@@ -58,9 +58,10 @@ func (s *Subnet) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (rec
 	})
 	nodeClass.Status.Subnets = lo.Map(subnets, func(ec2subnet ec2types.Subnet, _ int) v1.Subnet {
 		return v1.Subnet{
-			ID:     *ec2subnet.SubnetId,
-			Zone:   *ec2subnet.AvailabilityZone,
-			ZoneID: *ec2subnet.AvailabilityZoneId,
+			ID:         *ec2subnet.SubnetId,
+			Zone:       *ec2subnet.AvailabilityZone,
+			ZoneID:     *ec2subnet.AvailabilityZoneId,
+			OutpostArn: lo.FromPtr(ec2subnet.OutpostArn),
 		}
 	})
 	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeSubnetsReady)

--- a/pkg/providers/amifamily/outpost_test.go
+++ b/pkg/providers/amifamily/outpost_test.go
@@ -1,0 +1,89 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amifamily_test
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/resource"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/fake"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
+)
+
+var _ = Describe("Outpost EBS Defaults", func() {
+	It("should default to gp2 when OutpostArn is set and no explicit blockDeviceMappings", func() {
+		amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
+		launchTemplates, err := amiResolver.Resolve(nodeClass, nodeClaim, instanceTypes, karpv1.CapacityTypeOnDemand, string(ec2types.TenancyDefault), &amifamily.Options{
+			ClusterName: "test",
+			OutpostArn:  "arn:aws:outposts:us-west-2:123456789012:outpost/op-1234567890abcdef0",
+		}, "", 0)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(launchTemplates).ToNot(BeEmpty())
+		for _, lt := range launchTemplates {
+			for _, bdm := range lt.BlockDeviceMappings {
+				if bdm.EBS != nil {
+					Expect(lo.FromPtr(bdm.EBS.VolumeType)).To(Equal(string(ec2types.VolumeTypeGp2)))
+				}
+			}
+		}
+	})
+
+	It("should default to gp3 when OutpostArn is NOT set", func() {
+		amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
+		launchTemplates, err := amiResolver.Resolve(nodeClass, nodeClaim, instanceTypes, karpv1.CapacityTypeOnDemand, string(ec2types.TenancyDefault), &amifamily.Options{
+			ClusterName: "test",
+		}, "", 0)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(launchTemplates).ToNot(BeEmpty())
+		for _, lt := range launchTemplates {
+			for _, bdm := range lt.BlockDeviceMappings {
+				if bdm.EBS != nil {
+					Expect(lo.FromPtr(bdm.EBS.VolumeType)).To(Equal(string(ec2types.VolumeTypeGp3)))
+				}
+			}
+		}
+	})
+
+	It("should preserve user-specified blockDeviceMappings when OutpostArn is set", func() {
+		nodeClass.Spec.BlockDeviceMappings = []*v1.BlockDeviceMapping{
+			{
+				DeviceName: aws.String("/dev/xvda"),
+				EBS: &v1.BlockDevice{
+					Encrypted:  aws.Bool(true),
+					VolumeType: aws.String(string(ec2types.VolumeTypeIo1)),
+					VolumeSize: lo.ToPtr(resource.MustParse("50Gi")),
+					IOPS:       aws.Int64(3000),
+				},
+			},
+		}
+		amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
+		launchTemplates, err := amiResolver.Resolve(nodeClass, nodeClaim, instanceTypes, karpv1.CapacityTypeOnDemand, string(ec2types.TenancyDefault), &amifamily.Options{
+			ClusterName: "test",
+			OutpostArn:  "arn:aws:outposts:us-west-2:123456789012:outpost/op-1234567890abcdef0",
+		}, "", 0)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(launchTemplates).ToNot(BeEmpty())
+		for _, lt := range launchTemplates {
+			Expect(lt.BlockDeviceMappings).To(HaveLen(1))
+			Expect(lo.FromPtr(lt.BlockDeviceMappings[0].EBS.VolumeType)).To(Equal(string(ec2types.VolumeTypeIo1)))
+		}
+	})
+})

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -70,6 +70,7 @@ type Options struct {
 	AssociatePublicIPAddress  *bool
 	IPPrefixCount             *int32
 	NodeClassName             string
+	OutpostArn                string
 	ResolvedNetworkInterfaces []*ResolvedNetworkInterface `hash:"ignore"`
 }
 
@@ -336,6 +337,15 @@ func (r DefaultResolver) resolveLaunchTemplates(
 		}
 		if len(resolved.BlockDeviceMappings) == 0 {
 			resolved.BlockDeviceMappings = amiFamily.DefaultBlockDeviceMappings()
+		}
+		// On first-gen Outposts, gp3 is not supported. Default to gp2 when
+		// the user hasn't specified explicit block device mappings.
+		if options.OutpostArn != "" && len(nodeClass.Spec.BlockDeviceMappings) == 0 {
+			for _, bdm := range resolved.BlockDeviceMappings {
+				if bdm.EBS != nil && lo.FromPtr(bdm.EBS.VolumeType) == string(ec2types.VolumeTypeGp3) {
+					bdm.EBS.VolumeType = aws.String(string(ec2types.VolumeTypeGp2))
+				}
+			}
 		}
 		if resolved.MetadataOptions == nil {
 			resolved.MetadataOptions = amiFamily.DefaultMetadataOptions()

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
@@ -63,6 +64,7 @@ type NodeClass interface {
 	InstanceStorePolicy() *v1.InstanceStorePolicy
 	NetworkInterfaces() []*v1.NetworkInterface
 	KubeletConfiguration() *v1.KubeletConfiguration
+	OutpostArn() *string
 	PlacementGroupSelector() *v1.PlacementGroupSelector
 	ZoneInfo() []v1.ZoneInfo
 }
@@ -92,6 +94,7 @@ type DefaultProvider struct {
 
 	instanceTypesCache      *cache.Cache
 	discoveredCapacityCache *cache.Cache
+	outpostOfferingsCache   *cache.Cache
 	cm                      *pretty.ChangeMonitor
 
 	placementGroupProvider placementgroup.Provider
@@ -119,6 +122,7 @@ func NewDefaultProvider(
 		instanceTypesResolver:   instanceTypesResolver,
 		instanceTypesCache:      instanceTypesCache,
 		discoveredCapacityCache: discoveredCapacityCache,
+		outpostOfferingsCache:   cache.New(5*time.Minute, 10*time.Minute),
 		cm:                      pretty.NewChangeMonitor(),
 		placementGroupProvider:  placementGroupProvider,
 		offeringProvider: offering.NewDefaultProvider(
@@ -169,6 +173,21 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass NodeClass) ([]*clo
 	// date capacity information. Rather than incurring a cache miss each time an instance is launched into a reserved
 	// offering (or terminated), offerings are injected to the cached instance types on each call. Note that on-demand and
 	// spot offerings are still cached - only reserved offerings are generated each time.
+
+	// Filter to only instance types available on the Outpost when an OutpostArn is specified
+	if outpostArn := nodeClass.OutpostArn(); outpostArn != nil {
+		outpostTypes, err := p.getOutpostOfferings(ctx, *outpostArn)
+		if err != nil {
+			return nil, err
+		}
+		instanceTypes = lo.Filter(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
+			return outpostTypes.Has(it.Name)
+		})
+		if len(instanceTypes) == 0 {
+			return nil, fmt.Errorf("no instance types available on outpost %s", *outpostArn)
+		}
+	}
+
 	return p.offeringProvider.InjectOfferings(
 		ctx,
 		instanceTypes,
@@ -388,6 +407,37 @@ func (p *DefaultProvider) FilterForNodeClass(ctx context.Context, its []*cloudpr
 		}
 	}
 	return compatible
+}
+
+// getOutpostOfferings queries EC2 for instance types available on a specific Outpost
+// and returns the set of instance type names available there. Results are cached since
+// Outpost hardware changes extremely rarely.
+func (p *DefaultProvider) getOutpostOfferings(ctx context.Context, outpostArn string) (sets.Set[string], error) {
+	if cached, ok := p.outpostOfferingsCache.Get(outpostArn); ok {
+		return cached.(sets.Set[string]), nil
+	}
+	available := sets.New[string]()
+	paginator := ec2.NewDescribeInstanceTypeOfferingsPaginator(p.ec2api, &ec2.DescribeInstanceTypeOfferingsInput{
+		LocationType: ec2types.LocationType("outpost"),
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("location"),
+				Values: []string{outpostArn},
+			},
+		},
+		MaxResults: lo.ToPtr[int32](1000),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("describing instance type offerings for outpost %s, %w", outpostArn, err)
+		}
+		for _, offering := range page.InstanceTypeOfferings {
+			available.Insert(string(offering.InstanceType))
+		}
+	}
+	p.outpostOfferingsCache.SetDefault(outpostArn, available)
+	return available, nil
 }
 
 func (p *DefaultProvider) Reset() {

--- a/pkg/providers/instancetype/offering/offering.go
+++ b/pkg/providers/instancetype/offering/offering.go
@@ -51,6 +51,7 @@ type NodeClass interface {
 	ZoneInfo() []v1.ZoneInfo
 	NetworkInterfaces() []*v1.NetworkInterface
 	AMIFamily() string
+	OutpostArn() *string
 	PlacementGroupSelector() *v1.PlacementGroupSelector
 }
 
@@ -183,6 +184,10 @@ func (p *DefaultProvider) createOfferings(
 			for _, capacityType := range it.Requirements.Get(karpv1.CapacityTypeLabelKey).Values() {
 				// Reserved capacity types are constructed separately
 				if capacityType == karpv1.CapacityTypeReserved {
+					continue
+				}
+				// Spot is not available on Outposts
+				if capacityType == karpv1.CapacityTypeSpot && nodeClass.OutpostArn() != nil {
 					continue
 				}
 				// Check both the general ICE signal and the PG-scoped signal.

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -82,13 +82,14 @@ func (d *DefaultResolver) CacheKey(nodeClass NodeClass) string {
 	capacityReservationHash, _ := hashstructure.Hash(nodeClass.CapacityReservations(), hashstructure.FormatV2, nil)
 	networkInterfaceHash, _ := hashstructure.Hash(nodeClass.NetworkInterfaces(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	return fmt.Sprintf(
-		"%016x-%016x-%016x-%016x-%s-%s",
+		"%016x-%016x-%016x-%016x-%s-%s-%s",
 		kcHash,
 		blockDeviceMappingsHash,
 		capacityReservationHash,
 		networkInterfaceHash,
 		lo.FromPtr((*string)(nodeClass.InstanceStorePolicy())),
 		nodeClass.AMIFamily(),
+		lo.FromPtr(nodeClass.OutpostArn()),
 	)
 }
 

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -238,6 +238,7 @@ func (p *DefaultProvider) CreateAMIOptions(ctx context.Context, nodeClass *v1.EC
 		AssociatePublicIPAddress: nodeClass.Spec.AssociatePublicIPAddress,
 		IPPrefixCount:            nodeClass.Spec.IPPrefixCount,
 		NodeClassName:            nodeClass.Name,
+		OutpostArn:               lo.FromPtr(nodeClass.Spec.OutpostArn),
 	}, nil
 }
 

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -64,6 +64,7 @@ type Subnet struct {
 	Zone                    string
 	ZoneID                  string
 	AvailableIPAddressCount int32
+	OutpostArn              string
 }
 
 func NewDefaultProvider(ec2api sdk.EC2API, cache *cache.Cache, availableIPAddressCache *cache.Cache, associatePublicIPAddressCache *cache.Cache) *DefaultProvider {
@@ -115,14 +116,26 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 			}
 		}
 	}
+	// Filter subnets by OutpostArn if specified in the nodeClass spec
+	if nodeClass.Spec.OutpostArn != nil {
+		for id, subnet := range subnets {
+			if lo.FromPtr(subnet.OutpostArn) != *nodeClass.Spec.OutpostArn {
+				delete(subnets, id)
+			}
+		}
+		if len(subnets) == 0 {
+			return nil, fmt.Errorf("no subnets matched outpost %s with selector %v", *nodeClass.Spec.OutpostArn, nodeClass.Spec.SubnetSelectorTerms)
+		}
+	}
 	p.cache.SetDefault(hash, lo.Values(subnets))
 	if p.cm.HasChanged(fmt.Sprintf("subnets/%s", nodeClass.Name), lo.Keys(subnets)) {
 		log.FromContext(ctx).
 			WithValues("subnets", lo.Map(lo.Values(subnets), func(s ec2types.Subnet, _ int) v1.Subnet {
 				return v1.Subnet{
-					ID:     lo.FromPtr(s.SubnetId),
-					Zone:   lo.FromPtr(s.AvailabilityZone),
-					ZoneID: lo.FromPtr(s.AvailabilityZoneId),
+					ID:         lo.FromPtr(s.SubnetId),
+					Zone:       lo.FromPtr(s.AvailabilityZone),
+					ZoneID:     lo.FromPtr(s.AvailabilityZoneId),
+					OutpostArn: lo.FromPtr(s.OutpostArn),
 				}
 			})).V(1).Info("discovered subnets")
 	}
@@ -161,7 +174,7 @@ func (p *DefaultProvider) ZonalSubnetsForLaunch(ctx context.Context, nodeClass *
 				continue
 			}
 		}
-		zonalSubnets[subnet.Zone] = &Subnet{ID: subnet.ID, Zone: subnet.Zone, ZoneID: subnet.ZoneID, AvailableIPAddressCount: availableIPAddressCount[subnet.ID]}
+		zonalSubnets[subnet.Zone] = &Subnet{ID: subnet.ID, Zone: subnet.Zone, ZoneID: subnet.ZoneID, AvailableIPAddressCount: availableIPAddressCount[subnet.ID], OutpostArn: subnet.OutpostArn}
 	}
 
 	for _, subnet := range zonalSubnets {

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -454,6 +454,60 @@ var _ = Describe("SubnetProvider", func() {
 			))
 		})
 	})
+	Context("Outpost Filtering", func() {
+		It("should filter subnets by OutpostArn when specified", func() {
+			outpostArn := "arn:aws:outposts:us-west-2:123456789012:outpost/op-1234567890abcdef0"
+			nodeClass.Spec.OutpostArn = &outpostArn
+			awsEnv.EC2API.DescribeSubnetsBehavior.Output.Set(&ec2.DescribeSubnetsOutput{Subnets: []ec2types.Subnet{
+				{
+					SubnetId:                aws.String("subnet-outpost-1"),
+					AvailabilityZone:        aws.String("test-zone-1a"),
+					AvailabilityZoneId:      aws.String("tstz1-1a"),
+					AvailableIpAddressCount: aws.Int32(100),
+					OutpostArn:              aws.String(outpostArn),
+				},
+				{
+					SubnetId:                aws.String("subnet-region-1"),
+					AvailabilityZone:        aws.String("test-zone-1b"),
+					AvailabilityZoneId:      aws.String("tstz1-1b"),
+					AvailableIpAddressCount: aws.Int32(100),
+				},
+				{
+					SubnetId:                aws.String("subnet-outpost-2"),
+					AvailabilityZone:        aws.String("test-zone-1a"),
+					AvailabilityZoneId:      aws.String("tstz1-1a"),
+					AvailableIpAddressCount: aws.Int32(50),
+					OutpostArn:              aws.String(outpostArn),
+				},
+			}})
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(2))
+			Expect(lo.Map(subnets, func(s ec2types.Subnet, _ int) string { return lo.FromPtr(s.SubnetId) })).
+				To(ConsistOf("subnet-outpost-1", "subnet-outpost-2"))
+		})
+		It("should return all subnets when OutpostArn is not specified", func() {
+			outpostArn := "arn:aws:outposts:us-west-2:123456789012:outpost/op-1234567890abcdef0"
+			awsEnv.EC2API.DescribeSubnetsBehavior.Output.Set(&ec2.DescribeSubnetsOutput{Subnets: []ec2types.Subnet{
+				{
+					SubnetId:                aws.String("subnet-outpost-1"),
+					AvailabilityZone:        aws.String("test-zone-1a"),
+					AvailabilityZoneId:      aws.String("tstz1-1a"),
+					AvailableIpAddressCount: aws.Int32(100),
+					OutpostArn:              aws.String(outpostArn),
+				},
+				{
+					SubnetId:                aws.String("subnet-region-1"),
+					AvailabilityZone:        aws.String("test-zone-1b"),
+					AvailabilityZoneId:      aws.String("tstz1-1b"),
+					AvailableIpAddressCount: aws.Int32(100),
+				},
+			}})
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(2))
+		})
+	})
 	It("should not cause data races when calling List() simultaneously", func() {
 		wg := sync.WaitGroup{}
 		for range 10000 {

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -1643,8 +1643,47 @@ requires that the field is only set to true when configuring an instance with a 
 
 This value is a integer field that controls how many ip prefixes will be assigned to `NodeClaim`. See the [EC2 Launch Template Network Interface Spec](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ec2-launchtemplate-networkinterface.html) for more information. Sets ipv4PrefixCount if you are using an IPv4 Cluster, or ipv6PrefixCount if you are using IPv6.
 
+## spec.outpostArn
+
+This optional field specifies the ARN of an [AWS Outpost](https://docs.aws.amazon.com/outposts/latest/userguide/what-is-outposts.html) to target for node provisioning. When set, Karpenter adjusts its behavior to operate within the constraints of Outpost hardware:
+
+- **Subnet filtering**: Only subnets associated with the specified Outpost are considered for node placement.
+- **Instance type discovery**: Karpenter calls `DescribeInstanceTypeOfferings` with `LocationType=outpost` to discover which instance types are available on the Outpost. Only those types are used for scheduling decisions.
+- **Capacity type**: Spot instances are not available on Outposts. Karpenter automatically restricts provisioning to on-demand capacity when `outpostArn` is set.
+- **EBS volume defaults**: First-generation Outposts support only `gp2` EBS volumes, while second-generation Outposts support `gp3`. When no explicit `spec.blockDeviceMappings` are configured, Karpenter overrides the default `gp3` volume type to `gp2` for root volumes on first-generation Outposts.
+
+When `outpostArn` is not set, all behavior remains unchanged.
+
+{{% alert title="Note" color="primary" %}}
+Outpost instance type offerings are cached with a 5-minute TTL. If you add new instance types to your Outpost, Karpenter will discover them within 5 minutes.
+{{% /alert %}}
+
+{{% alert title="Important" color="warning" %}}
+The subnets selected by `spec.subnetSelectorTerms` must include at least one subnet on the specified Outpost. No additional IAM permissions are required beyond the existing `ec2:DescribeInstanceTypeOfferings` permission that Karpenter already uses for regional instance type discovery.
+{{% /alert %}}
+
+#### Examples
+
+Target a specific Outpost for all nodes provisioned by this EC2NodeClass:
+
+```yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: outpost
+spec:
+  outpostArn: arn:aws:outposts:us-west-2:123456789012:outpost/op-1234567890abcdef0
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}"
+  role: "KarpenterNodeRole-${CLUSTER_NAME}"
+```
+
 ## status.subnets
-[`status.subnets`]({{< ref "#statussubnets" >}}) contains the resolved `id` and `zone` of the subnets that were selected by the [`spec.subnetSelectorTerms`]({{< ref "#specsubnetselectorterms" >}}) for the node class. The subnets will be sorted by the available IP address count in decreasing order.
+[`status.subnets`]({{< ref "#statussubnets" >}}) contains the resolved `id` and `zone` of the subnets that were selected by the [`spec.subnetSelectorTerms`]({{< ref "#specsubnetselectorterms" >}}) for the node class. The subnets will be sorted by the available IP address count in decreasing order. When [`spec.outpostArn`]({{< ref "#specoutpostarn" >}}) is set, each subnet entry also includes an `outpostArn` field indicating which Outpost the subnet is associated with.
 
 #### Examples
 


### PR DESCRIPTION
# feat: Add AWS Outposts support via `outpostArn` field on EC2NodeClass

Fixes #1284

## Description

Adds an optional `outpostArn` field to `EC2NodeClassSpec` that enables Karpenter to provision nodes on AWS Outpost racks. The field is fully optional - when omitted, Karpenter behaves identically to upstream. When set, the following Outpost-specific behavior activates:

- **Instance type discovery**: Queries `DescribeInstanceTypeOfferings` with `LocationType=outpost` to restrict scheduling to instance types physically available on the rack.
- **Subnet filtering**: Only subnets associated with the specified Outpost are considered for launch.
- **EBS volume defaults**: Defaults to `gp2` instead of `gp3` when no explicit `blockDeviceMappings` are provided (first-gen Outposts do not support gp3).
- **Capacity type restriction**: Spot is unavailable on Outposts; only on-demand offerings are considered.

The implementation is backward-compatible. Non-Outpost EC2NodeClasses are completely unaffected - all new logic is gated behind nil checks on the `outpostArn` pointer.

## Configuration Examples

### First-generation Outpost (M5, C5, R5, G4dn, i3en - gp2/io1 only)

```yaml
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: outpost-gen1
spec:
  outpostArn: arn:aws:outposts:us-west-2:111111111111:outpost/op-0123456789abcdef0
  amiFamily: AL2023
  role: KarpenterNodeRole-my-cluster
  amiSelectorTerms:
    - id: ami-0af9e13b4642cbf1e  # EKS 1.31 AL2023
  subnetSelectorTerms:
    - tags:
        karpenter.sh/discovery: my-cluster
  securityGroupSelectorTerms:
    - tags:
        karpenter.sh/discovery: my-cluster
  blockDeviceMappings:
    - deviceName: /dev/xvda
      ebs:
        volumeSize: 50Gi
        volumeType: gp2       # gp3 NOT supported on gen1
        encrypted: true
---
apiVersion: karpenter.sh/v1
kind: NodePool
metadata:
  name: outpost-gen1
spec:
  template:
    spec:
      nodeClassRef:
        group: karpenter.k8s.aws
        kind: EC2NodeClass
        name: outpost-gen1
      requirements:
        - key: karpenter.sh/capacity-type
          operator: In
          values: ["on-demand"]
        - key: node.kubernetes.io/instance-type
          operator: In
          values: ["m5.xlarge", "m5.2xlarge", "c5.xlarge", "r5.xlarge"]
  limits:
    cpu: "64"
  disruption:
    consolidationPolicy: WhenEmpty
    consolidateAfter: 30m
```

### Second-generation Outpost (M7i, C7i, R7i, M8i, C8i, R8i - gp2/gp3/io1)

```yaml
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: outpost-gen2
spec:
  outpostArn: arn:aws:outposts:eu-west-1:222222222222:outpost/op-abcdef0123456789a
  amiFamily: AL2023
  role: KarpenterNodeRole-my-cluster
  amiSelectorTerms:
    - id: ami-0123456789abcdef0  # EKS optimized AMI for your version
  subnetSelectorTerms:
    - tags:
        karpenter.sh/discovery: my-cluster
  securityGroupSelectorTerms:
    - tags:
        karpenter.sh/discovery: my-cluster
  blockDeviceMappings:
    - deviceName: /dev/xvda
      ebs:
        volumeSize: 100Gi
        volumeType: gp3       # gp3 supported on gen2
        encrypted: true
---
apiVersion: karpenter.sh/v1
kind: NodePool
metadata:
  name: outpost-gen2
spec:
  template:
    spec:
      nodeClassRef:
        group: karpenter.k8s.aws
        kind: EC2NodeClass
        name: outpost-gen2
      requirements:
        - key: karpenter.sh/capacity-type
          operator: In
          values: ["on-demand"]
        - key: node.kubernetes.io/instance-type
          operator: In
          values: ["m7i.xlarge", "m7i.2xlarge", "c7i.xlarge", "r7i.xlarge"]
  limits:
    cpu: "128"
  disruption:
    consolidationPolicy: WhenEmpty
    consolidateAfter: 30m
```

## IAM Requirements

No additional IAM permissions are required beyond the standard Karpenter controller policy. The Outpost-specific queries use the same APIs already permitted:

- `ec2:DescribeInstanceTypeOfferings` - same action, called with `LocationType=outpost` filter
- `ec2:DescribeSubnets` - response already includes `OutpostArn` on Outpost subnets

The only difference is the query parameters. Standard Karpenter call:

```bash
aws ec2 describe-instance-type-offerings \
  --location-type availability-zone
```

Outpost-aware call (same IAM action):

```bash
aws ec2 describe-instance-type-offerings \
  --location-type outpost \
  --filters "Name=location,Values=arn:aws:outposts:eu-west-1:222222222222:outpost/op-abcdef0123456789a"
```

Example response showing instance types available on a first-gen Outpost rack:

```
InstanceType   Location                                                          LocationType
c5.large       arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
c5.xlarge      arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
m5.xlarge      arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
m5.2xlarge     arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
m5.4xlarge     arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
r5.large       arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
r5.xlarge      arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
r5.2xlarge     arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
r5.4xlarge     arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
g4dn.2xlarge   arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
g4dn.4xlarge   arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
i3en.2xlarge   arn:aws:outposts:us-west-2:222222222222:outpost/op-abcdef012...     outpost
```

For **shared Outposts** (Outpost owned by account A, used from account B via AWS RAM), no cross-account permissions are needed. The EC2 APIs work transparently on RAM-shared Outpost resources.

## Known Limitations

| Limitation | Detail |
|-----------|--------|
| No spot capacity | Outposts only support on-demand. Karpenter filters spot offerings automatically. |
| Fixed capacity | Outpost hardware is finite. `InsufficientInstanceCapacity` errors are expected when the rack is full. No enhanced backoff is implemented yet. |
| EBS volume types | First-gen: gp2 and io1 only. Second-gen: adds gp3. The auto-default (gp3→gp2) applies to all Outposts; override with explicit `blockDeviceMappings` on gen2 if you want gp3. |
| AMI alias resolution | The `alias` AMI selector (e.g., `al2023@v1.31`) may not resolve on all Karpenter versions. Use explicit AMI IDs via `id` selector for reliability. |
| Single AZ | Each Outpost maps to one AZ. Topology spread across AZs requires a regional NodePool as fallback. |
| No spill-to-region | When Outpost capacity is exhausted, pods remain pending. A separate regional NodePool can serve as overflow (not automated). |
| Pricing | Outpost instances use region on-demand pricing for scheduling decisions. Actual cost is pre-paid via the rack subscription. |
| Generation detection | Karpenter does not auto-detect Outpost generation. Users must set appropriate `volumeType` and instance type requirements for their hardware. |

## Changes

- `pkg/apis/v1/ec2nodeclass.go`: Add `OutpostArn *string` field with ARN pattern validation
- `pkg/apis/v1/ec2nodeclass_status.go`: Add `OutpostArn` to `Subnet` status struct
- `pkg/apis/v1/ec2nodeclass_validation_cel_test.go`: CEL validation tests
- `pkg/controllers/nodeclass/subnet.go`: Propagate `OutpostArn` into subnet status
- `pkg/providers/subnet/subnet.go`: Filter subnets by OutpostArn, propagate in ZonalSubnetsForLaunch, descriptive error on empty result
- `pkg/providers/subnet/suite_test.go`: Unit tests for Outpost subnet filtering
- `pkg/providers/instancetype/instancetype.go`: `getOutpostOfferings()` with caching (5m TTL), filter in `List()`, descriptive error on empty result
- `pkg/providers/instancetype/types.go`: Include OutpostArn in cache key
- `pkg/providers/instancetype/offering/offering.go`: Skip spot offerings when OutpostArn is set
- `pkg/providers/amifamily/resolver.go`: gp3→gp2 override when OutpostArn is set
- `pkg/providers/amifamily/outpost_test.go`: Unit tests for EBS default override
- `pkg/providers/launchtemplate/launchtemplate.go`: Thread OutpostArn into AMI resolver options
- `pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml`: Add outpostArn to CRD schema

## How was this change tested?

- Unit tests for subnet filtering, EBS defaults, and CEL validation
- End-to-end tested on a first-gen Outpost rack (M5/C5/R5/G4dn/i3en) with EKS 1.31
- Verified scale-out: Karpenter provisioned c5.xlarge, r5.xlarge, and m5.2xlarge on the Outpost
- Verified scale-in: Karpenter terminated empty nodes via WhenEmpty consolidation
- Verified backward compatibility: non-Outpost EC2NodeClasses unaffected

## Does this change impact docs?

- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
