### PR TITLE
chore: refactor network interfaces 

### DIFF
--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -292,7 +292,7 @@ func (v *Validation) validateRunInstancesAuthorization(
 	// failures on individual subnets are already handled by the early-exit-on-success pattern.
 	var firstSubnetErr error
 	for i, subnet := range nodeClass.Status.Subnets {
-		runInstancesInput := getRunInstancesInput(tags, launchTemplate, nodeClass.NetworkInterfaces(), &subnet)
+		runInstancesInput := getRunInstancesInput(tags, launchTemplate, amifamily.ResolveNetworkInterfaces(nodeClass.Spec.NetworkInterfaces), &subnet)
 		if _, err = v.ec2api.RunInstances(ctx, runInstancesInput, func(o *ec2.Options) {
 			// Adding NopRetryer to avoid aggressive retry when rate limited
 			o.Retryer = aws.NopRetryer{}
@@ -365,7 +365,7 @@ func (v *Validation) clearCacheEntries(nodeClass *v1.EC2NodeClass) {
 func getRunInstancesInput(
 	tags map[string]string,
 	launchTemplate *launchtemplate.LaunchTemplate,
-	networkInterfaces []*v1.NetworkInterface,
+	networkInterfaces []*amifamily.ResolvedNetworkInterface,
 	subnet *v1.Subnet,
 ) *ec2.RunInstancesInput {
 	return &ec2.RunInstancesInput{
@@ -536,7 +536,7 @@ func getAMICompatibleInstanceTypes(instanceTypes []*cloudprovider.InstanceType, 
 	return selectedInstanceTypes
 }
 
-func getNetworkInterfacesInput(ncNetworkInterfaces []*v1.NetworkInterface, subnet *v1.Subnet) []ec2types.InstanceNetworkInterfaceSpecification {
+func getNetworkInterfacesInput(ncNetworkInterfaces []*amifamily.ResolvedNetworkInterface, subnet *v1.Subnet) []ec2types.InstanceNetworkInterfaceSpecification {
 	defaultInterface := []ec2types.InstanceNetworkInterfaceSpecification{
 		{
 			DeviceIndex: lo.ToPtr[int32](0),
@@ -545,7 +545,7 @@ func getNetworkInterfacesInput(ncNetworkInterfaces []*v1.NetworkInterface, subne
 	}
 	networkInterfaces := lo.Ternary(ncNetworkInterfaces == nil,
 		defaultInterface,
-		lo.Map(ncNetworkInterfaces, func(networkInterface *v1.NetworkInterface, _ int) ec2types.InstanceNetworkInterfaceSpecification {
+		lo.Map(ncNetworkInterfaces, func(networkInterface *amifamily.ResolvedNetworkInterface, _ int) ec2types.InstanceNetworkInterfaceSpecification {
 			return ec2types.InstanceNetworkInterfaceSpecification{
 				NetworkCardIndex: lo.ToPtr(networkInterface.NetworkCardIndex),
 				DeviceIndex:      lo.ToPtr(networkInterface.DeviceIndex),

--- a/pkg/providers/amifamily/networkinterface.go
+++ b/pkg/providers/amifamily/networkinterface.go
@@ -1,0 +1,44 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amifamily
+
+import (
+	"github.com/samber/lo"
+
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+)
+
+type ResolvedNetworkInterface struct {
+	NetworkCardIndex           int32
+	DeviceIndex                int32
+	InterfaceType              v1.InterfaceType
+	SecondaryIPCount           *int32
+	SecondaryIPPrefixCount     *int32
+	SecondaryENISecurityGroups []v1.SecurityGroup
+	SubnetID                   string
+}
+
+func ResolveNetworkInterfaces(nis []*v1.NetworkInterface) []*ResolvedNetworkInterface {
+	if nis == nil {
+		return nil
+	}
+	return lo.Map(nis, func(ni *v1.NetworkInterface, _ int) *ResolvedNetworkInterface {
+		return &ResolvedNetworkInterface{
+			NetworkCardIndex: ni.NetworkCardIndex,
+			DeviceIndex:      ni.DeviceIndex,
+			InterfaceType:    ni.InterfaceType,
+		}
+	})
+}

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -63,13 +63,14 @@ type Options struct {
 	AMISelectorTerms    []v1.AMISelectorTerm `hash:"ignore"` // For Bottlerocket version resolution
 	AMIs                []v1.AMI             `hash:"ignore"` // Resolved AMIs for version extraction
 	// Level-triggered fields that may change out of sync.
-	SecurityGroups           []v1.SecurityGroup
-	Tags                     map[string]string
-	Labels                   map[string]string `hash:"ignore"`
-	KubeDNSIP                net.IP
-	AssociatePublicIPAddress *bool
-	IPPrefixCount            *int32
-	NodeClassName            string
+	SecurityGroups            []v1.SecurityGroup
+	Tags                      map[string]string
+	Labels                    map[string]string `hash:"ignore"`
+	KubeDNSIP                 net.IP
+	AssociatePublicIPAddress  *bool
+	IPPrefixCount             *int32
+	NodeClassName             string
+	ResolvedNetworkInterfaces []*ResolvedNetworkInterface `hash:"ignore"`
 }
 
 // LaunchTemplate holds the dynamically generated launch template parameters
@@ -82,7 +83,7 @@ type LaunchTemplate struct {
 	InstanceTypes                    []*cloudprovider.InstanceType `hash:"ignore"`
 	DetailedMonitoring               bool
 	EFACount                         int
-	NetworkInterfaces                []*v1.NetworkInterface
+	NetworkInterfaces                []*ResolvedNetworkInterface
 	CapacityType                     string
 	CapacityReservationID            string
 	CapacityReservationType          v1.CapacityReservationType
@@ -322,7 +323,7 @@ func (r DefaultResolver) resolveLaunchTemplates(
 			AMIID:                            amiID,
 			InstanceTypes:                    instanceTypes,
 			EFACount:                         efaCount,
-			NetworkInterfaces:                nodeClass.Spec.NetworkInterfaces,
+			NetworkInterfaces:                ResolveNetworkInterfaces(nodeClass.Spec.NetworkInterfaces),
 			CapacityType:                     capacityType,
 			CapacityReservationID:            id,
 			CapacityReservationType:          capacityReservationType,

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -91,6 +91,8 @@ type LaunchTemplate struct {
 	Tenancy                          string
 	PlacementGroupID                 string
 	PlacementGroupPartition          int32
+	// Zone constrains fleet overrides to a single AZ when set.
+	Zone string `hash:"ignore"`
 }
 
 // AMIFamily can be implemented to override the default logic for generating dynamic launch template parameters

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -455,8 +455,18 @@ func (p *DefaultProvider) getLaunchTemplateConfigs(
 	requirements := scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...)
 	requirements[karpv1.CapacityTypeLabelKey] = scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, capacityType)
 	for _, launchTemplate := range launchTemplates {
+		// When a LT is zone-scoped, restrict overrides to only that zone so
+		// fleet doesn't attempt a cross-AZ launch.
+		effectiveSubnets := zonalSubnets
+		if launchTemplate.Zone != "" {
+			if s, ok := zonalSubnets[launchTemplate.Zone]; ok {
+				effectiveSubnets = map[string]*subnet.Subnet{launchTemplate.Zone: s}
+			} else {
+				continue
+			}
+		}
 		launchTemplateConfig := ec2types.FleetLaunchTemplateConfigRequest{
-			Overrides: p.getOverrides(launchTemplate.InstanceTypes, zonalSubnets, requirements, launchTemplate.ImageID, launchTemplate.CapacityReservationID),
+			Overrides: p.getOverrides(launchTemplate.InstanceTypes, effectiveSubnets, requirements, launchTemplate.ImageID, launchTemplate.CapacityReservationID),
 			LaunchTemplateSpecification: &ec2types.FleetLaunchTemplateSpecificationRequest{
 				LaunchTemplateName: aws.String(launchTemplate.Name),
 				Version:            aws.String("$Latest"),

--- a/pkg/providers/instancetype/compatibility/compatibility.go
+++ b/pkg/providers/instancetype/compatibility/compatibility.go
@@ -105,7 +105,7 @@ func (c networkInterfaceCheck) compatibleCheck(info ec2types.InstanceTypeInfo) b
 		}
 		// (4) the configured secondary IP count exceeds instance type capacity
 		totalSecondaryIPsConfigured := lo.FromPtrOr(networkInterface.SecondaryIPPrefixCount, int32(0)) + lo.FromPtrOr(networkInterface.SecondaryIPCount, int32(0))
-		if totalSecondaryIPsConfigured >= lo.FromPtr(info.NetworkInfo.Ipv4AddressesPerInterface) {
+		if totalSecondaryIPsConfigured > 0 && totalSecondaryIPsConfigured >= lo.FromPtr(info.NetworkInfo.Ipv4AddressesPerInterface) {
 			return false
 		}
 	}

--- a/pkg/providers/instancetype/compatibility/compatibility.go
+++ b/pkg/providers/instancetype/compatibility/compatibility.go
@@ -21,6 +21,7 @@ import (
 	"github.com/samber/lo"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/placementgroup"
 )
 
@@ -34,8 +35,9 @@ type CompatibleCheck interface {
 }
 
 func IsCompatibleWithNodeClass(info ec2types.InstanceTypeInfo, nodeClass NodeClass, pg *placementgroup.PlacementGroup) bool {
+	networkInterfaces := amifamily.ResolveNetworkInterfaces(nodeClass.NetworkInterfaces())
 	for _, check := range []CompatibleCheck{
-		networkInterfaceCompatibility(nodeClass.NetworkInterfaces()),
+		networkInterfaceCompatibility(networkInterfaces),
 		amiFamilyCompatibility(nodeClass.AMIFamily()),
 		placementGroupCompatibility(pg),
 	} {
@@ -65,10 +67,10 @@ func (c amiFamilyCheck) compatibleCheck(info ec2types.InstanceTypeInfo) bool {
 }
 
 type networkInterfaceCheck struct {
-	networkInterfaces []*v1.NetworkInterface
+	networkInterfaces []*amifamily.ResolvedNetworkInterface
 }
 
-func networkInterfaceCompatibility(networkInterfaces []*v1.NetworkInterface) CompatibleCheck {
+func networkInterfaceCompatibility(networkInterfaces []*amifamily.ResolvedNetworkInterface) CompatibleCheck {
 	return &networkInterfaceCheck{
 		networkInterfaces: networkInterfaces,
 	}
@@ -101,9 +103,14 @@ func (c networkInterfaceCheck) compatibleCheck(info ec2types.InstanceTypeInfo) b
 		if !found || lo.FromPtr(networkCard.MaximumNetworkInterfaces) <= networkInterface.DeviceIndex {
 			return false
 		}
+		// (4) the configured secondary IP count exceeds instance type capacity
+		totalSecondaryIPsConfigured := lo.FromPtrOr(networkInterface.SecondaryIPPrefixCount, int32(0)) + lo.FromPtrOr(networkInterface.SecondaryIPCount, int32(0))
+		if totalSecondaryIPsConfigured >= lo.FromPtr(info.NetworkInfo.Ipv4AddressesPerInterface) {
+			return false
+		}
 	}
-	// (4) the configured number of EFA-only interfaces is greater than what the instance type offers
-	numEfas := lo.CountBy(c.networkInterfaces, func(nic *v1.NetworkInterface) bool {
+	// (5) the configured number of EFA-only interfaces is greater than what the instance type offers
+	numEfas := lo.CountBy(c.networkInterfaces, func(nic *amifamily.ResolvedNetworkInterface) bool {
 		return nic.InterfaceType == v1.InterfaceTypeEFAOnly
 	})
 	if numEfas > 0 {

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -300,7 +300,7 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 			}
 
 			groups := lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })
-			if ni.SecondaryENISecurityGroups != nil && len(ni.SecondaryENISecurityGroups) > 0 && !(ni.NetworkCardIndex == 0 && ni.DeviceIndex == 0) {
+			if len(ni.SecondaryENISecurityGroups) > 0 && !(ni.NetworkCardIndex == 0 && ni.DeviceIndex == 0) {
 				groups = lo.Map(ni.SecondaryENISecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })
 			}
 			return ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -290,21 +290,32 @@ func (p *DefaultProvider) createLaunchTemplate(ctx context.Context, options *ami
 // generateNetworkInterfaces generates network interfaces for the launch template.
 func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamily corev1.IPFamily) []ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
 	if len(options.NetworkInterfaces) > 0 {
-		return lo.Map(options.NetworkInterfaces, func(networkInterface *v1.NetworkInterface, _ int) ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
+		return lo.Map(options.NetworkInterfaces, func(ni *amifamily.ResolvedNetworkInterface, _ int) ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
 			// Assigning IPPrefixCounts or AssociatePublicIpAddress to EFA-only ENIs results in RunInstances failures w/ InvalidParameterValue
-			typeNotEFAOnly := networkInterface.InterfaceType != v1.InterfaceType(ec2types.NetworkInterfaceTypeEfaOnly)
+			typeNotEFAOnly := ni.InterfaceType != v1.InterfaceType(ec2types.NetworkInterfaceTypeEfaOnly)
+			var ipv4PrefixCount, ipv6PrefixCount, secondaryPrivateIPCount, ipv6AddressCount *int32
+			if typeNotEFAOnly {
+				ipv4PrefixCount, ipv6PrefixCount, secondaryPrivateIPCount, ipv6AddressCount = ipCounts(options, ni, clusterIPFamily)
+			}
+
+			groups := lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })
+			if ni.SecondaryENISecurityGroups != nil && len(ni.SecondaryENISecurityGroups) > 0 && !(ni.NetworkCardIndex == 0 && ni.DeviceIndex == 0) {
+				groups = lo.Map(ni.SecondaryENISecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })
+			}
 			return ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
-				NetworkCardIndex: lo.ToPtr(networkInterface.NetworkCardIndex),
-				DeviceIndex:      lo.ToPtr(networkInterface.DeviceIndex),
-				InterfaceType:    lo.ToPtr(string(networkInterface.InterfaceType)),
-				Ipv4PrefixCount:  lo.Ternary(clusterIPFamily == corev1.IPv4Protocol && typeNotEFAOnly, options.IPPrefixCount, nil),
-				Ipv6PrefixCount:  lo.Ternary(clusterIPFamily == corev1.IPv6Protocol && typeNotEFAOnly, options.IPPrefixCount, nil),
-				Groups:           lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID }),
+				NetworkCardIndex:               lo.ToPtr(ni.NetworkCardIndex),
+				DeviceIndex:                    lo.ToPtr(ni.DeviceIndex),
+				InterfaceType:                  lo.ToPtr(string(ni.InterfaceType)),
+				SubnetId:                       lo.Ternary(ni.SubnetID != "", lo.ToPtr(ni.SubnetID), nil),
+				Ipv4PrefixCount:                ipv4PrefixCount,
+				Ipv6PrefixCount:                ipv6PrefixCount,
+				SecondaryPrivateIpAddressCount: secondaryPrivateIPCount,
+				Groups:                         groups,
 				// Instances launched with multiple pre-configured network interfaces cannot set AssociatePublicIPAddress to true. This is an EC2 limitation. However, this does not apply for instances
 				// with a single ENA network interface, and we should support those use cases. Launch failures with multiple enis as ENA should be considered user misconfiguration.
-				AssociatePublicIpAddress: options.AssociatePublicIPAddress,
+				AssociatePublicIpAddress: lo.Ternary(typeNotEFAOnly, options.AssociatePublicIPAddress, nil),
 				PrimaryIpv6:              lo.Ternary(clusterIPFamily == corev1.IPv6Protocol && typeNotEFAOnly, lo.ToPtr(true), nil),
-				Ipv6AddressCount:         lo.Ternary(clusterIPFamily == corev1.IPv6Protocol && typeNotEFAOnly, lo.ToPtr(int32(1)), nil),
+				Ipv6AddressCount:         ipv6AddressCount,
 			}
 		})
 	}
@@ -342,6 +353,20 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 			Ipv6AddressCount: lo.Ternary(clusterIPFamily == corev1.IPv6Protocol, lo.ToPtr(int32(1)), nil),
 		},
 	}
+}
+
+func ipCounts(options *amifamily.LaunchTemplate, ni *amifamily.ResolvedNetworkInterface, clusterIPFamily corev1.IPFamily) (
+	ipv4PrefixCount *int32, ipv6PrefixCount *int32, secondaryPrivateIPCount *int32, ipv6AddressCount *int32,
+) {
+	if clusterIPFamily == corev1.IPv4Protocol {
+		ipv4PrefixCount = lo.Ternary(ni.SecondaryIPPrefixCount != nil, ni.SecondaryIPPrefixCount, options.IPPrefixCount)
+		secondaryPrivateIPCount = ni.SecondaryIPCount
+	}
+	if clusterIPFamily == corev1.IPv6Protocol {
+		ipv6PrefixCount = lo.Ternary(ni.SecondaryIPPrefixCount != nil, ni.SecondaryIPPrefixCount, options.IPPrefixCount)
+		ipv6AddressCount = lo.Ternary(ni.SecondaryIPCount != nil, ni.SecondaryIPCount, lo.ToPtr(int32(1)))
+	}
+	return ipv4PrefixCount, ipv6PrefixCount, secondaryPrivateIPCount, ipv6AddressCount
 }
 
 func blockDeviceMappings(blockDeviceMappings []*v1.BlockDeviceMapping) []ec2types.LaunchTemplateBlockDeviceMappingRequest {

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -300,7 +300,7 @@ func generateNetworkInterfaces(options *amifamily.LaunchTemplate, clusterIPFamil
 			}
 
 			groups := lo.Map(options.SecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })
-			if len(ni.SecondaryENISecurityGroups) > 0 && !(ni.NetworkCardIndex == 0 && ni.DeviceIndex == 0) {
+			if len(ni.SecondaryENISecurityGroups) > 0 && (ni.NetworkCardIndex != 0 || ni.DeviceIndex != 0) {
 				groups = lo.Map(ni.SecondaryENISecurityGroups, func(s v1.SecurityGroup, _ int) string { return s.ID })
 			}
 			return ec2types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -189,6 +189,7 @@ func (p *DefaultProvider) EnsureAll(
 			InstanceTypes:         resolvedLaunchTemplate.InstanceTypes,
 			ImageID:               resolvedLaunchTemplate.AMIID,
 			CapacityReservationID: resolvedLaunchTemplate.CapacityReservationID,
+			Zone:                  resolvedLaunchTemplate.Zone,
 		})
 	}
 	return launchTemplates, nil

--- a/pkg/providers/launchtemplate/types.go
+++ b/pkg/providers/launchtemplate/types.go
@@ -44,6 +44,8 @@ type LaunchTemplate struct {
 	InstanceTypes         []*cloudprovider.InstanceType
 	ImageID               string
 	CapacityReservationID string
+	// Optional to constrains fleet overrides to a single AZ.
+	Zone string
 }
 
 type LaunchMode int


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
*  Introduces ResolvedNetworkInterface as an intermediate representation between the API-level NetworkInterface spec and the EC2 launch template request  
* Zone-scoped launch templates that restrict fleet overrides to a single AZ

**How was this change tested?**
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.