### PR TITLE
docs: fix preferred affinity relaxation order docs

### DIFF
--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by ascending weight (lowest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by ascending weight (lowest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/v1.10/concepts/scheduling.md
+++ b/website/content/en/v1.10/concepts/scheduling.md
@@ -226,7 +226,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by ascending weight (lowest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/v1.10/concepts/scheduling.md
+++ b/website/content/en/v1.10/concepts/scheduling.md
@@ -226,7 +226,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/v1.11/concepts/scheduling.md
+++ b/website/content/en/v1.11/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by ascending weight (lowest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/v1.11/concepts/scheduling.md
+++ b/website/content/en/v1.11/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/v1.12/concepts/scheduling.md
+++ b/website/content/en/v1.12/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by ascending weight (lowest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).

--- a/website/content/en/v1.12/concepts/scheduling.md
+++ b/website/content/en/v1.12/concepts/scheduling.md
@@ -228,7 +228,7 @@ See [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assig
 
 Karpenter is aware of preferences (node affinity, pod affinity, pod anti-affinity, and pod topology) and treats them as requirements in most circumstances. Karpenter uses these preferences when determining if a pod can schedule on a node (absent topology requirements), or when determining if a pod can be shifted to a new node.
 
-Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time by descending weight (highest weight is relaxed first), and the remaining requirements are tried again.
+Karpenter starts by treating preferred affinities as required affinities when constructing requirements for a pod. When these requirements cannot be met, the pod's preferences are relaxed one-at-a-time and the remaining requirements are tried again.
 
 {{% alert title="Warning" color="warning" %}}
 Karpenter does not interpret preferred affinities as required when constructing topology requirements for scheduling to a node. If these preferences are necessary, required affinities should be used [as documented in Node Affinity](#node-affinity).


### PR DESCRIPTION
## Summary

- Update the scheduling docs to say preferred affinities are relaxed by descending weight.
- Apply the wording fix to the current docs, preview docs, and versioned v1.10-v1.12 docs.

Fixes #9048.

## Validation

- `git diff --check`
- Confirmed all updated scheduling docs now say `descending weight (highest weight is relaxed first)`

Note: I also attempted a Hugo build with `npx hugo --minify --source .`, but this local environment does not have `go`, which Hugo needs to download modules for this site.