### PR TITLE
chore: bump max k8s version to 1.36

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -21,7 +21,7 @@ inputs:
     required: true
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
-    default: "1.35"
+    default: "1.36"
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
   private_cluster:

--- a/.github/actions/e2e/run-tests-private-cluster/action.yaml
+++ b/.github/actions/e2e/run-tests-private-cluster/action.yaml
@@ -33,7 +33,7 @@ inputs:
     required: true
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
-    default: "1.35"
+    default: "1.36"
   private_cluster:
     description: "Whether to create a private cluster which does not add access to the public internet. Valid values are 'true' or 'false'"
     default: 'false'

--- a/.github/actions/e2e/setup-cluster/action.yaml
+++ b/.github/actions/e2e/setup-cluster/action.yaml
@@ -27,7 +27,7 @@ inputs:
     required: true
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
-    default: "1.35"
+    default: "1.36"
   eksctl_version:
     description: "Version of eksctl to install"
     default: v0.202.0

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -3,7 +3,7 @@ description: 'Installs Go Downloads and installs Karpenter Dependencies'
 inputs:
   k8sVersion:
     description: Kubernetes version to use when installing the toolchain
-    default: "1.35.x"
+    default: "1.36.x"
   use-cache:
     description: 'Whether to cache dependencies'
     default: true

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          k8sVersion: ["1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x"]
+          k8sVersion: ["1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x", "1.36.x"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/install-deps
@@ -23,7 +23,7 @@ jobs:
     - run: K8S_VERSION=${{ matrix.k8sVersion }} make ci-test
     - name: Send coverage
       # should only send converage once https://docs.coveralls.io/parallel-builds
-      if: matrix.k8sVersion == '1.35.x'
+      if: matrix.k8sVersion == '1.36.x'
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: goveralls -coverprofile=coverage.out -service=github

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -7,7 +7,7 @@ on:
         default: "us-east-2"
       k8s_version:
         type: string
-        default: "1.35"
+        default: "1.36"
       cleanup:
         type: boolean
         required: true
@@ -34,14 +34,14 @@ on:
       k8s_version:
         type: choice
         options:
-          - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
           - "1.33"
           - "1.34"
           - "1.35"
-        default: "1.35"
+          - "1.36"
+        default: "1.36"
       cleanup:
         type: boolean
         required: true

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -16,14 +16,14 @@ on:
       k8s_version:
         type: choice
         options:
-          - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
           - "1.33"
           - "1.34"
           - "1.35"
-        default: "1.35"
+          - "1.36"
+        default: "1.36"
       cleanup:
         required: true
         default: true
@@ -43,7 +43,7 @@ on:
         default: "us-east-2"
       k8s_version:
         type: string
-        default: "1.35"
+        default: "1.36"
       cleanup:
         required: true
         type: boolean

--- a/.github/workflows/e2e-version-compatibility-trigger.yaml
+++ b/.github/workflows/e2e-version-compatibility-trigger.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: ["1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"]
+        k8s_version: ["1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"]
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       region: ${{ inputs.region || 'eu-west-1' }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,14 +30,14 @@ on:
       k8s_version:
         type: choice
         options:
-          - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
           - "1.33"
           - "1.34"
           - "1.35"
-        default: "1.35"
+          - "1.36"
+        default: "1.36"
       cluster_name:
         type: string
       cleanup:
@@ -67,7 +67,7 @@ on:
         required: true
       k8s_version:
         type: string
-        default: "1.35"
+        default: "1.36"
       enable_metrics:
         type: boolean
         default: false

--- a/pkg/controllers/providers/version/suite_test.go
+++ b/pkg/controllers/providers/version/suite_test.go
@@ -80,10 +80,10 @@ var _ = Describe("Version", func() {
 		options.FromContext(ctx).EKSControlPlane = true
 		awsEnv.EKSAPI.DescribeClusterBehavior.Output.Set(&eks.DescribeClusterOutput{
 			Cluster: &ekstypes.Cluster{
-				Version: lo.ToPtr("1.29"),
+				Version: lo.ToPtr("1.30"),
 			},
 		})
 		ExpectSingletonReconciled(ctx, controller)
-		Expect(awsEnv.VersionProvider.Get(ctx)).To(Equal("1.29"))
+		Expect(awsEnv.VersionProvider.Get(ctx)).To(Equal("1.30"))
 	})
 })

--- a/pkg/fake/eksapi.go
+++ b/pkg/fake/eksapi.go
@@ -54,7 +54,7 @@ func (s *EKSAPI) DescribeCluster(_ context.Context, input *eks.DescribeClusterIn
 				KubernetesNetworkConfig: &ekstypes.KubernetesNetworkConfigResponse{
 					ServiceIpv4Cidr: lo.ToPtr("10.100.0.0/16"),
 				},
-				Version: lo.ToPtr("1.29"),
+				Version: lo.ToPtr("1.30"),
 			},
 		}, nil
 	})

--- a/pkg/providers/version/suite_test.go
+++ b/pkg/providers/version/suite_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Operator", func() {
 			options.FromContext(ctx).EKSControlPlane = true
 			ExpectSingletonReconciled(ctx, versionController)
 			version := awsEnv.VersionProvider.Get(ctx)
-			Expect(version).To(Equal("1.29"))
+			Expect(version).To(Equal("1.30"))
 		})
 	})
 

--- a/pkg/providers/version/version.go
+++ b/pkg/providers/version/version.go
@@ -41,7 +41,7 @@ const (
 	// If a user runs a karpenter image on a k8s version outside the min and max,
 	// One error message will be fired to notify
 	MinK8sVersion = "1.26"
-	MaxK8sVersion = "1.35"
+	MaxK8sVersion = "1.36"
 )
 
 type Provider interface {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
* bumps the max supported Kubernetes version to 1.36 and removes 1.29 as it is no longer available in extended support ([ref](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions-extended))

**How was this change tested?**
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.