### PR TITLE
ci: fix metric count check in dry run

### DIFF
--- a/hack/docgen.sh
+++ b/hack/docgen.sh
@@ -8,6 +8,12 @@ compatibilitymatrix() {
     go run hack/docs/compatibilitymatrix_gen/main.go website/content/en/preview/upgrading/compatibility.md hack/docs/compatibilitymatrix_gen/compatibility.yaml $versionCount
 }
 
+# Ensure modules are downloaded so that go list -m -f '{{ .Dir }}' can resolve paths.
+go mod download
+
+if [[ -z "${KARPENTER_CORE_DIR:-}" ]]; then
+    KARPENTER_CORE_DIR=$(go list -m -f '{{ .Dir }}' sigs.k8s.io/karpenter)
+fi
 CONTROLLER_RUNTIME_DIR=$(go list -m -f '{{ .Dir }}' sigs.k8s.io/controller-runtime)
 AWS_SDK_GO_PROMETHEUS_DIR=$(go list -m -f '{{ .Dir }}' github.com/jonathan-innis/aws-sdk-go-prometheus)
 OPERATORPKG_DIR=$(go list -m -f '{{ .Dir }}' github.com/awslabs/operatorpkg)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Previously in the CI, the Go mod cache was empty (as no go mod download step and caching disabled), so `go list -m -f '{{ .Dir }}'` in `hack/docgen.sh` is empty. This meant that `KARPENTER_CORE_DIR`,  `CONTROLLER_RUNTIME_DIR`, `AWS_SDK_GO_PROMETHEUS_DIR`, and `OPERATORPKG_DIR` where all empty when running `hack/docs/metrics_gen/main.go`

A check introduced https://github.com/aws/karpenter-provider-aws/pull/9119/changes#diff-6c5f241381b4c7eec85166938f8200e59ba597e524bd1f499252ea9db0229d07R114 to calculate the min expected metrics then caused this to be shown.

This change fixes it by calling go mod download to ensure the modules are available.

**How was this change tested?**
Tested in https://github.com/ryan-mist/karpenter-provider-aws/tree/test-docgen
* Before - https://github.com/ryan-mist/karpenter-provider-aws/actions/runs/26864992397/job/79229567699
```
2026/06/03 05:46:26 writing output to website/content/en/preview/upgrading/compatibility.md
2026/06/03 05:46:27 parsing code in pkg/
2026/06/03 05:46:27 parsing code in /pkg
2026/06/03 05:46:27 parsing code in /pkg
2026/06/03 05:46:27 parsing code in 
2026/06/03 05:46:27 parsing code in 
2026/06/03 05:46:27 expected at least 100 metrics but only found 42; the generator may be silently dropping metrics due to unrecognized identifiers or new declaration patterns
exit status 1
make: *** [Makefile:187: docgen] Error 1
Error: Process completed with exit code 2.
```
* After - https://github.com/ryan-mist/karpenter-provider-aws/actions/runs/26866323970/job/79230714158
```
2026/06/03 05:56:55 writing output to website/content/en/preview/upgrading/compatibility.md
2026/06/03 05:56:56 parsing code in pkg/
2026/06/03 05:56:56 parsing code in /home/runner/go/pkg/mod/sigs.k8s.io/karpenter@v1.12.1-0.20260508221319-9655ec09a42e/pkg
2026/06/03 05:56:56 parsing code in /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg
2026/06/03 05:56:56 parsing code in /home/runner/go/pkg/mod/github.com/jonathan-innis/aws-sdk-go-prometheus@v0.1.1
2026/06/03 05:56:56 parsing code in /home/runner/go/pkg/mod/github.com/awslabs/operatorpkg@v0.0.0-20251222193911-34e9a1898737
2026/06/03 05:56:56 writing output to website/content/en/preview/reference/metrics.md
2026/06/03 05:57:06 writing output to website/content/en/preview/reference/instance-types.md

(still fails because I haven't set the CI up completely, but passes the new check)
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.