### PR TITLE
ci: attempt to fix upgrade suite

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -58,6 +58,7 @@ runs:
       PRIVATE_CLUSTER: ${{ inputs.private_cluster }}
     run: |
       output=$(./test/hack/e2e_scripts/install_karpenter.sh 2>&1)
+      echo "$output"
       if echo "$output" | grep -i "warning.*violate.*podsecurity"; then
         echo "ERROR: Karpenter does not respect restricted Pod Security Standard"
         exit 1

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -117,7 +117,7 @@ jobs:
       statuses: write # ./.github/actions/commit-status/start
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      from_git_ref: e169c8f9b56a7ce0b0c4b7f4ae233d5740365590
+      from_git_ref: a1ea5f8f71684a7958d56bf452e9513948945813
       to_git_ref: ${{ inputs.git_ref }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
An attempt to fix the upgrade suite, which has been failing for a while. This has 2 changes:
1. bumps the commit that we are upgrading from to a never commit (https://github.com/aws/karpenter-provider-aws/commit/a1ea5f8f71684a7958d56bf452e9513948945813) so the snapshot image still exists
2. echos the output of the error when installing karpenter to increase visibility to errors if there are any (This was done previously but hidden by https://github.com/aws/karpenter-provider-aws/pull/8274)

**How was this change tested?**
* make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.