### PR TITLE
ci: fix min values testing flakes

### DIFF
--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -195,6 +195,10 @@ func MakeInstances() []ec2types.InstanceTypeInfo {
 	// Use keys from the static pricing data so that we guarantee pricing for the data
 	// Create uniform instance data so all of them schedule for a given pod
 	for _, it := range pricing.NewDefaultProvider(nil, nil, "us-east-1", true).InstanceTypes() {
+		// a1 instances are incompatible with AL2023 (the default test AMI family)
+		if strings.HasPrefix(string(it), "a1.") {
+			continue
+		}
 		instanceTypes = append(instanceTypes, ec2types.InstanceTypeInfo{
 			InstanceType: it,
 			ProcessorInfo: &ec2types.ProcessorInfo{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Suite tests like [CreateFleet input should respect minValues for Exists Operator in requirement from NodePool](https://github.com/aws/karpenter-provider-aws/blob/b3facf567c3e888c16061d5e1838b5272017472d/pkg/cloudprovider/suite_test.go#L462) can sometimes fail min values check due to non-determinstic `fake.MakeInstances()` and `fake.MakeUniqueInstancesAndFamilies(...)` that result in `a1` instance types being chosen for tests. 

In https://github.com/aws/karpenter-provider-aws/pull/9017, we started marking these offerings as unavailable when AL2023 is being used (as a1 instance types are not supported with al2023s). This causes minValues to not be satisfied in these runs. 

We first saw this in https://github.com/aws/karpenter-provider-aws/actions/runs/23730434115/job/69122870695, which was soon after PR 9017 was merged.

**Examples**
- https://github.com/aws/karpenter-provider-aws/actions/runs/26867018895/job/79232887807
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues for Exists Operator in requirement from NodePool

- https://github.com/aws/karpenter-provider-aws/actions/runs/26783967391/job/78955157347
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues for In operator requirement from NodePool

- https://github.com/aws/karpenter-provider-aws/actions/runs/26780174509/job/78942191717
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues for Exists Operator in requirement from NodePool

- https://github.com/aws/karpenter-provider-aws/actions/runs/26779583265/job/78940135379
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues for Exists Operator in requirement from NodePool

- https://github.com/aws/karpenter-provider-aws/actions/runs/26588710880/job/78341551664
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues for In operator requirement from NodePool

- https://github.com/aws/karpenter-provider-aws/actions/runs/26543388892/job/78189847573
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues from multiple keys in NodePool

- https://github.com/aws/karpenter-provider-aws/actions/runs/26068766311/job/76645350800
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues from multiple keys in NodePool

- https://github.com/aws/karpenter-provider-aws/actions/runs/26068000192/job/76642976911
> [FAIL] CloudProvider MinValues [It] CreateFleet input should respect minValues for In operator requirement from NodePool


**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.