### PR TITLE
fix: create managed instance profile when migrating spec.instanceProfile to spec.role with the same underlying role

### DIFF
--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -175,7 +175,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 }
 
 func (c *Controller) cleanupInstanceProfiles(ctx context.Context, nodeClass *v1.EC2NodeClass) error {
-	pathPrefix := instanceprofile.FormatPath("karpenter", c.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID))
+	pathPrefix := instanceprofile.KarpenterPath(c.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID))
 	out, err := c.instanceProfileProvider.ListProfiles(ctx, pathPrefix)
 
 	if err != nil {

--- a/pkg/controllers/nodeclass/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclass/garbagecollection/controller.go
@@ -112,7 +112,7 @@ func (c *Controller) cleanupInactiveProfiles(ctx context.Context) error {
 		return err
 	}
 
-	clusterPathPrefix := instanceprofile.FormatPath("karpenter", c.region, options.FromContext(ctx).ClusterName)
+	clusterPathPrefix := instanceprofile.KarpenterPath(c.region, options.FromContext(ctx).ClusterName)
 	profiles, err := c.instanceProfileProvider.ListProfiles(ctx, clusterPathPrefix)
 	if err != nil {
 		return fmt.Errorf("listing instance profiles, %w", err)

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -17,6 +17,7 @@ package nodeclass
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
@@ -55,6 +56,11 @@ func (ip *InstanceProfile) protectProfile(profile string) {
 func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	if nodeClass.Spec.Role != "" {
 		var currentRole string
+		// managed is true when status.InstanceProfile points to a profile karpenter owns
+		// (identified by the karpenter IAM path prefix). When migrating from spec.instanceProfile
+		// to spec.role, status.InstanceProfile still holds the user's static profile name, which
+		// is not managed and must be replaced. See #9028.
+		var managed bool
 		oldProfileName := nodeClass.Status.InstanceProfile
 		// Use a short-lived cache to prevent instance profile recreation for the same role in the same EC2NodeClass
 		// in case of a status patch error in the EC2NodeClass controller
@@ -69,13 +75,18 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 				if !awserrors.IsNotFound(err) {
 					return reconcile.Result{}, fmt.Errorf("getting instance profile %s, %w", nodeClass.Status.InstanceProfile, err)
 				}
-			} else if len(profile.Roles) > 0 {
-				currentRole = lo.FromPtr(profile.Roles[0].RoleName)
+			} else {
+				managedPrefix := instanceprofile.FormatPath("karpenter", ip.region, options.FromContext(ctx).ClusterName)
+				managed = strings.HasPrefix(lo.FromPtr(profile.Path), managedPrefix)
+				if managed && len(profile.Roles) > 0 {
+					currentRole = lo.FromPtr(profile.Roles[0].RoleName)
+				}
 			}
 		}
 
-		// If role has changed, create new profile
-		if currentRole != nodeClass.Spec.Role {
+		// Create a new managed profile if we don't already own one, or if the role on the
+		// owned profile differs from the requested spec.role.
+		if !managed || currentRole != nodeClass.Spec.Role {
 			// Generate new profile name
 			newProfileName := nodeClass.InstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
 

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -57,10 +57,30 @@ func (ip *InstanceProfile) protectProfile(profile string) {
 	}
 }
 
+func (ip *InstanceProfile) getCurrentRole(ctx context.Context, nodeClass *v1.EC2NodeClass) (string, bool, error) {
+	if nodeClass.Status.InstanceProfile == "" {
+		return "", false, nil
+	}
+
+	profile, err := ip.instanceProfileProvider.Get(ctx, nodeClass.Status.InstanceProfile)
+	if err != nil {
+		if awserrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("getting instance profile %s, %w", nodeClass.Status.InstanceProfile, err)
+	}
+
+	managedPathPrefix := instanceprofile.KarpenterPath(ip.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID))
+	currentProfileIsManaged := strings.HasPrefix(lo.FromPtr(profile.Path), managedPathPrefix) ||
+		nodeClass.Status.InstanceProfile == nodeClass.LegacyInstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
+	if !currentProfileIsManaged || len(profile.Roles) == 0 {
+		return "", currentProfileIsManaged, nil
+	}
+	return lo.FromPtr(profile.Roles[0].RoleName), true, nil
+}
+
 func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	if nodeClass.Spec.Role != "" {
-		var currentRole string
-		var currentProfileIsManaged bool
 		oldProfileName := nodeClass.Status.InstanceProfile
 		// Use a short-lived cache to prevent instance profile recreation for the same role in the same EC2NodeClass
 		// in case of a status patch error in the EC2NodeClass controller
@@ -68,21 +88,9 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 			nodeClass.Status.InstanceProfile = profileName.(string)
 		}
 
-		// Get the current profile info if it exists
-		if nodeClass.Status.InstanceProfile != "" {
-			profile, err := ip.instanceProfileProvider.Get(ctx, nodeClass.Status.InstanceProfile)
-			if err != nil {
-				if !awserrors.IsNotFound(err) {
-					return reconcile.Result{}, fmt.Errorf("getting instance profile %s, %w", nodeClass.Status.InstanceProfile, err)
-				}
-			} else {
-				managedPathPrefix := instanceprofile.FormatPath("karpenter", ip.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID))
-				currentProfileIsManaged = strings.HasPrefix(lo.FromPtr(profile.Path), managedPathPrefix) ||
-					nodeClass.Status.InstanceProfile == nodeClass.LegacyInstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
-				if currentProfileIsManaged && len(profile.Roles) > 0 {
-					currentRole = lo.FromPtr(profile.Roles[0].RoleName)
-				}
-			}
+		currentRole, currentProfileIsManaged, err := ip.getCurrentRole(ctx, nodeClass)
+		if err != nil {
+			return reconcile.Result{}, err
 		}
 
 		// Create a new managed profile if status references a user-managed profile or the
@@ -96,7 +104,7 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 				newProfileName,
 				nodeClass.InstanceProfileRole(),
 				nodeClass.InstanceProfileTags(options.FromContext(ctx).ClusterName, ip.region),
-				instanceprofile.FormatPath("karpenter", ip.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID)),
+				instanceprofile.KarpenterPath(ip.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID)),
 			); err != nil {
 				// If we failed Create, we may have successfully created the instance profile but failed to either attach the new
 				// role or remove the existing role. To prevent runaway instance profile creation, we'll attempt to delete the

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -17,6 +17,7 @@ package nodeclass
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/patrickmn/go-cache"
@@ -59,6 +60,7 @@ func (ip *InstanceProfile) protectProfile(profile string) {
 func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	if nodeClass.Spec.Role != "" {
 		var currentRole string
+		var currentProfileIsManaged bool
 		oldProfileName := nodeClass.Status.InstanceProfile
 		// Use a short-lived cache to prevent instance profile recreation for the same role in the same EC2NodeClass
 		// in case of a status patch error in the EC2NodeClass controller
@@ -73,13 +75,19 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 				if !awserrors.IsNotFound(err) {
 					return reconcile.Result{}, fmt.Errorf("getting instance profile %s, %w", nodeClass.Status.InstanceProfile, err)
 				}
-			} else if len(profile.Roles) > 0 {
-				currentRole = lo.FromPtr(profile.Roles[0].RoleName)
+			} else {
+				managedPathPrefix := instanceprofile.FormatPath("karpenter", ip.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID))
+				currentProfileIsManaged = strings.HasPrefix(lo.FromPtr(profile.Path), managedPathPrefix) ||
+					nodeClass.Status.InstanceProfile == nodeClass.LegacyInstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
+				if currentProfileIsManaged && len(profile.Roles) > 0 {
+					currentRole = lo.FromPtr(profile.Roles[0].RoleName)
+				}
 			}
 		}
 
-		// If role has changed, create new profile
-		if currentRole != nodeClass.Spec.Role {
+		// Create a new managed profile if status references a user-managed profile or the
+		// role on the current managed profile differs from spec.role.
+		if !currentProfileIsManaged || currentRole != nodeClass.Spec.Role {
 			// Generate new profile name
 			newProfileName := nodeClass.InstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
 

--- a/pkg/controllers/nodeclass/instanceprofile_test.go
+++ b/pkg/controllers/nodeclass/instanceprofile_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samber/lo"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
 
 	"github.com/aws/karpenter-provider-aws/pkg/fake"
@@ -153,6 +154,7 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 			profileName: {
 				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
 				InstanceProfileName: aws.String(profileName),
+				Path:                aws.String(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
 				Roles: []iamtypes.Role{
 					{
 						RoleName: aws.String("role-A"),
@@ -275,6 +277,7 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 			cachedProfileName: {
 				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
 				InstanceProfileName: aws.String(cachedProfileName),
+				Path:                aws.String(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
 				Roles: []iamtypes.Role{
 					{
 						RoleName: aws.String("role-A"),
@@ -399,6 +402,48 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 		// Verify new profile is set in status
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.Status.InstanceProfile).To(Equal("new-profile"))
+	})
+
+	It("should create a managed instance profile when switching from spec.instanceProfile to spec.role", func() {
+		// Regression for #9028: previously, when migrating from a static spec.instanceProfile
+		// to spec.role, status.InstanceProfile still held the static profile name and the
+		// reconciler kept reusing it. If the static profile was later deleted (e.g. by IaC
+		// cleanup), launches failed silently with credential errors.
+		staticProfileName := "user-static-profile"
+		awsEnv.IAMAPI.InstanceProfiles = map[string]*iamtypes.InstanceProfile{
+			staticProfileName: {
+				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
+				InstanceProfileName: aws.String(staticProfileName),
+				// User-managed profile lives at the IAM root path, not under /karpenter/.
+				Path: aws.String("/"),
+				Roles: []iamtypes.Role{
+					{RoleName: aws.String("role-A")},
+				},
+			},
+		}
+
+		// Initial state mimics a successful reconcile while spec.instanceProfile was set.
+		nodeClass.Spec.InstanceProfile = lo.ToPtr(staticProfileName)
+		nodeClass.Status.InstanceProfile = staticProfileName
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		// User now switches to spec.role with the same underlying role.
+		nodeClass.Spec.InstanceProfile = nil
+		nodeClass.Spec.Role = "role-A"
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		// Status should no longer point at the user's static profile.
+		Expect(nodeClass.Status.InstanceProfile).NotTo(Equal(staticProfileName))
+		// And a managed profile should have been created under the karpenter IAM path.
+		managedPrefix := instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName)
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveKey(nodeClass.Status.InstanceProfile))
+		Expect(lo.FromPtr(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Path)).To(HavePrefix(managedPrefix))
+		Expect(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Roles).To(HaveLen(1))
+		Expect(lo.FromPtr(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Roles[0].RoleName)).To(Equal("role-A"))
+		Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeInstanceProfileReady)).To(BeTrue())
 	})
 
 	It("should allow different NodeClasses with same role to create instance profiles independently", func() {

--- a/pkg/controllers/nodeclass/instanceprofile_test.go
+++ b/pkg/controllers/nodeclass/instanceprofile_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samber/lo"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
 
 	"github.com/aws/karpenter-provider-aws/pkg/fake"
@@ -149,10 +150,42 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 	})
 	It("should not call CreateInstanceProfile or AddRoleToInstanceProfile when instance profile exists with correct role", func() {
 		profileName := "profile-A"
+		nodeClass.Spec.Role = "role-A"
+		nodeClass.Status.InstanceProfile = profileName
+		ExpectApplied(ctx, env.Client, nodeClass)
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+
 		awsEnv.IAMAPI.InstanceProfiles = map[string]*iamtypes.InstanceProfile{
 			profileName: {
 				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
 				InstanceProfileName: aws.String(profileName),
+				Path:                aws.String(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
+				Roles: []iamtypes.Role{
+					{
+						RoleName: aws.String("role-A"),
+					},
+				},
+			},
+		}
+
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
+		Expect(awsEnv.IAMAPI.InstanceProfiles[profileName].Roles).To(HaveLen(1))
+		Expect(*awsEnv.IAMAPI.InstanceProfiles[profileName].Roles[0].RoleName).To(Equal("role-A"))
+
+		Expect(awsEnv.IAMAPI.CreateInstanceProfileBehavior.Calls()).To(BeZero())
+		Expect(awsEnv.IAMAPI.AddRoleToInstanceProfileBehavior.Calls()).To(BeZero())
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeInstanceProfileReady)).To(BeTrue())
+	})
+	It("should reuse a legacy managed instance profile when the role is unchanged", func() {
+		profileName := nodeClass.LegacyInstanceProfileName(options.FromContext(ctx).ClusterName, fake.DefaultRegion)
+		awsEnv.IAMAPI.InstanceProfiles = map[string]*iamtypes.InstanceProfile{
+			profileName: {
+				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
+				InstanceProfileName: aws.String(profileName),
+				Path:                aws.String("/"),
 				Roles: []iamtypes.Role{
 					{
 						RoleName: aws.String("role-A"),
@@ -166,14 +199,11 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 		ExpectApplied(ctx, env.Client, nodeClass)
 		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
 
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		Expect(nodeClass.Status.InstanceProfile).To(Equal(profileName))
 		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveLen(1))
-		Expect(awsEnv.IAMAPI.InstanceProfiles[profileName].Roles).To(HaveLen(1))
-		Expect(*awsEnv.IAMAPI.InstanceProfiles[profileName].Roles[0].RoleName).To(Equal("role-A"))
-
 		Expect(awsEnv.IAMAPI.CreateInstanceProfileBehavior.Calls()).To(BeZero())
 		Expect(awsEnv.IAMAPI.AddRoleToInstanceProfileBehavior.Calls()).To(BeZero())
-		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
-		Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeInstanceProfileReady)).To(BeTrue())
 	})
 	It("should resolve the specified instance profile into the status when using instanceProfile field", func() {
 		nodeClass.Spec.Role = ""
@@ -275,6 +305,7 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 			cachedProfileName: {
 				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
 				InstanceProfileName: aws.String(cachedProfileName),
+				Path:                aws.String(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
 				Roles: []iamtypes.Role{
 					{
 						RoleName: aws.String("role-A"),
@@ -399,6 +430,49 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 		// Verify new profile is set in status
 		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 		Expect(nodeClass.Status.InstanceProfile).To(Equal("new-profile"))
+	})
+
+	It("should create a managed instance profile when switching from spec.instanceProfile to spec.role", func() {
+		// Regression for #9028: previously, when migrating from a static spec.instanceProfile
+		// to spec.role, status.InstanceProfile still held the static profile name and the
+		// reconciler kept reusing it. If the static profile was later deleted (e.g. by IaC
+		// cleanup), launches failed silently with credential errors.
+		staticProfileName := "user-static-profile"
+		awsEnv.IAMAPI.InstanceProfiles = map[string]*iamtypes.InstanceProfile{
+			staticProfileName: {
+				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
+				InstanceProfileName: aws.String(staticProfileName),
+				// User-managed profile lives at the IAM root path, not under /karpenter/.
+				Path: aws.String("/"),
+				Roles: []iamtypes.Role{
+					{RoleName: aws.String("role-A")},
+				},
+			},
+		}
+
+		// Initial state mimics a successful reconcile while spec.instanceProfile was set.
+		nodeClass.Spec.Role = ""
+		nodeClass.Spec.InstanceProfile = lo.ToPtr(staticProfileName)
+		nodeClass.Status.InstanceProfile = staticProfileName
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		// User now switches to spec.role with the same underlying role.
+		nodeClass.Spec.InstanceProfile = nil
+		nodeClass.Spec.Role = "role-A"
+		ExpectApplied(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+
+		nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+		// Status should no longer point at the user's static profile.
+		Expect(nodeClass.Status.InstanceProfile).NotTo(Equal(staticProfileName))
+		// And a managed profile should have been created under the karpenter IAM path.
+		managedPrefix := instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName)
+		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveKey(nodeClass.Status.InstanceProfile))
+		Expect(lo.FromPtr(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Path)).To(HavePrefix(managedPrefix))
+		Expect(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Roles).To(HaveLen(1))
+		Expect(lo.FromPtr(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Roles[0].RoleName)).To(Equal("role-A"))
+		Expect(nodeClass.StatusConditions().IsTrue(v1.ConditionTypeInstanceProfileReady)).To(BeTrue())
 	})
 
 	It("should allow different NodeClasses with same role to create instance profiles independently", func() {

--- a/pkg/controllers/nodeclass/instanceprofile_test.go
+++ b/pkg/controllers/nodeclass/instanceprofile_test.go
@@ -159,7 +159,7 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 			profileName: {
 				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
 				InstanceProfileName: aws.String(profileName),
-				Path:                aws.String(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
+				Path:                aws.String(instanceprofile.KarpenterPath(fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
 				Roles: []iamtypes.Role{
 					{
 						RoleName: aws.String("role-A"),
@@ -305,7 +305,7 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 			cachedProfileName: {
 				InstanceProfileId:   aws.String(fake.InstanceProfileID()),
 				InstanceProfileName: aws.String(cachedProfileName),
-				Path:                aws.String(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
+				Path:                aws.String(instanceprofile.KarpenterPath(fake.DefaultRegion, options.FromContext(ctx).ClusterName, string(nodeClass.UID))),
 				Roles: []iamtypes.Role{
 					{
 						RoleName: aws.String("role-A"),
@@ -433,10 +433,6 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 	})
 
 	It("should create a managed instance profile when switching from spec.instanceProfile to spec.role", func() {
-		// Regression for #9028: previously, when migrating from a static spec.instanceProfile
-		// to spec.role, status.InstanceProfile still held the static profile name and the
-		// reconciler kept reusing it. If the static profile was later deleted (e.g. by IaC
-		// cleanup), launches failed silently with credential errors.
 		staticProfileName := "user-static-profile"
 		awsEnv.IAMAPI.InstanceProfiles = map[string]*iamtypes.InstanceProfile{
 			staticProfileName: {
@@ -467,7 +463,7 @@ var _ = Describe("NodeClass InstanceProfile Status Controller", func() {
 		// Status should no longer point at the user's static profile.
 		Expect(nodeClass.Status.InstanceProfile).NotTo(Equal(staticProfileName))
 		// And a managed profile should have been created under the karpenter IAM path.
-		managedPrefix := instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName)
+		managedPrefix := instanceprofile.KarpenterPath(fake.DefaultRegion, options.FromContext(ctx).ClusterName)
 		Expect(awsEnv.IAMAPI.InstanceProfiles).To(HaveKey(nodeClass.Status.InstanceProfile))
 		Expect(lo.FromPtr(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Path)).To(HavePrefix(managedPrefix))
 		Expect(awsEnv.IAMAPI.InstanceProfiles[nodeClass.Status.InstanceProfile].Roles).To(HaveLen(1))

--- a/pkg/providers/instanceprofile/instanceprofile.go
+++ b/pkg/providers/instanceprofile/instanceprofile.go
@@ -77,6 +77,11 @@ func FormatPath(segments ...string) string {
 	return "/" + strings.Join(segments, "/") + "/"
 }
 
+// KarpenterPath builds the IAM path used for Karpenter-managed instance profiles.
+func KarpenterPath(region, clusterName string, segments ...string) string {
+	return FormatPath(append([]string{"karpenter", region, clusterName}, segments...)...)
+}
+
 func (p *DefaultProvider) Get(ctx context.Context, instanceProfileName string) (*iamtypes.InstanceProfile, error) {
 	profileCacheKey := GetProfileCacheKey(instanceProfileName)
 	if instanceProfile, ok := p.instanceProfileCache.Get(profileCacheKey); ok {

--- a/pkg/providers/instanceprofile/suite_test.go
+++ b/pkg/providers/instanceprofile/suite_test.go
@@ -110,7 +110,7 @@ var _ = AfterEach(func() {
 
 var _ = Describe("InstanceProfileProvider", func() {
 	karpenterPath := func(nodeClassUID string) string {
-		return instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName, nodeClassUID)
+		return instanceprofile.KarpenterPath(fake.DefaultRegion, options.FromContext(ctx).ClusterName, nodeClassUID)
 	}
 	DescribeTable(
 		"should support IAM roles",
@@ -261,12 +261,12 @@ var _ = Describe("InstanceProfileProvider", func() {
 						RoleName: aws.String("role-3"),
 					},
 				},
-				Path: lo.ToPtr(instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(otherClusterCtx).ClusterName, "some-uid")),
+				Path: lo.ToPtr(instanceprofile.KarpenterPath(fake.DefaultRegion, options.FromContext(otherClusterCtx).ClusterName, "some-uid")),
 			},
 		}
 
 		// List all cluster profiles
-		clusterPath := instanceprofile.FormatPath("karpenter", fake.DefaultRegion, options.FromContext(ctx).ClusterName)
+		clusterPath := instanceprofile.KarpenterPath(fake.DefaultRegion, options.FromContext(ctx).ClusterName)
 		profiles, err := awsEnv.InstanceProfileProvider.ListProfiles(ctx, clusterPath)
 		Expect(err).To(BeNil())
 
@@ -399,5 +399,15 @@ var _ = Describe("FormatPath", func() {
 		Entry("two segments", "/eks/us-west-2/", "eks", "us-west-2"),
 		Entry("three segments", "/karpenter/us-west-2/my-cluster/", "karpenter", "us-west-2", "my-cluster"),
 		Entry("four segments", "/karpenter/us-west-2/my-cluster/uid/", "karpenter", "us-west-2", "my-cluster", "uid"),
+	)
+})
+
+var _ = Describe("KarpenterPath", func() {
+	DescribeTable("should format managed instance profile paths",
+		func(expected string, segments ...string) {
+			Expect(instanceprofile.KarpenterPath("us-west-2", "my-cluster", segments...)).To(Equal(expected))
+		},
+		Entry("cluster path", "/karpenter/us-west-2/my-cluster/"),
+		Entry("NodeClass path", "/karpenter/us-west-2/my-cluster/uid/", "uid"),
 	)
 })


### PR DESCRIPTION
Fixes #9028

## Summary
- When an EC2NodeClass migrated from spec.instanceProfile to spec.role, the reconciler could keep reusing the user-managed static profile when its attached role matched spec.role.
- Treat the status profile as managed only when its IAM path belongs to the current NodeClass, while preserving legacy Karpenter-managed profiles identified by their synthesized legacy name.
- Create a new Karpenter-managed profile when status still references a user-managed profile.

## Test plan
- [x] Added a regression test for switching from a static spec.instanceProfile to spec.role with the same attached role.
- [x] Added a compatibility test proving legacy Karpenter-managed profiles are reused.
- [x] Updated managed-profile and recreation-cache fixtures to use the assigned NodeClass UID in the IAM path.
- [x] Focused instance-profile suite: 22/22 passed.
- [x] Full NodeClass controller packages passed.
- [x] go vet ./pkg/controllers/nodeclass/... passed.