### PR TITLE
docs: note eks:DescribeCluster requirement for Zonal Shift onboarding

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
@@ -233,6 +233,8 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
     }
     ```
 
+    Karpenter also requires permission for `eks:DescribeCluster` when Zonal Shift is enabled. The standard onboarding's `KarpenterControllerEKSIntegrationPolicy` already grants this; if you manage IAM manually, make sure the controller role has `eks:DescribeCluster` on the cluster resource.
+
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -233,6 +233,8 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
     }
     ```
 
+    Karpenter also requires permission for `eks:DescribeCluster` when Zonal Shift is enabled. The standard onboarding's `KarpenterControllerEKSIntegrationPolicy` already grants this; if you manage IAM manually, make sure the controller role has `eks:DescribeCluster` on the cluster resource.
+
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
@@ -233,6 +233,8 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
     }
     ```
 
+    Karpenter also requires permission for `eks:DescribeCluster` when Zonal Shift is enabled. The standard onboarding's `KarpenterControllerEKSIntegrationPolicy` already grants this; if you manage IAM manually, make sure the controller role has `eks:DescribeCluster` on the cluster resource.
+
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash


### PR DESCRIPTION
Fixes the docs gap in #9151 (the docs half of @ryan-mist's [#9153](https://github.com/aws/karpenter-provider-aws/pull/9153)).

## Description

Karpenter calls \`eks:DescribeCluster\` at startup when \`enableZonalShift\` is true, to look up the cluster ARN. Users following the getting-started CloudFormation template are already covered: \`KarpenterControllerEKSIntegrationPolicy\` grants \`eks:DescribeCluster\` for API server discovery. But users who manage IAM manually and only follow the Zonal Shift onboarding section's JSON snippet (which lists only \`arc-zonal-shift:GetManagedResource\`) were missing this requirement, and Karpenter would panic at startup when DescribeCluster was denied.

This adds a short note immediately under the existing Zonal Shift IAM JSON block in both \`preview/\` and \`docs/\` versions of the getting-started guide, pointing manual-IAM users at the requirement and noting that the standard onboarding already covers it.

No code changes. CloudFormation template already includes the permission and needs no changes.