### PR TITLE
feat: inject clock into StatusConditions calls via operatorpkg WithClock

### DIFF
--- a/pkg/controllers/nodeclass/ami.go
+++ b/pkg/controllers/nodeclass/ami.go
@@ -20,8 +20,10 @@ import (
 	"sort"
 	"time"
 
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -34,12 +36,14 @@ import (
 
 type AMI struct {
 	amiProvider amifamily.Provider
+	clk         clock.Clock
 	cm          *pretty.ChangeMonitor
 }
 
-func NewAMIReconciler(provider amifamily.Provider) *AMI {
+func NewAMIReconciler(clk clock.Clock, provider amifamily.Provider) *AMI {
 	return &AMI{
 		amiProvider: provider,
+		clk:         clk,
 		cm:          pretty.NewChangeMonitor(),
 	}
 }
@@ -48,14 +52,14 @@ func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconc
 	amis, err := a.amiProvider.List(ctx, nodeClass)
 	if err != nil {
 		if amifamily.IsAl2DeprecationError(err) || amifamily.IsWS2025UnsupportedVersionError(err) {
-			nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "UnsupportedAlias", err.Error())
+			nodeClass.StatusConditions(status.WithClock(a.clk)).SetFalse(v1.ConditionTypeAMIsReady, "UnsupportedAlias", err.Error())
 			return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("getting amis, %w", err))
 		}
 		return reconcile.Result{}, fmt.Errorf("getting amis, %w", err)
 	}
 	if len(amis) == 0 {
 		nodeClass.Status.AMIs = nil
-		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeAMIsReady, "AMINotFound", "AMISelector did not match any AMIs")
+		nodeClass.StatusConditions(status.WithClock(a.clk)).SetFalse(v1.ConditionTypeAMIsReady, "AMINotFound", "AMISelector did not match any AMIs")
 		// If users have omitted the necessary tags from their AMIs and later add them, we need to reprocess the information.
 		// Returning 'ok' in this case means that the nodeclass will remain in an unready state until the component is restarted.
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
@@ -89,6 +93,6 @@ func (a *AMI) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconc
 		}
 	})
 
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeAMIsReady)
+	nodeClass.StatusConditions(status.WithClock(a.clk)).SetTrue(v1.ConditionTypeAMIsReady)
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }

--- a/pkg/controllers/nodeclass/capacityreservation.go
+++ b/pkg/controllers/nodeclass/capacityreservation.go
@@ -22,6 +22,7 @@ import (
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/awslabs/operatorpkg/singleton"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	"k8s.io/utils/clock"
@@ -56,7 +57,7 @@ func (c *CapacityReservation) Reconcile(ctx context.Context, nc *v1.EC2NodeClass
 	}
 	if len(reservations) == 0 {
 		nc.Status.CapacityReservations = nil
-		nc.StatusConditions().SetTrue(v1.ConditionTypeCapacityReservationsReady)
+		nc.StatusConditions(status.WithClock(c.clk)).SetTrue(v1.ConditionTypeCapacityReservationsReady)
 		return reconcile.Result{RequeueAfter: capacityReservationPollPeriod}, nil
 	}
 
@@ -84,7 +85,7 @@ func (c *CapacityReservation) Reconcile(ctx context.Context, nc *v1.EC2NodeClass
 			"total-count", len(reservations),
 		).Error(multierr.Combine(errors...), "failed to parse discovered capacity reservations")
 	}
-	nc.StatusConditions().SetTrue(v1.ConditionTypeCapacityReservationsReady)
+	nc.StatusConditions(status.WithClock(c.clk)).SetTrue(v1.ConditionTypeCapacityReservationsReady)
 	return reconcile.Result{RequeueAfter: c.requeueAfter(reservations...)}, nil
 }
 

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -92,7 +92,7 @@ func NewController(
 	amiResolver amifamily.Resolver,
 	disableDryRun bool,
 ) *Controller {
-	validation := NewValidationReconciler(kubeClient, cloudProvider, ec2api, amiResolver, instanceTypeProvider, launchTemplateProvider, validationCache, disableDryRun)
+	validation := NewValidationReconciler(clk, kubeClient, cloudProvider, ec2api, amiResolver, instanceTypeProvider, launchTemplateProvider, validationCache, disableDryRun)
 	return &Controller{
 		kubeClient:              kubeClient,
 		recorder:                recorder,
@@ -101,12 +101,12 @@ func NewController(
 		instanceProfileProvider: instanceProfileProvider,
 		validation:              validation,
 		reconcilers: []reconcile.TypedReconciler[*v1.EC2NodeClass]{
-			NewAMIReconciler(amiProvider),
+			NewAMIReconciler(clk, amiProvider),
 			NewCapacityReservationReconciler(clk, capacityReservationProvider),
-			NewPlacementGroupReconciler(placementGroupProvider),
-			NewSubnetReconciler(subnetProvider),
-			NewSecurityGroupReconciler(securityGroupProvider),
-			NewInstanceProfileReconciler(instanceProfileProvider, region, recreationCache),
+			NewPlacementGroupReconciler(clk, placementGroupProvider),
+			NewSubnetReconciler(clk, subnetProvider),
+			NewSecurityGroupReconciler(clk, securityGroupProvider),
+			NewInstanceProfileReconciler(clk, instanceProfileProvider, region, recreationCache),
 			validation,
 		},
 	}

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -31,13 +33,15 @@ import (
 type InstanceProfile struct {
 	instanceProfileProvider instanceprofile.Provider
 	region                  string
+	clk                     clock.Clock
 	recreationCache         *cache.Cache
 }
 
-func NewInstanceProfileReconciler(instanceProfileProvider instanceprofile.Provider, region string, cache *cache.Cache) *InstanceProfile {
+func NewInstanceProfileReconciler(clk clock.Clock, instanceProfileProvider instanceprofile.Provider, region string, cache *cache.Cache) *InstanceProfile {
 	return &InstanceProfile{
 		instanceProfileProvider: instanceProfileProvider,
 		region:                  region,
+		clk:                     clk,
 		recreationCache:         cache,
 	}
 }
@@ -114,6 +118,6 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 		ip.protectProfile(nodeClass.Status.InstanceProfile)
 		nodeClass.Status.InstanceProfile = lo.FromPtr(nodeClass.Spec.InstanceProfile)
 	}
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeInstanceProfileReady)
+	nodeClass.StatusConditions(status.WithClock(ip.clk)).SetTrue(v1.ConditionTypeInstanceProfileReady)
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclass/placementgroup.go
+++ b/pkg/controllers/nodeclass/placementgroup.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 
 	"github.com/awslabs/operatorpkg/serrors"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
@@ -30,12 +32,14 @@ import (
 
 type PlacementGroupReconciler struct {
 	provider placementgroup.Provider
+	clk      clock.Clock
 	cm       *pretty.ChangeMonitor
 }
 
-func NewPlacementGroupReconciler(provider placementgroup.Provider) *PlacementGroupReconciler {
+func NewPlacementGroupReconciler(clk clock.Clock, provider placementgroup.Provider) *PlacementGroupReconciler {
 	return &PlacementGroupReconciler{
 		provider: provider,
+		clk:      clk,
 		cm:       pretty.NewChangeMonitor(),
 	}
 }
@@ -49,14 +53,14 @@ func (p *PlacementGroupReconciler) Reconcile(ctx context.Context, nc *v1.EC2Node
 		selector = lo.FromPtr(lo.CoalesceOrEmpty(term.Name, term.ID))
 	}
 	if err != nil {
-		nc.StatusConditions().SetFalse(v1.ConditionTypePlacementGroupReady, "PlacementGroupResolutionFailed", "Failed to resolve placement group")
+		nc.StatusConditions(status.WithClock(p.clk)).SetFalse(v1.ConditionTypePlacementGroupReady, "PlacementGroupResolutionFailed", "Failed to resolve placement group")
 		return reconcile.Result{}, serrors.Wrap(fmt.Errorf("resolving placement group, %w", err), "placement-group", selector)
 	}
 	if pg == nil {
 		if nc.Spec.PlacementGroupSelector != nil {
-			nc.StatusConditions().SetFalse(v1.ConditionTypePlacementGroupReady, "PlacementGroupNotFound", fmt.Sprintf("Placement group %q not found", selector))
+			nc.StatusConditions(status.WithClock(p.clk)).SetFalse(v1.ConditionTypePlacementGroupReady, "PlacementGroupNotFound", fmt.Sprintf("Placement group %q not found", selector))
 		} else {
-			nc.StatusConditions().SetTrue(v1.ConditionTypePlacementGroupReady)
+			nc.StatusConditions(status.WithClock(p.clk)).SetTrue(v1.ConditionTypePlacementGroupReady)
 		}
 		return reconcile.Result{}, nil
 	}
@@ -65,6 +69,6 @@ func (p *PlacementGroupReconciler) Reconcile(ctx context.Context, nc *v1.EC2Node
 		log.FromContext(ctx).V(1).WithValues("id", pg.ID, "name", pg.Name, "strategy", pg.Strategy).Info("discovered placement group")
 	}
 
-	nc.StatusConditions().SetTrue(v1.ConditionTypePlacementGroupReady)
+	nc.StatusConditions(status.WithClock(p.clk)).SetTrue(v1.ConditionTypePlacementGroupReady)
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclass/securitygroup.go
+++ b/pkg/controllers/nodeclass/securitygroup.go
@@ -21,7 +21,9 @@ import (
 	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -30,11 +32,13 @@ import (
 
 type SecurityGroup struct {
 	securityGroupProvider securitygroup.Provider
+	clk                   clock.Clock
 }
 
-func NewSecurityGroupReconciler(securityGroupProvider securitygroup.Provider) *SecurityGroup {
+func NewSecurityGroupReconciler(clk clock.Clock, securityGroupProvider securitygroup.Provider) *SecurityGroup {
 	return &SecurityGroup{
 		securityGroupProvider: securityGroupProvider,
+		clk:                   clk,
 	}
 }
 
@@ -45,7 +49,7 @@ func (sg *SecurityGroup) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeCla
 	}
 	if len(securityGroups) == 0 && len(nodeClass.Spec.SecurityGroupSelectorTerms) > 0 {
 		nodeClass.Status.SecurityGroups = nil
-		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeSecurityGroupsReady, "SecurityGroupsNotFound", "SecurityGroupSelector did not match any SecurityGroups")
+		nodeClass.StatusConditions(status.WithClock(sg.clk)).SetFalse(v1.ConditionTypeSecurityGroupsReady, "SecurityGroupsNotFound", "SecurityGroupSelector did not match any SecurityGroups")
 		// If users have omitted the necessary tags from their SecurityGroups and later add them, we need to reprocess the information.
 		// Returning 'ok' in this case means that the nodeclass will remain in an unready state until the component is restarted.
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
@@ -59,6 +63,6 @@ func (sg *SecurityGroup) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeCla
 			Name: *securityGroup.GroupName,
 		}
 	})
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeSecurityGroupsReady)
+	nodeClass.StatusConditions(status.WithClock(sg.clk)).SetTrue(v1.ConditionTypeSecurityGroupsReady)
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }

--- a/pkg/controllers/nodeclass/subnet.go
+++ b/pkg/controllers/nodeclass/subnet.go
@@ -21,7 +21,9 @@ import (
 	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -30,11 +32,13 @@ import (
 
 type Subnet struct {
 	subnetProvider subnet.Provider
+	clk            clock.Clock
 }
 
-func NewSubnetReconciler(subnetProvider subnet.Provider) *Subnet {
+func NewSubnetReconciler(clk clock.Clock, subnetProvider subnet.Provider) *Subnet {
 	return &Subnet{
 		subnetProvider: subnetProvider,
+		clk:            clk,
 	}
 }
 
@@ -45,7 +49,7 @@ func (s *Subnet) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (rec
 	}
 	if len(subnets) == 0 {
 		nodeClass.Status.Subnets = nil
-		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeSubnetsReady, "SubnetsNotFound", "SubnetSelector did not match any Subnets")
+		nodeClass.StatusConditions(status.WithClock(s.clk)).SetFalse(v1.ConditionTypeSubnetsReady, "SubnetsNotFound", "SubnetSelector did not match any Subnets")
 		// If users have omitted the necessary tags from their Subnets and later add them, we need to reprocess the information.
 		// Returning 'ok' in this case means that the nodeclass will remain in an unready state until the component is restarted.
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
@@ -63,6 +67,6 @@ func (s *Subnet) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (rec
 			ZoneID: *ec2subnet.AvailabilityZoneId,
 		}
 	})
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeSubnetsReady)
+	nodeClass.StatusConditions(status.WithClock(s.clk)).SetTrue(v1.ConditionTypeSubnetsReady)
 	return reconcile.Result{RequeueAfter: time.Minute}, nil
 }

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -20,9 +20,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/awslabs/operatorpkg/status"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -79,10 +81,12 @@ type Validation struct {
 	instanceTypeProvider   instancetype.Provider
 	launchTemplateProvider launchtemplate.Provider
 	cache                  *cache.Cache
+	clk                    clock.Clock
 	dryRunDisabled         bool
 }
 
 func NewValidationReconciler(
+	clk clock.Clock,
 	kubeClient client.Client,
 	cloudProvider cloudprovider.CloudProvider,
 	ec2api sdk.EC2API,
@@ -100,6 +104,7 @@ func NewValidationReconciler(
 		instanceTypeProvider:   instanceTypeProvider,
 		launchTemplateProvider: launchTemplateProvider,
 		cache:                  cache,
+		clk:                    clk,
 		dryRunDisabled:         dryRunDisabled,
 	}
 }
@@ -114,7 +119,7 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 			if awserrors.IsServerError(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}
-			nodeClass.StatusConditions().SetFalse(
+			nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(
 				v1.ConditionTypeValidationSucceeded,
 				"ClusterCIDRResolutionFailed",
 				"Failed to detect the cluster CIDR",
@@ -124,10 +129,10 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 	}
 
 	if _, ok := lo.Find(v.requiredConditions(), func(cond string) bool {
-		return nodeClass.StatusConditions().Get(cond).IsFalse()
+		return nodeClass.StatusConditions(status.WithClock(v.clk)).Get(cond).IsFalse()
 	}); ok {
 		// If any of the required status conditions are false, we know validation will fail regardless of the other values.
-		nodeClass.StatusConditions().SetFalse(
+		nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(
 			v1.ConditionTypeValidationSucceeded,
 			ConditionReasonDependenciesNotReady,
 			"Awaiting AMI, Instance Profile, Security Group, and Subnet resolution",
@@ -135,11 +140,11 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 		return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}
 	if _, ok := lo.Find(v.requiredConditions(), func(cond string) bool {
-		return nodeClass.StatusConditions().Get(cond).IsUnknown()
+		return nodeClass.StatusConditions(status.WithClock(v.clk)).Get(cond).IsUnknown()
 	}); ok {
 		// If none of the status conditions are false, but at least one is unknown, we should also consider the validation
 		// state to be unknown. Once all required conditions collapse to a true or false state, we can test validation.
-		nodeClass.StatusConditions().SetUnknownWithReason(
+		nodeClass.StatusConditions(status.WithClock(v.clk)).SetUnknownWithReason(
 			v1.ConditionTypeValidationSucceeded,
 			ConditionReasonDependenciesNotReady,
 			"Awaiting AMI, Instance Profile, Security Group, and Subnet resolution",
@@ -156,7 +161,7 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 	}
 	tags, err := utils.GetTags(nodeClass, nodeClaim, options.FromContext(ctx).ClusterName)
 	if err != nil {
-		nodeClass.StatusConditions().SetFalse(v1.ConditionTypeValidationSucceeded, ConditionReasonTagValidationFailed, err.Error())
+		nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(v1.ConditionTypeValidationSucceeded, ConditionReasonTagValidationFailed, err.Error())
 		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("validating tags, %w", err))
 	}
 
@@ -164,9 +169,9 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 		// We still update the status condition even if it's cached since we may have had a conflict error previously
 		entry := val.(validationCacheEntry)
 		if entry.reason == "" {
-			nodeClass.StatusConditions().SetTrue(v1.ConditionTypeValidationSucceeded)
+			nodeClass.StatusConditions(status.WithClock(v.clk)).SetTrue(v1.ConditionTypeValidationSucceeded)
 		} else {
-			nodeClass.StatusConditions().SetFalse(
+			nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(
 				v1.ConditionTypeValidationSucceeded,
 				entry.reason,
 				entry.message,
@@ -176,7 +181,7 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 	}
 
 	if v.dryRunDisabled {
-		nodeClass.StatusConditions().SetTrue(v1.ConditionTypeValidationSucceeded)
+		nodeClass.StatusConditions(status.WithClock(v.clk)).SetTrue(v1.ConditionTypeValidationSucceeded)
 		v.cache.SetDefault(v.cacheKey(nodeClass, tags), validationCacheEntry{})
 		return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 	}
@@ -197,7 +202,7 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 	}
 
 	v.cache.SetDefault(v.cacheKey(nodeClass, tags), validationCacheEntry{})
-	nodeClass.StatusConditions().SetTrue(v1.ConditionTypeValidationSucceeded)
+	nodeClass.StatusConditions(status.WithClock(v.clk)).SetTrue(v1.ConditionTypeValidationSucceeded)
 	return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 }
 
@@ -207,7 +212,7 @@ func (v *Validation) updateCacheOnFailure(nodeClass *v1.EC2NodeClass, tags map[s
 		reason:  failureReason,
 		message: message,
 	})
-	nodeClass.StatusConditions().SetFalse(
+	nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(
 		v1.ConditionTypeValidationSucceeded,
 		failureReason,
 		message,

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -52,7 +52,7 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 	Context("Preconditions", func() {
 		var reconciler *nodeclass.Validation
 		BeforeEach(func() {
-			reconciler = nodeclass.NewValidationReconciler(env.Client, cloudProvider, awsEnv.EC2API, awsEnv.AMIResolver, awsEnv.InstanceTypesProvider, awsEnv.LaunchTemplateProvider, awsEnv.ValidationCache, options.FromContext(ctx).DisableDryRun)
+			reconciler = nodeclass.NewValidationReconciler(env.Clock, env.Client, cloudProvider, awsEnv.EC2API, awsEnv.AMIResolver, awsEnv.InstanceTypesProvider, awsEnv.LaunchTemplateProvider, awsEnv.ValidationCache, options.FromContext(ctx).DisableDryRun)
 			for _, cond := range []string{
 				v1.ConditionTypeAMIsReady,
 				v1.ConditionTypeInstanceProfileReady,

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -115,7 +115,7 @@ type Environment struct {
 
 func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment {
 	// Mock
-	clock := &clock.FakeClock{}
+	clock := clock.NewFakeClock(time.Now())
 	store := nodeoverlay.NewInstanceTypeStore()
 
 	// API
@@ -260,7 +260,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 }
 
 func (env *Environment) Reset() {
-	env.Clock.SetTime(time.Time{})
+	env.Clock.SetTime(time.Now())
 	env.EC2API.Reset()
 	env.EKSAPI.Reset()
 	env.SSMAPI.Reset()


### PR DESCRIPTION
## Summary
- Upgrades `operatorpkg` to `v0.0.0-20260501204335-c49b4ca8d58d` which supports `WithClock` for status conditions
- Bumps `sigs.k8s.io/karpenter` to `v1.12.1-0.20260527205500-924ddee92750` (which includes kubernetes-sigs/karpenter#3009)
- Updates `EC2NodeClass.StatusConditions()` to accept `...status.ForOption`
- Injects `status.WithClock(clk)` into all StatusConditions write calls in the nodeclass controller sub-reconcilers

This ensures that when a dependency-injected clock is available in controllers, all `StatusCondition` mutations use that same clock for `LastTransitionTime`. This prevents inconsistent sources of truth for time in tests where a fake clock is used.

Depends on: kubernetes-sigs/karpenter#3009 (merged)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.