### PR TITLE
ci: fix nested virt suite test

### DIFF
--- a/test/suites/integration/launch_template_test.go
+++ b/test/suites/integration/launch_template_test.go
@@ -46,37 +46,3 @@ var _ = Describe("Launch Template Deletion", func() {
 		}).WithPolling(5.0).Should(Succeed())
 	})
 })
-
-var _ = Describe("Launch Template CPU Options", func() {
-	It("should create launch template with nested virtualization enabled", func() {
-		nodeClass.Spec.CPUOptions = &v1.CPUOptions{
-			NestedVirtualization: aws.String("enabled"),
-		}
-
-		pod := coretest.Pod()
-		env.ExpectCreated(nodePool, nodeClass, pod)
-		env.EventuallyExpectHealthy(pod)
-		env.ExpectCreatedNodeCount("==", 1)
-
-		Eventually(func(g Gomega) {
-			output, err := env.EC2API.DescribeLaunchTemplates(env.Context, &ec2.DescribeLaunchTemplatesInput{
-				Filters: []ec2types.Filter{
-					{Name: aws.String(fmt.Sprintf("tag:%s", v1.LabelNodeClass)), Values: []string{nodeClass.Name}},
-				},
-			})
-			g.Expect(err).To(BeNil())
-			g.Expect(output.LaunchTemplates).To(HaveLen(1))
-
-			ltOutput, err := env.EC2API.DescribeLaunchTemplateVersions(env.Context, &ec2.DescribeLaunchTemplateVersionsInput{
-				LaunchTemplateId: output.LaunchTemplates[0].LaunchTemplateId,
-				Versions:         []string{"$Latest"},
-			})
-			g.Expect(err).To(BeNil())
-			g.Expect(ltOutput.LaunchTemplateVersions).To(HaveLen(1))
-
-			ltData := ltOutput.LaunchTemplateVersions[0].LaunchTemplateData
-			g.Expect(ltData.CpuOptions).ToNot(BeNil())
-			g.Expect(ltData.CpuOptions.NestedVirtualization).To(Equal(ec2types.NestedVirtualizationSpecificationEnabled))
-		}).WithPolling(5.0).Should(Succeed())
-	})
-})

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -1251,7 +1251,7 @@ var _ = DescribeTableSubtree("Scheduling", Ordered, ContinueOnFailure, func(minV
 		env.ExpectCreated(nodePool, nodeClass, pod)
 		env.EventuallyExpectHealthy(pod)
 		node := env.ExpectCreatedNodeCount("==", 1)[0]
-		
+
 		instance := env.GetInstance(node.Name)
 		Expect(instance.CpuOptions).ToNot(BeNil())
 		Expect(instance.CpuOptions.NestedVirtualization).To(Equal(ec2types.NestedVirtualizationSpecificationEnabled))

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/awslabs/operatorpkg/object"
@@ -1240,6 +1241,20 @@ var _ = DescribeTableSubtree("Scheduling", Ordered, ContinueOnFailure, func(minV
 		}
 		// Each pod should be in a different partition
 		Expect(partitions.Len()).To(Equal(3))
+	})
+	It("should launch an instance with nested virtualization enabled", func() {
+		nodeClass.Spec.CPUOptions = &v1.CPUOptions{
+			NestedVirtualization: aws.String("enabled"),
+		}
+
+		pod := test.Pod()
+		env.ExpectCreated(nodePool, nodeClass, pod)
+		env.EventuallyExpectHealthy(pod)
+		node := env.ExpectCreatedNodeCount("==", 1)[0]
+		
+		instance := env.GetInstance(node.Name)
+		Expect(instance.CpuOptions).ToNot(BeNil())
+		Expect(instance.CpuOptions.NestedVirtualization).To(Equal(ec2types.NestedVirtualizationSpecificationEnabled))
 	})
 },
 	Entry("MinValuesPolicyBestEffort", options.MinValuesPolicyBestEffort),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
The current e2e test for nested virtualization expects the number of LTs for the NodeClass to eventually be 1, however, this may not always happen as NodeClaim launches can result in multiple launch templates being created and deleted nearly simultaneously.

This PR changes it to check the nested virt spec against the instance that was launched.


e.g. https://github.com/aws/karpenter-provider-aws/actions/runs/27154191650/job/80152705882
```
        {"level":"INFO","time":"2026-06-08T18:10:31.500Z","logger":"controller","caller":"provisioning/provisioner.go:438","message":"created nodeclaim","commit":"f22f2ea","controller":"provisioner","namespace":"","name":"","reconcileID":"9cc33478-3a71-4832-a7c4-4485f56efe63","NodePool":{"name":"skullroad-66-idq61k6h9n"},"NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"requests":{"cpu":"180m","memory":"104Mi","pods":"5"},"instance-types":"c5.12xlarge, c5.18xlarge, c5.24xlarge, c5.2xlarge, c5.4xlarge and 595 other(s)"}
        {"level":"DEBUG","time":"2026-06-08T18:10:31.583Z","logger":"controller","caller":"instance/instance.go:324","message":"filtered out instance types from launch","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","filter":"exotic-instance-filter","instance-types":"c5.metal, c7gn.metal, m5.metal, m7gd.metal, c5d.metal and 16 other(s)"}
        {"level":"DEBUG","time":"2026-06-08T18:10:31.782Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:286","message":"created launch template","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","launch-template-name":"karpenter.k8s.aws/692891143349738313","id":"lt-0b0e04f1c650609f1"}
        {"level":"DEBUG","time":"2026-06-08T18:10:31.939Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:286","message":"created launch template","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","launch-template-name":"karpenter.k8s.aws/11029883122447851390","id":"lt-083686bd6cee7f653"}
        {"level":"DEBUG","time":"2026-06-08T18:10:32.099Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:286","message":"created launch template","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","launch-template-name":"karpenter.k8s.aws/14000881007085375265","id":"lt-0bbfd13b5b7e556e4"}
        {"level":"DEBUG","time":"2026-06-08T18:10:32.263Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:286","message":"created launch template","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","launch-template-name":"karpenter.k8s.aws/10096238700158694539","id":"lt-027f56378f1b093df"}
        {"level":"DEBUG","time":"2026-06-08T18:10:32.432Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:286","message":"created launch template","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","launch-template-name":"karpenter.k8s.aws/16187933280421643809","id":"lt-0410600c043486e90"}
        {"level":"DEBUG","time":"2026-06-08T18:10:32.583Z","logger":"controller","caller":"launchtemplate/launchtemplate.go:286","message":"created launch template","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","launch-template-name":"karpenter.k8s.aws/16927303744149207693","id":"lt-0831c0b525c3566b7"}
...
        {"level":"INFO","time":"2026-06-08T18:11:00.319Z","logger":"controller","caller":"lifecycle/launch.go:121","message":"launched nodeclaim","commit":"f22f2ea","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"skullroad-66-idq61k6h9n-f4bhh"},"namespace":"","name":"skullroad-66-idq61k6h9n-f4bhh","reconcileID":"914511f3-03bf-4ab6-9f09-52130ed861ca","provider-id":"aws:///us-east-2a/i-0c7fd102958d931cc","instance-type":"c8i-flex.large","zone":"us-east-2a","capacity-type":"on-demand","allocatable":{"cpu":"1930m","ephemeral-storage":"17Gi","memory":"2784Mi","pods":"59","vpc.amazonaws.com/pod-eni":"3"}}
...
        {"level":"DEBUG","time":"2026-06-08T18:11:57.253Z","logger":"controller","caller":"go-cache@v2.1.0+incompatible/cache.go:946","message":"deleted launch template","commit":"f22f2ea","id":"lt-0b0e04f1c650609f1","name":"karpenter.k8s.aws/692891143349738313"}
        {"level":"DEBUG","time":"2026-06-08T18:11:57.428Z","logger":"controller","caller":"go-cache@v2.1.0+incompatible/cache.go:946","message":"deleted launch template","commit":"f22f2ea","id":"lt-0831c0b525c3566b7","name":"karpenter.k8s.aws/16927303744149207693"}
        {"level":"DEBUG","time":"2026-06-08T18:11:57.600Z","logger":"controller","caller":"go-cache@v2.1.0+incompatible/cache.go:946","message":"deleted launch template","commit":"f22f2ea","id":"lt-03a910b39ed7304a9","name":"karpenter.k8s.aws/10361784292827838664"}
        {"level":"DEBUG","time":"2026-06-08T18:11:57.780Z","logger":"controller","caller":"go-cache@v2.1.0+incompatible/cache.go:946","message":"deleted launch template","commit":"f22f2ea","id":"lt-083686bd6cee7f653","name":"karpenter.k8s.aws/11029883122447851390"}
        {"level":"DEBUG","time":"2026-06-08T18:11:57.957Z","logger":"controller","caller":"go-cache@v2.1.0+incompatible/cache.go:946","message":"deleted launch template","commit":"f22f2ea","id":"lt-0bbfd13b5b7e556e4","name":"karpenter.k8s.aws/14000881007085375265"}
        {"level":"DEBUG","time":"2026-06-08T18:11:58.131Z","logger":"controller","caller":"go-cache@v2.1.0+incompatible/cache.go:946","message":"deleted launch template","commit":"f22f2ea","id":"lt-027f56378f1b093df","name":"karpenter.k8s.aws/10096238700158694539"}
        {"level":"DEBUG","time":"2026-06-08T18:11:58.309Z","logger":"controller","caller":"go-cache@v2.1.0+incompatible/cache.go:946","message":"deleted launch template","commit":"f22f2ea","id":"lt-0410600c043486e90","name":"karpenter.k8s.aws/16187933280421643809"}
```

**How was this change tested?**
* `karpenter snapshot`
```
Scheduling
/home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/scheduling/suite_test.go:70
  MinValuesPolicyBestEffort
  /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/scheduling/suite_test.go:1260
    should launch an instance with nested virtualization enabled
    /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/scheduling/suite_test.go:1245
...
  < Exit [AfterEach] TOP-LEVEL - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/scheduling/suite_test.go:69 @ 06/09/26 00:31:39.029 (27.255s)
• [133.248 seconds]
------------------------------
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.