### PR TITLE
docs: Publish page Markdown and llms.txt

### DIFF
--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -35,6 +35,32 @@ blackfriday:
   hrefTargetBlank: true
   angledQuotes: false
   latexDashes: true
+outputFormats:
+  md:
+    mediaType: text/markdown
+    baseName: index
+    isPlainText: true
+    isHTML: false
+    permalinkable: true
+  llms:
+    mediaType: text/plain
+    baseName: llms
+    isPlainText: true
+    isHTML: false
+    rel: alternate
+    root: true
+outputs:
+  home:
+    - HTML
+    - RSS
+    - llms
+  page:
+    - HTML
+    - md
+  section:
+    - HTML
+    - RSS
+    - md
 markup:
   goldmark:
     renderer:

--- a/website/layouts/_default/list.md
+++ b/website/layouts/_default/list.md
@@ -2,17 +2,19 @@
   Plain-markdown twin of a section/list page, served at <section>/index.md.
   Emits the section's own content, then a linked list of its child pages so an
   LLM can navigate the section.
+
+  Auto-generated section nodes have no backing file; RenderShortcodes panics on
+  those, so the body is only rendered when the page is file-backed.
 */ -}}
 # {{ .Title }}
 {{ with .Description }}
 > {{ . }}
 {{ end }}
-{{/* Auto-generated section nodes have no backing file; RenderShortcodes panics
-     on those, so only render a body when the page is file-backed. */}}
 {{- with .File }}{{ $.RenderShortcodes }}{{ end }}
-{{ with .Pages }}
+{{- with .Pages.ByWeight }}
+
 ## Pages in this section
 {{ range . }}
-- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }})
+- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp | safeHTML }}{{ end }}
 {{- end }}
-{{ end }}
+{{ end -}}

--- a/website/layouts/_default/list.md
+++ b/website/layouts/_default/list.md
@@ -1,0 +1,20 @@
+{{- /*
+  Plain-markdown twin of a section/list page, served at <section>/index.md.
+  Emits the section's own content, then a linked list of its child pages so an
+  LLM can navigate the section.
+*/ -}}
+# {{ .Title }}
+{{ with .Description }}
+> {{ . }}
+{{ end }}
+Source: {{ .Permalink | replaceRE `index\.md$` "" }}
+
+{{/* Auto-generated section nodes have no backing file; RenderShortcodes panics
+     on those, so only render a body when the page is file-backed. */}}
+{{- with .File }}{{ $.RenderShortcodes }}{{ end }}
+{{ with .Pages }}
+## Pages in this section
+{{ range . }}
+- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }})
+{{- end }}
+{{ end }}

--- a/website/layouts/_default/list.md
+++ b/website/layouts/_default/list.md
@@ -7,8 +7,6 @@
 {{ with .Description }}
 > {{ . }}
 {{ end }}
-Source: {{ .Permalink | replaceRE `index\.md$` "" }}
-
 {{/* Auto-generated section nodes have no backing file; RenderShortcodes panics
      on those, so only render a body when the page is file-backed. */}}
 {{- with .File }}{{ $.RenderShortcodes }}{{ end }}

--- a/website/layouts/_default/single.md
+++ b/website/layouts/_default/single.md
@@ -4,10 +4,9 @@
   body. RenderShortcodes resolves Hugo shortcodes (e.g. script, ref) in place
   while leaving the surrounding markdown intact.
 */ -}}
+
 # {{ .Title }}
 {{ with .Description }}
 > {{ . }}
-{{ end }}
-Source: {{ .Permalink | replaceRE `index\.md$` "" }}
-
+> {{ end }}
 {{- with .File }}{{ $.RenderShortcodes }}{{ end }}

--- a/website/layouts/_default/single.md
+++ b/website/layouts/_default/single.md
@@ -1,12 +1,11 @@
 {{- /*
   Plain-markdown twin of a page, served at <page>/index.md for LLM consumption.
-  Emits a small header (title, source URL, description) followed by the page
+  Emits a small header (title, description) followed by the page
   body. RenderShortcodes resolves Hugo shortcodes (e.g. script, ref) in place
   while leaving the surrounding markdown intact.
 */ -}}
-
 # {{ .Title }}
 {{ with .Description }}
 > {{ . }}
-> {{ end }}
+{{ end }}
 {{- with .File }}{{ $.RenderShortcodes }}{{ end }}

--- a/website/layouts/_default/single.md
+++ b/website/layouts/_default/single.md
@@ -1,0 +1,13 @@
+{{- /*
+  Plain-markdown twin of a page, served at <page>/index.md for LLM consumption.
+  Emits a small header (title, source URL, description) followed by the page
+  body. RenderShortcodes resolves Hugo shortcodes (e.g. script, ref) in place
+  while leaving the surrounding markdown intact.
+*/ -}}
+# {{ .Title }}
+{{ with .Description }}
+> {{ . }}
+{{ end }}
+Source: {{ .Permalink | replaceRE `index\.md$` "" }}
+
+{{- with .File }}{{ $.RenderShortcodes }}{{ end }}

--- a/website/layouts/index.llms.txt
+++ b/website/layouts/index.llms.txt
@@ -6,14 +6,26 @@
   subsections become headings; deeper nesting is walked recursively by the
   llms-pages.txt partial (kept as .txt so plain-text output isn't HTML-escaped).
 */ -}}
+{{- $latest := printf "v%s.%s" (index (split site.Params.latest_release_version ".") 0) (index (split site.Params.latest_release_version ".") 1) -}}
 # {{ site.Title }}
 
 > {{ site.Params.description }}
 
 {{ with site.GetPage "/docs" -}}
-## Documentation
 {{ range .Sections.ByWeight }}
-### {{ .Title }}
+## {{ .Title }}
 {{- partial "llms-pages.txt" (dict "section" . "depth" 0) }}
 {{ end }}
+{{- end }}
+
+## Versions
+
+The links above point at the current stable release ({{ $latest }}), served under the `/docs/` path. The same documentation is archived for other releases under a version-prefixed path. To read any page for a specific version, replace the `/docs/` prefix in its URL with the version prefix below (and append `index.md` for the Markdown form).
+
+Available versions:
+- `/docs/` — current stable release ({{ $latest }})
+{{- range site.Params.versions }}
+{{- if ne . "preview" }}
+- `/{{ . }}/` — the {{ . }} release
+{{- end }}
 {{- end }}

--- a/website/layouts/index.llms.txt
+++ b/website/layouts/index.llms.txt
@@ -1,0 +1,22 @@
+{{- /*
+  llms.txt — an index of the site's documentation for LLMs, following the
+  spec at https://llmstxt.org. Scoped to the current "docs" section so the
+  file stays focused and avoids duplicating every archived version. Each link
+  points at the page's plain-markdown twin (index.md).
+*/ -}}
+# {{ site.Title }}
+
+> {{ site.Params.description }}
+
+{{ with site.GetPage "/docs" -}}
+## Documentation
+{{ range .Sections.ByWeight }}
+### {{ .Title }}
+{{ range .RegularPages.ByWeight }}
+- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp }}{{ end }}
+{{- end }}
+{{- range .Sections.ByWeight }}
+- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp }}{{ end }}
+{{- end }}
+{{ end }}
+{{- end }}

--- a/website/layouts/index.llms.txt
+++ b/website/layouts/index.llms.txt
@@ -2,7 +2,9 @@
   llms.txt — an index of the site's documentation for LLMs, following the
   spec at https://llmstxt.org. Scoped to the current "docs" section so the
   file stays focused and avoids duplicating every archived version. Each link
-  points at the page's plain-markdown twin (index.md).
+  points at the page's plain-markdown twin (index.md). Top-level docs
+  subsections become headings; deeper nesting is walked recursively by the
+  llms-pages.txt partial (kept as .txt so plain-text output isn't HTML-escaped).
 */ -}}
 # {{ site.Title }}
 
@@ -12,11 +14,6 @@
 ## Documentation
 {{ range .Sections.ByWeight }}
 ### {{ .Title }}
-{{ range .RegularPages.ByWeight }}
-- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp }}{{ end }}
-{{- end }}
-{{- range .Sections.ByWeight }}
-- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp }}{{ end }}
-{{- end }}
+{{- partial "llms-pages.txt" (dict "section" . "depth" 0) }}
 {{ end }}
 {{- end }}

--- a/website/layouts/partials/llms-pages.txt
+++ b/website/layouts/partials/llms-pages.txt
@@ -1,0 +1,18 @@
+{{- /*
+  Recursively lists a section's pages for llms.txt. Emits each regular page as
+  a bullet, then recurses into subsections (linking the subsection's own
+  index.md and indenting its children) so nesting of any depth is captured.
+
+  Args (dict):
+    section — the section page to walk
+    depth   — current nesting depth (0 at the top level), drives indentation
+*/ -}}
+{{- $section := .section -}}
+{{- $indent := strings.Repeat .depth "  " -}}
+{{- range $section.RegularPages.ByWeight }}
+{{ $indent }}- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp | safeHTML }}{{ end }}
+{{- end -}}
+{{- range $section.Sections.ByWeight }}
+{{ $indent }}- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp | safeHTML }}{{ end }}
+{{- partial "llms-pages.txt" (dict "section" . "depth" (add $.depth 1)) -}}
+{{- end -}}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add Markdown output to the docs site more that can be consumed more efficiently by AI agents.

Approach:

1. Twins every content page so that an `index.md` page is emitted alongside the `index.html` page (e.g. /docs/concepts/disruption/index.md). Hugo shortcodes are resolved in place via `.RenderShortcodes` so `{{% script %}}` blocks become real fenced code and `{{< ref >}}` links become plain URLs.
2. `llms.txt` served at the site root (eg. /llms.txt), which contains a structured index of the current `docs` section, linking each page to its `.md` twin.

This minimizes maintenance overhead by generating all of the new files at build time.

Why not use the Markdown files in GitHub repository? At least at the time of writing Claude Code only allows auto-approval of WebFetch by domain. Auto-approving github.com is not considered a secure approach, meaning users will need to manually approve each documentation page fetch. `llms.txt` also provides a convenient, efficient page index for the LLM to orient.

**How was this change tested?**

Tested with `huge server` and validated:

1. `llms.txt` is generated, paths are correct
4. Markdown files are generated and served at the expected URLs

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.