### PR TITLE
ci: fix neuron tests on k8s 1.36

### DIFF
--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -889,7 +889,7 @@ leaderElection:
 							Name:    neuronSchedulerExtension,
 							Args:    []string{fmt.Sprintf("--config=/etc/kubernetes/%[1]v/%[1]v-config.yaml", neuronSchedulerExtension), "--leader-elect=true", "--v=2"},
 							Command: []string{"/usr/local/bin/kube-scheduler"},
-							Image:   fmt.Sprintf("public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.%[1]v.0-eks-1-%[1]v-latest", env.K8sMinorVersion()),
+							Image:   fmt.Sprintf("public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.%v.0-eks-1-%v-", env.K8sMinorVersion(), env.K8sMinorVersion()) + lo.Ternary(env.K8sMinorVersion() >= 35, "2", "latest"),
 							LivenessProbe: &corev1.Probe{
 								InitialDelaySeconds: 15,
 								ProbeHandler: corev1.ProbeHandler{

--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Extended Resources", func() {
 		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      v1.LabelInstanceGeneration,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{"1", "2"},
+			Values:   []string{"2"},
 		})
 		env.ExpectCreated(nodeClass, nodePool, dep)
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
@@ -180,7 +180,7 @@ var _ = Describe("Extended Resources", func() {
 		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      v1.LabelInstanceGeneration,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{"1", "2"},
+			Values:   []string{"2"},
 		})
 		env.ExpectCreated(nodeClass, nodePool, dep)
 		env.EventuallyExpectHealthyPodCount(selector, numPods)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes https://github.com/aws/karpenter-provider-aws/actions/runs/26971349325/job/79587298895
```
Summarizing 2 Failures:
  [FAIL] Extended Resources [It] should provision nodes for a deployment that requests aws.amazon.com/neuron
  /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/integration/extended_resources_test.go:150
  [FAIL] Extended Resources [It] should provision nodes for a deployment that requests aws.amazon.com/neuroncore
  /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/integration/extended_resources_test.go:186
```

* Aligns the 1.35 and 1.36 eks-distro images with  https://gallery.ecr.aws/eks-distro/kubernetes/kube-scheduler
  * Recently removed `-latest` and only uses `-1`, `-2`, etc

* removes Inf1 from testing setup as it is no longer supported with newer neuron SDK versions - https://awsdocs-neuron.readthedocs-hosted.com/en/latest/about-neuron/announcements/neuron2.x/announce-correction-neuron-driver-support-inf1.html#announce-correction-neuron-driver-inf1-support

**How was this change tested?**
```
ryanmist@c889f3b6ff52 karpenter-provider-aws % make e2etests TEST_SUITE=integration FOCUS="should provision nodes for a deployment that requests aws.amazon.com/neuron"
..
[AfterSuite]
/Users/ryanmist/desktop/karp/karpenter-provider-aws/test/suites/integration/suite_test.go:38
  > Enter [AfterSuite] TOP-LEVEL - /Users/ryanmist/desktop/karp/karpenter-provider-aws/test/suites/integration/suite_test.go:38 @ 06/05/26 16:11:08.941
  < Exit [AfterSuite] TOP-LEVEL - /Users/ryanmist/desktop/karp/karpenter-provider-aws/test/suites/integration/suite_test.go:38 @ 06/05/26 16:11:08.941 (0s)
[AfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 2 of 81 Specs in 369.823 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 79 Skipped
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.