### PR TITLE
docs: clarify security group name selector behavior

### DIFF
--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -677,14 +677,14 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by group name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
+
+When `name` is specified, the selector resolves by security group name. Tags in the same term are not used for filtering; use `tags` without `name` to match tag conditions.
 
 Select using multiple tag terms:
 ```yaml

--- a/website/content/en/v1.0/concepts/nodeclasses.md
+++ b/website/content/en/v1.0/concepts/nodeclasses.md
@@ -637,14 +637,14 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by group name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
+
+When `name` is specified, the selector resolves by security group name. Tags in the same term are not used for filtering; use `tags` without `name` to match tag conditions.
 
 Select using multiple tag terms:
 ```yaml

--- a/website/content/en/v1.10/concepts/nodeclasses.md
+++ b/website/content/en/v1.10/concepts/nodeclasses.md
@@ -663,14 +663,14 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by group name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
+
+When `name` is specified, the selector resolves by security group name. Tags in the same term are not used for filtering; use `tags` without `name` to match tag conditions.
 
 Select using multiple tag terms:
 ```yaml

--- a/website/content/en/v1.11/concepts/nodeclasses.md
+++ b/website/content/en/v1.11/concepts/nodeclasses.md
@@ -677,14 +677,14 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by group name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
+
+When `name` is specified, the selector resolves by security group name. Tags in the same term are not used for filtering; use `tags` without `name` to match tag conditions.
 
 Select using multiple tag terms:
 ```yaml

--- a/website/content/en/v1.12/concepts/nodeclasses.md
+++ b/website/content/en/v1.12/concepts/nodeclasses.md
@@ -677,14 +677,14 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by group name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
+
+When `name` is specified, the selector resolves by security group name. Tags in the same term are not used for filtering; use `tags` without `name` to match tag conditions.
 
 Select using multiple tag terms:
 ```yaml


### PR DESCRIPTION
Summary:
- Clarify that `securityGroupSelectorTerms[].name` selects by security group name.
- Remove the same-term `tags` example from the name selector path, since the resolver handles `name` before tag filters.
- Apply the clarification to preview and versioned docs per the documentation update guide.

Verification:
- `git diff --check`
- `npm ci` from `website/`
- `npx hugo --minify` was attempted; it stops before site rendering with the existing Hugo/template mismatch: `no such template "_internal/google_analytics_async.html"` after a Hugo module compatibility warning.

This was prepared with Codex assistance, with the final diff reviewed before opening.

Fixes #9157