### PR TITLE
fix: correct YAML quoting in nested JSON list

### DIFF
--- a/charts/karpenter/templates/clusterrole-core.yaml
+++ b/charts/karpenter/templates/clusterrole-core.yaml
@@ -46,7 +46,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", list, "watch"]
+    verbs: ["get", "list", "watch"]
   # Write
   - apiGroups: ["karpenter.sh"]
     resources: ["nodeclaims", "nodeclaims/status"]


### PR DESCRIPTION
Fix an unquoted string in the `clusterrole-core.yaml` helm chart