### PR TITLE
test: increase AMI test timeout to 60s

### DIFF
--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -436,6 +436,6 @@ func EventuallyExpectAMIsToExist(nodeClass *v1.EC2NodeClass) *v1.EC2NodeClass {
 	Eventually(func(g Gomega) {
 		g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nodeClass), nc)).To(Succeed())
 		g.Expect(nc.Status.AMIs).ToNot(BeNil())
-	}).WithTimeout(30 * time.Second).Should(Succeed())
+	}).WithTimeout(60 * time.Second).Should(Succeed())
 	return nc
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The wildcard AMI test
https://github.com/aws/karpenter-provider-aws/blob/37652337e39fcff3f51e39b218519220915f8c9a/test/suites/ami/suite_test.go#L256
calls the EC2 `describe-images` API with a wildcard filter. With a 30s timeout this test always fails (somehow the CI testing seems to get the results from the EC2 API faster). Running the same query from the CLI takes 45s to 50s.

Query built by the test
```json
{"DryRun":null,"ExecutableUsers":null,"Filters":[{"Name":"name","Values":["*"]},{"Name":"state","Values":["available"]}],"ImageIds":null,"IncludeDeprecated":true,"IncludeDisabled":null,"MaxResults":1000,"NextToken":null,"Owners":["self","amazon"]}
```

Equivalent query I ran in CLI
```zsh
aws ec2 describe-images \
  --owners self amazon \
  --filters "Name=name,Values=*" "Name=state,Values=available" \
  --include-deprecated \
  --max-items 1000
```

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.