### PR TITLE
ci: account for VPC CNI ENI attachment in suite tests

### DIFF
--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -218,6 +218,14 @@ func (env *Environment) GetNetworkInterfaces(ids ...string) []ec2types.NetworkIn
 	return dnio.NetworkInterfaces
 }
 
+func FindNetworkInterface(interfaces []ec2types.InstanceNetworkInterface, networkCardIndex, deviceIndex int32) (ec2types.InstanceNetworkInterface, bool) {
+	return lo.Find(interfaces, func(ni ec2types.InstanceNetworkInterface) bool {
+		return ni.Attachment != nil &&
+			ni.Attachment.NetworkCardIndex != nil && aws.ToInt32(ni.Attachment.NetworkCardIndex) == networkCardIndex &&
+			ni.Attachment.DeviceIndex != nil && aws.ToInt32(ni.Attachment.DeviceIndex) == deviceIndex
+	})
+}
+
 func (env *Environment) GetSpotInstance(id string) ec2types.SpotInstanceRequest {
 	GinkgoHelper()
 	siro, err := env.EC2API.DescribeSpotInstanceRequests(env.Context, &ec2.DescribeSpotInstanceRequestsInput{

--- a/test/suites/integration/connection_tracking_test.go
+++ b/test/suites/integration/connection_tracking_test.go
@@ -47,9 +47,10 @@ var _ = Describe("ConnectionTracking", func() {
 		instance := env.GetInstance(pod.Spec.NodeName)
 		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
 
-		primaryNI := instance.NetworkInterfaces[0]
-		Expect(primaryNI.Attachment).ToNot(BeNil())
-		Expect(aws.ToInt32(primaryNI.Attachment.DeviceIndex)).To(Equal(int32(0)))
+		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni ec2types.InstanceNetworkInterface) bool {
+			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && aws.ToInt32(ni.Attachment.DeviceIndex) == 0
+		})
+		Expect(found).To(BeTrue())
 
 		niOutput, err := env.EC2API.DescribeNetworkInterfaces(env.Context, &ec2.DescribeNetworkInterfacesInput{
 			NetworkInterfaceIds: []string{aws.ToString(primaryNI.NetworkInterfaceId)},
@@ -143,7 +144,10 @@ var _ = Describe("ConnectionTracking", func() {
 		instance := env.GetInstance(pod.Spec.NodeName)
 		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
 
-		primaryNI := instance.NetworkInterfaces[0]
+		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni ec2types.InstanceNetworkInterface) bool {
+			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && aws.ToInt32(ni.Attachment.DeviceIndex) == 0
+		})
+		Expect(found).To(BeTrue())
 		niOutput, err := env.EC2API.DescribeNetworkInterfaces(env.Context, &ec2.DescribeNetworkInterfacesInput{
 			NetworkInterfaceIds: []string{aws.ToString(primaryNI.NetworkInterfaceId)},
 		})
@@ -164,7 +168,10 @@ var _ = Describe("ConnectionTracking", func() {
 		instance := env.GetInstance(pod.Spec.NodeName)
 		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
 
-		primaryNI := instance.NetworkInterfaces[0]
+		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni ec2types.InstanceNetworkInterface) bool {
+			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && aws.ToInt32(ni.Attachment.DeviceIndex) == 0
+		})
+		Expect(found).To(BeTrue())
 		niOutput, err := env.EC2API.DescribeNetworkInterfaces(env.Context, &ec2.DescribeNetworkInterfacesInput{
 			NetworkInterfaceIds: []string{aws.ToString(primaryNI.NetworkInterfaceId)},
 		})

--- a/test/suites/integration/connection_tracking_test.go
+++ b/test/suites/integration/connection_tracking_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	environmentaws "github.com/aws/karpenter-provider-aws/test/pkg/environment/aws"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,9 +48,7 @@ var _ = Describe("ConnectionTracking", func() {
 		instance := env.GetInstance(pod.Spec.NodeName)
 		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
 
-		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni ec2types.InstanceNetworkInterface) bool {
-			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && aws.ToInt32(ni.Attachment.DeviceIndex) == 0
-		})
+		primaryNI, found := environmentaws.FindNetworkInterface(instance.NetworkInterfaces, 0, 0)
 		Expect(found).To(BeTrue())
 
 		niOutput, err := env.EC2API.DescribeNetworkInterfaces(env.Context, &ec2.DescribeNetworkInterfacesInput{
@@ -144,9 +143,7 @@ var _ = Describe("ConnectionTracking", func() {
 		instance := env.GetInstance(pod.Spec.NodeName)
 		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
 
-		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni ec2types.InstanceNetworkInterface) bool {
-			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && aws.ToInt32(ni.Attachment.DeviceIndex) == 0
-		})
+		primaryNI, found := environmentaws.FindNetworkInterface(instance.NetworkInterfaces, 0, 0)
 		Expect(found).To(BeTrue())
 		niOutput, err := env.EC2API.DescribeNetworkInterfaces(env.Context, &ec2.DescribeNetworkInterfacesInput{
 			NetworkInterfaceIds: []string{aws.ToString(primaryNI.NetworkInterfaceId)},
@@ -168,9 +165,7 @@ var _ = Describe("ConnectionTracking", func() {
 		instance := env.GetInstance(pod.Spec.NodeName)
 		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
 
-		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni ec2types.InstanceNetworkInterface) bool {
-			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && aws.ToInt32(ni.Attachment.DeviceIndex) == 0
-		})
+		primaryNI, found := environmentaws.FindNetworkInterface(instance.NetworkInterfaces, 0, 0)
 		Expect(found).To(BeTrue())
 		niOutput, err := env.EC2API.DescribeNetworkInterfaces(env.Context, &ec2.DescribeNetworkInterfacesInput{
 			NetworkInterfaceIds: []string{aws.ToString(primaryNI.NetworkInterfaceId)},

--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -101,9 +101,13 @@ var _ = Describe("IPv6", func() {
 		env.ExpectCreatedNodeCount("==", 1)
 		node := env.GetNode(pod.Spec.NodeName)
 		instance := env.GetInstanceByID(env.ExpectParsedProviderID(node.Spec.ProviderID))
-		Expect(instance.NetworkInterfaces).To(HaveLen(1))
-		Expect(instance.NetworkInterfaces[0].Ipv6Addresses).To(HaveLen(1))
-		_, hasIPv6Primary := lo.Find(instance.NetworkInterfaces[0].Ipv6Addresses, func(ip types.InstanceIpv6Address) bool {
+		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
+		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni types.InstanceNetworkInterface) bool {
+			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && lo.FromPtr(ni.Attachment.DeviceIndex) == int32(0)
+		})
+		Expect(found).To(BeTrue())
+		Expect(primaryNI.Ipv6Addresses).To(HaveLen(1))
+		_, hasIPv6Primary := lo.Find(primaryNI.Ipv6Addresses, func(ip types.InstanceIpv6Address) bool {
 			return lo.FromPtr(ip.IsPrimaryIpv6)
 		})
 		Expect(hasIPv6Primary).To(BeTrue())

--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -102,9 +102,7 @@ var _ = Describe("IPv6", func() {
 		node := env.GetNode(pod.Spec.NodeName)
 		instance := env.GetInstanceByID(env.ExpectParsedProviderID(node.Spec.ProviderID))
 		Expect(instance.NetworkInterfaces).ToNot(BeEmpty())
-		primaryNI, found := lo.Find(instance.NetworkInterfaces, func(ni types.InstanceNetworkInterface) bool {
-			return ni.Attachment != nil && ni.Attachment.DeviceIndex != nil && lo.FromPtr(ni.Attachment.DeviceIndex) == int32(0)
-		})
+		primaryNI, found := aws.FindNetworkInterface(instance.NetworkInterfaces, 0, 0)
 		Expect(found).To(BeTrue())
 		Expect(primaryNI.Ipv6Addresses).To(HaveLen(1))
 		_, hasIPv6Primary := lo.Find(primaryNI.Ipv6Addresses, func(ip types.InstanceIpv6Address) bool {

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -1055,12 +1055,7 @@ var _ = DescribeTableSubtree("Scheduling", Ordered, ContinueOnFailure, func(minV
 		Expect(len(networkInterfaces)).To(BeNumerically(">=", 2))
 
 		for _, deviceIndex := range []int32{0, 1} {
-			networkInterface, found := lo.Find(networkInterfaces, func(i ec2types.InstanceNetworkInterface) bool {
-				if i.Attachment == nil || i.Attachment.DeviceIndex == nil {
-					return false
-				}
-				return deviceIndex == lo.FromPtr(i.Attachment.DeviceIndex)
-			})
+			networkInterface, found := environmentaws.FindNetworkInterface(networkInterfaces, 0, deviceIndex)
 			Expect(found).To(BeTrue())
 			Expect(lo.FromPtr(networkInterface.InterfaceType)).To(Equal(
 				lo.Ternary(deviceIndex == 0, string(ec2types.NetworkInterfaceTypeInterface), string(ec2types.NetworkInterfaceTypeEfaOnly)),

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -1051,16 +1051,17 @@ var _ = DescribeTableSubtree("Scheduling", Ordered, ContinueOnFailure, func(minV
 
 		instance := env.GetInstance(node.Name)
 		networkInterfaces := instance.NetworkInterfaces
-		Expect(networkInterfaces).To(HaveLen(2))
+		// VPC CNI may attach additional interfaces beyond what we configured, so we check for at least our expected count
+		Expect(len(networkInterfaces)).To(BeNumerically(">=", 2))
 
 		for _, deviceIndex := range []int32{0, 1} {
 			networkInterface, found := lo.Find(networkInterfaces, func(i ec2types.InstanceNetworkInterface) bool {
-				Expect(i.Attachment).ToNot(BeNil())
-				Expect(i.Attachment.DeviceIndex).ToNot(BeNil())
+				if i.Attachment == nil || i.Attachment.DeviceIndex == nil {
+					return false
+				}
 				return deviceIndex == lo.FromPtr(i.Attachment.DeviceIndex)
 			})
-			Expect(found).To(Equal(true))
-
+			Expect(found).To(BeTrue())
 			Expect(lo.FromPtr(networkInterface.InterfaceType)).To(Equal(
 				lo.Ternary(deviceIndex == 0, string(ec2types.NetworkInterfaceTypeInterface), string(ec2types.NetworkInterfaceTypeEfaOnly)),
 			))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes a race condition between our testing infra describe calls and VPC CNI in some of the scheduling suite tests. What happens is the VPC CNI attaches interfaces (after node registration) before describe instance calls. This can cause more network interfaces on the instance than what we currently expect (and launched with).

e.g - https://github.com/aws/karpenter-provider-aws/actions/runs/26836134505/job/79130429626
```
 > Enter [It] should provision EFAs according to NodeClass configuration
  [FAILED] Expected
      <[]types.InstanceNetworkInterface | len:3, cap:4>: [
          {
....
  to have length 2
  In [It] at: /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/scheduling/suite_test.go:1054 @ 06/02/26 19:46:11.632
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.