### PR TITLE
test: Update AMI pinned version test to get pinned version from SSM

### DIFF
--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -405,6 +405,62 @@ func (env *Environment) GetAMIBySSMPath(ssmPath string) string {
 	return *parameter.Parameter.Value
 }
 
+// getPinnedAMIPath returns any one valid pinned AMI path which is a child of the SSM path supplied
+func (env *Environment) getPinnedAMIPath(ssmPath string) string {
+	GinkgoHelper()
+
+	paginator := ssm.NewGetParametersByPathPaginator(env.SSMAPI, &ssm.GetParametersByPathInput{
+		Path:      aws.String(ssmPath),
+		Recursive: aws.Bool(true),
+	})
+	var amiPath string
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(env.Context)
+		Expect(err).ToNot(HaveOccurred())
+		for _, param := range page.Parameters {
+			name := aws.ToString(param.Name)
+			// Get only the image_id path so we know what suffix to trim later
+			if !strings.Contains(name, "recommended") && !strings.Contains(name, "latest") && strings.HasSuffix(name, "/image_id") {
+				amiPath = name
+				break
+			}
+		}
+		if amiPath != "" {
+			break
+		}
+	}
+	Expect(amiPath).ToNot(BeEmpty(), "no pinned AMI version found under SSM path: %s", ssmPath)
+	amiPath = strings.TrimSuffix(amiPath, "/image_id")
+	return amiPath
+}
+
+// GetPinnedAMIVersion returns any one valid pinned AMI version for the AMI family supplied
+func (env *Environment) GetPinnedAMIVersion(amiFamily string) string {
+	GinkgoHelper()
+
+	k8sVersion := env.K8sVersion()
+	var ssmPath string
+	switch amiFamily {
+	case "al2023":
+		ssmPath = fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard", k8sVersion)
+	case "al2":
+		ssmPath = fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2", k8sVersion)
+	case "bottlerocket":
+		ssmPath = fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64", k8sVersion)
+	}
+	amiPath := env.getPinnedAMIPath(ssmPath)
+	pathParts := strings.Split(amiPath, "/")
+	var amiVersion string
+	if strings.Contains(ssmPath, "bottlerocket") {
+		amiVersion = pathParts[len(pathParts)-1]
+	} else {
+		lastPathPart := pathParts[len(pathParts)-1]
+		parts := strings.Split(lastPathPart, "-")
+		amiVersion = parts[len(parts)-1]
+	}
+	return amiVersion
+}
+
 func (env *Environment) GetDeprecatedAMI(amiID string, amifamily string) string {
 	out, err := env.EC2API.DescribeImages(env.Context, &ec2.DescribeImagesInput{
 		Filters: []ec2types.Filter{

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -218,22 +218,10 @@ var _ = Describe("AMI", func() {
 
 	Context("AMIFamily", func() {
 		DescribeTable(
-			"should provision a node using an alias",
+			"should provision a node using the latest alias",
 			func(alias string) {
 				if strings.HasPrefix(alias, "al2@") && env.K8sMinorVersion() > 32 {
 					Skip("AL2 is not supported on versions > 1.32")
-				}
-				amiParts := strings.SplitN(alias, "@", 2)
-				amiFamily := amiParts[0]
-				amiVersion := amiParts[1]
-				if amiVersion == "pinned-with-v" || amiVersion == "pinned-without-v" {
-					amiAlias := env.GetPinnedAMIVersion(amiFamily)
-					if amiVersion == "pinned-without-v" {
-						amiAlias = strings.TrimPrefix(amiAlias, "v")
-					} else if amiVersion == "pinned-with-v" && !strings.HasPrefix(amiAlias, "v") {
-						amiAlias = "v" + amiAlias
-					}
-					alias = fmt.Sprintf("%s@%s", amiFamily, amiAlias)
 				}
 				pod := coretest.Pod()
 				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
@@ -242,12 +230,32 @@ var _ = Describe("AMI", func() {
 				env.ExpectCreatedNodeCount("==", 1)
 			},
 			Entry("AL2023 (latest)", "al2023@latest"),
-			Entry("AL2023 (pinned)", "al2023@pinned-with-v"),
 			Entry("AL2 (latest)", "al2@latest"),
-			Entry("AL2 (pinned)", "al2@pinned-with-v"),
 			Entry("Bottlerocket (latest)", "bottlerocket@latest"),
-			Entry("Bottlerocket (pinned with v prefix)", "bottlerocket@pinned-with-v"),
-			Entry("Bottlerocket (pinned without v prefix)", "bottlerocket@pinned-without-v"),
+		)
+		DescribeTable(
+			"should provision a node using a pinned alias",
+			func(amiFamily string, withV bool) {
+				if amiFamily == "al2" && env.K8sMinorVersion() > 32 {
+					Skip("AL2 is not supported on versions > 1.32")
+				}
+				amiVersion := env.GetPinnedAMIVersion(amiFamily)
+				if !withV {
+					amiVersion = strings.TrimPrefix(amiVersion, "v")
+				} else if withV && !strings.HasPrefix(amiVersion, "v") {
+					amiVersion = "v" + amiVersion
+				}
+				alias := fmt.Sprintf("%s@%s", amiFamily, amiVersion)
+				pod := coretest.Pod()
+				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
+				env.ExpectCreated(nodeClass, nodePool, pod)
+				env.EventuallyExpectHealthy(pod)
+				env.ExpectCreatedNodeCount("==", 1)
+			},
+			Entry("AL2023 (pinned)", "al2023", true),
+			Entry("AL2 (pinned)", "al2", true),
+			Entry("Bottlerocket (pinned with v prefix)", "bottlerocket", true),
+			Entry("Bottlerocket (pinned without v prefix)", "bottlerocket", false),
 		)
 		It("should support Custom AMIFamily with AMI Selectors", func() {
 			al2023AMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))

--- a/test/suites/ami/suite_test.go
+++ b/test/suites/ami/suite_test.go
@@ -223,6 +223,18 @@ var _ = Describe("AMI", func() {
 				if strings.HasPrefix(alias, "al2@") && env.K8sMinorVersion() > 32 {
 					Skip("AL2 is not supported on versions > 1.32")
 				}
+				amiParts := strings.SplitN(alias, "@", 2)
+				amiFamily := amiParts[0]
+				amiVersion := amiParts[1]
+				if amiVersion == "pinned-with-v" || amiVersion == "pinned-without-v" {
+					amiAlias := env.GetPinnedAMIVersion(amiFamily)
+					if amiVersion == "pinned-without-v" {
+						amiAlias = strings.TrimPrefix(amiAlias, "v")
+					} else if amiVersion == "pinned-with-v" && !strings.HasPrefix(amiAlias, "v") {
+						amiAlias = "v" + amiAlias
+					}
+					alias = fmt.Sprintf("%s@%s", amiFamily, amiAlias)
+				}
 				pod := coretest.Pod()
 				nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: alias}}
 				env.ExpectCreated(nodeClass, nodePool, pod)
@@ -230,12 +242,12 @@ var _ = Describe("AMI", func() {
 				env.ExpectCreatedNodeCount("==", 1)
 			},
 			Entry("AL2023 (latest)", "al2023@latest"),
-			Entry("AL2023 (pinned)", "al2023@v20250116"),
+			Entry("AL2023 (pinned)", "al2023@pinned-with-v"),
 			Entry("AL2 (latest)", "al2@latest"),
-			Entry("AL2 (pinned)", "al2@v20250116"),
+			Entry("AL2 (pinned)", "al2@pinned-with-v"),
 			Entry("Bottlerocket (latest)", "bottlerocket@latest"),
-			Entry("Bottlerocket (pinned with v prefix)", "bottlerocket@v1.53.0"),
-			Entry("Bottlerocket (pinned without v prefix)", "bottlerocket@1.53.0"),
+			Entry("Bottlerocket (pinned with v prefix)", "bottlerocket@pinned-with-v"),
+			Entry("Bottlerocket (pinned without v prefix)", "bottlerocket@pinned-without-v"),
 		)
 		It("should support Custom AMIFamily with AMI Selectors", func() {
 			al2023AMI := env.GetAMIBySSMPath(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", env.K8sVersion()))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The pinned version test in the AMI suite currently hardcodes pinned version. This causes the test to fail every time there is a new K8s version unless manually updated (https://github.com/aws/karpenter-provider-aws/pull/8910). This PR changes the test to query SSM for an up-to-date AMI version and use that as the pinned version.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.