### PR TITLE
docs: corrected arc-zonal-shift condition key in cloudformation docs

### DIFF
--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -511,7 +511,7 @@ For the cluster that will be created (`arn:${AWS::Partition}:eks:${AWS::Region}:
   ],
   "Condition": {
     "StringEquals": {
-      "aws:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+      "arc-zonal-shift:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
     }
   }
 }

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -511,7 +511,7 @@ For the cluster that will be created (`arn:${AWS::Partition}:eks:${AWS::Region}:
   ],
   "Condition": {
     "StringEquals": {
-      "aws:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+      "arc-zonal-shift:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
     }
   }
 }

--- a/website/content/en/v1.12/reference/cloudformation.md
+++ b/website/content/en/v1.12/reference/cloudformation.md
@@ -511,7 +511,7 @@ For the cluster that will be created (`arn:${AWS::Partition}:eks:${AWS::Region}:
   ],
   "Condition": {
     "StringEquals": {
-      "aws:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+      "arc-zonal-shift:ResourceIdentifier": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
     }
   }
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.



Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->
docs: correct arc-zonal-shift condition key in cloudformation docs

Fixes #9136  <!-- issue number -->

**Description**

The IAM policy condition key for ARC Zonal Shift was documented as `aws:ResourceIdentifier` across all three doc versions. The correct namespace is `arc-zonal-shift:ResourceIdentifier`. This was partially fixed in #9123 but the cloudformation.md files were missed.

**How was this change tested?**

Manually verified via grep that no remaining instances of aws:ResourceIdentifier exist in the zonal shift policy block across the changed files.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.