### PR TITLE
chore: add testing for resolved network interfaces

### DIFF
--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -41,12 +41,16 @@ import (
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
+	"github.com/patrickmn/go-cache"
+
 	"github.com/aws/karpenter-provider-aws/pkg/apis"
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider"
 	"github.com/aws/karpenter-provider-aws/pkg/fake"
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/amifamily"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/instance"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -910,4 +914,129 @@ var _ = Describe("InstanceProvider", func() {
 			})
 		})
 	})
+	Context("Zonal Override Filtering", func() {
+		var instanceProvider *instance.DefaultProvider
+		var mockLTProvider *mockLaunchTemplateProvider
+		BeforeEach(func() {
+			mockLTProvider = &mockLaunchTemplateProvider{}
+			instanceProvider = instance.NewDefaultProvider(
+				ctx,
+				fake.DefaultRegion,
+				events.NewRecorder(&record.FakeRecorder{}),
+				awsEnv.EC2API,
+				awsEnv.UnavailableOfferingsCache,
+				awsEnv.SubnetProvider,
+				mockLTProvider,
+				awsEnv.CapacityReservationProvider,
+				awsEnv.PlacementGroupProvider,
+				awsEnv.ZonalShiftProvider,
+				cache.New(cache.NoExpiration, cache.NoExpiration),
+			)
+		})
+		It("should restrict fleet overrides to matching zone when Zone is set", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+
+			mockLTProvider.launchTemplates = []*launchtemplate.LaunchTemplate{
+				{Name: "lt-zone-scoped", Zone: "test-zone-1a", InstanceTypes: instanceTypes, ImageID: "ami-test"},
+			}
+			awsEnv.EC2API.CreateFleetBehavior.Output.Set(&ec2.CreateFleetOutput{
+				Instances: []ec2types.CreateFleetInstance{{
+					InstanceIds:  []string{fake.InstanceID()},
+					InstanceType: "m5.xlarge",
+					LaunchTemplateAndOverrides: &ec2types.LaunchTemplateAndOverridesResponse{
+						Overrides: &ec2types.FleetLaunchTemplateOverrides{
+							SubnetId:         lo.ToPtr("subnet-test1"),
+							AvailabilityZone: lo.ToPtr("test-zone-1a"),
+						},
+					},
+				}},
+			})
+
+			_, err = instanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(awsEnv.EC2API.CreateFleetBehavior.CalledWithInput.Len()).To(Equal(1))
+			createFleetInput := awsEnv.EC2API.CreateFleetBehavior.CalledWithInput.Pop()
+			for _, ltConfig := range createFleetInput.LaunchTemplateConfigs {
+				for _, override := range ltConfig.Overrides {
+					Expect(lo.FromPtr(override.AvailabilityZone)).To(Equal("test-zone-1a"))
+				}
+			}
+		})
+		It("should return error when Zone has no matching subnet", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+
+			mockLTProvider.launchTemplates = []*launchtemplate.LaunchTemplate{
+				{Name: "lt-no-zone", Zone: "test-zone-nonexistent", InstanceTypes: instanceTypes, ImageID: "ami-test"},
+			}
+
+			_, err = instanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no capacity offerings"))
+		})
+		It("should use all subnets when Zone is empty", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+
+			mockLTProvider.launchTemplates = []*launchtemplate.LaunchTemplate{
+				{Name: "lt-no-zone", Zone: "", InstanceTypes: instanceTypes, ImageID: "ami-test"},
+			}
+			awsEnv.EC2API.CreateFleetBehavior.Output.Set(&ec2.CreateFleetOutput{
+				Instances: []ec2types.CreateFleetInstance{{
+					InstanceIds:  []string{fake.InstanceID()},
+					InstanceType: "m5.xlarge",
+					LaunchTemplateAndOverrides: &ec2types.LaunchTemplateAndOverridesResponse{
+						Overrides: &ec2types.FleetLaunchTemplateOverrides{
+							SubnetId:         lo.ToPtr("subnet-test1"),
+							AvailabilityZone: lo.ToPtr("test-zone-1a"),
+						},
+					},
+				}},
+			})
+
+			_, err = instanceProvider.Create(ctx, nodeClass, nodeClaim, nil, instanceTypes)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(awsEnv.EC2API.CreateFleetBehavior.CalledWithInput.Len()).To(Equal(1))
+			createFleetInput := awsEnv.EC2API.CreateFleetBehavior.CalledWithInput.Pop()
+			zones := sets.New[string]()
+			for _, ltConfig := range createFleetInput.LaunchTemplateConfigs {
+				for _, override := range ltConfig.Overrides {
+					zones.Insert(lo.FromPtr(override.AvailabilityZone))
+				}
+			}
+			Expect(zones.Len()).To(BeNumerically(">", 1))
+		})
+	})
 })
+
+type mockLaunchTemplateProvider struct {
+	launchTemplates []*launchtemplate.LaunchTemplate
+}
+
+func (m *mockLaunchTemplateProvider) EnsureAll(_ context.Context, _ *v1.EC2NodeClass, _ *karpv1.NodeClaim,
+	_ []*corecloudprovider.InstanceType, _ string, _ map[string]string, _ string) ([]*launchtemplate.LaunchTemplate, error) {
+	return m.launchTemplates, nil
+}
+
+func (m *mockLaunchTemplateProvider) DeleteAll(_ context.Context, _ *v1.EC2NodeClass) error {
+	return nil
+}
+
+func (m *mockLaunchTemplateProvider) InvalidateCache(_ context.Context, _ string, _ string) {}
+
+func (m *mockLaunchTemplateProvider) ResolveClusterCIDR(_ context.Context) error {
+	return nil
+}
+
+func (m *mockLaunchTemplateProvider) CreateAMIOptions(_ context.Context, _ *v1.EC2NodeClass, _ map[string]string, _ map[string]string) (*amifamily.Options, error) {
+	return nil, nil
+}

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -2587,6 +2587,175 @@ eviction-max-pod-grace-period = 10
 			Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[1].PrimaryIpv6)).To(Equal(false))
 			Expect(input.LaunchTemplateData.NetworkInterfaces[1].Ipv6AddressCount).To(BeNil())
 		})
+		DescribeTable("ResolvedNetworkInterface fields",
+			func(setup func(*amifamily.LaunchTemplate), ipFamily corev1.IPFamily, assertFn func(*ec2.CreateLaunchTemplateInput)) {
+				opts := &amifamily.LaunchTemplate{
+					Options: &amifamily.Options{
+						SecurityGroups: []v1.SecurityGroup{{ID: "sg-default1"}, {ID: "sg-default2"}},
+						IPPrefixCount:  lo.ToPtr(int32(1)),
+					},
+					MetadataOptions: &v1.MetadataOptions{
+						HTTPEndpoint:            lo.ToPtr("enabled"),
+						HTTPProtocolIPv6:        lo.ToPtr("disabled"),
+						HTTPPutResponseHopLimit: lo.ToPtr(int64(2)),
+						HTTPTokens:              lo.ToPtr("required"),
+					},
+				}
+				setup(opts)
+				input := launchtemplate.NewCreateLaunchTemplateInputBuilder(opts, ipFamily, "").Build(ctx)
+				assertFn(input)
+			},
+			Entry("should use SecondaryIPPrefixCount over IPPrefixCount for IPv4",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface, SecondaryIPPrefixCount: lo.ToPtr(int32(5))},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].Ipv4PrefixCount)).To(Equal(int32(5)))
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].Ipv6PrefixCount).To(BeNil())
+				},
+			),
+			Entry("should fall back to IPPrefixCount when SecondaryIPPrefixCount is nil for IPv4",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].Ipv4PrefixCount)).To(Equal(int32(1)))
+				},
+			),
+			Entry("should use SecondaryIPPrefixCount over IPPrefixCount for IPv6",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface, SecondaryIPPrefixCount: lo.ToPtr(int32(4))},
+					}
+				},
+				corev1.IPv6Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].Ipv6PrefixCount)).To(Equal(int32(4)))
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].Ipv4PrefixCount).To(BeNil())
+				},
+			),
+			Entry("should set SecondaryPrivateIpAddressCount from SecondaryIPCount for IPv4",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface, SecondaryIPCount: lo.ToPtr(int32(10))},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].SecondaryPrivateIpAddressCount)).To(Equal(int32(10)))
+				},
+			),
+			Entry("should set Ipv6AddressCount from SecondaryIPCount for IPv6",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface, SecondaryIPCount: lo.ToPtr(int32(7))},
+					}
+				},
+				corev1.IPv6Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].Ipv6AddressCount)).To(Equal(int32(7)))
+				},
+			),
+			Entry("should default Ipv6AddressCount to 1 when SecondaryIPCount is nil for IPv6",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface},
+					}
+				},
+				corev1.IPv6Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].Ipv6AddressCount)).To(Equal(int32(1)))
+				},
+			),
+			Entry("should use SecondaryENISecurityGroups on non-primary interface",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface},
+						{NetworkCardIndex: 1, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface, SecondaryENISecurityGroups: []v1.SecurityGroup{{ID: "sg-sec1"}}},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].Groups).To(Equal([]string{"sg-default1", "sg-default2"}))
+					Expect(input.LaunchTemplateData.NetworkInterfaces[1].Groups).To(Equal([]string{"sg-sec1"}))
+				},
+			),
+			Entry("should ignore SecondaryENISecurityGroups on primary interface",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface, SecondaryENISecurityGroups: []v1.SecurityGroup{{ID: "sg-should-ignore"}}},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].Groups).To(Equal([]string{"sg-default1", "sg-default2"}))
+				},
+			),
+			Entry("should use SecondaryENISecurityGroups on non-primary by device index",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 1, InterfaceType: v1.InterfaceTypeInterface, SecondaryENISecurityGroups: []v1.SecurityGroup{{ID: "sg-sec1"}}},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].Groups).To(Equal([]string{"sg-sec1"}))
+				},
+			),
+			Entry("should set SubnetId when SubnetID is configured",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface, SubnetID: "subnet-custom"},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(lo.FromPtr(input.LaunchTemplateData.NetworkInterfaces[0].SubnetId)).To(Equal("subnet-custom"))
+				},
+			),
+			Entry("should leave SubnetId nil when SubnetID is empty",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeInterface},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].SubnetId).To(BeNil())
+				},
+			),
+			Entry("should not set IP counts on EFA-only interfaces",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeEFAOnly, SecondaryIPPrefixCount: lo.ToPtr(int32(5)), SecondaryIPCount: lo.ToPtr(int32(3))},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].Ipv4PrefixCount).To(BeNil())
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].Ipv6PrefixCount).To(BeNil())
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].SecondaryPrivateIpAddressCount).To(BeNil())
+				},
+			),
+			Entry("should not set AssociatePublicIpAddress on EFA-only interfaces",
+				func(opts *amifamily.LaunchTemplate) {
+					opts.AssociatePublicIPAddress = lo.ToPtr(true)
+					opts.NetworkInterfaces = []*amifamily.ResolvedNetworkInterface{
+						{NetworkCardIndex: 0, DeviceIndex: 0, InterfaceType: v1.InterfaceTypeEFAOnly},
+					}
+				},
+				corev1.IPv4Protocol,
+				func(input *ec2.CreateLaunchTemplateInput) {
+					Expect(input.LaunchTemplateData.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeNil())
+				},
+			),
+		)
 	})
 	Context("Tenancy", func() {
 		DescribeTable("should set tenancy on launch template",


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds testing from https://github.com/aws/karpenter-provider-aws/commit/a761afccd14ec9098432e126144f0f0d4a4f0238. Both around zonal override constraints when calling CreateFleet and launch template configurations from the resolved network interface fields.

**How was this change tested?**
* make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.