### PR TITLE
fix: evict stale instance cache entries in List()

### DIFF
--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -222,13 +222,10 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		placementGroupProvider,
 		zsProvider,
 		// Instance cache entries never expire. The cache is actively refreshed by the garbage
-		// collection controller's List() every 2 minutes, and entries are explicitly removed
-		// when Get() returns NotFound from EC2. NoExpiration ensures cached instances in zonally
-		// shifted AZs remain available for the zonal shift guards in Get(), Delete(), and
-		// CreateTags(), even if List() cannot return instances from the impaired AZ.
-		// TODO: Add a cache garbage collector that reconciles entries against EC2 and the API
-		// server, evicting entries for instances that no longer exist in either. Note: removing
-		// NodeClaim finalizers to bypass Karpenter's lifecycle management is not supported.
+		// collection controller's List() every 2 minutes, and stale entries are evicted by
+		// List() for instances no longer returned by EC2. NoExpiration ensures cached instances
+		// in zonally shifted AZs remain available for the zonal shift guards in Get(), Delete(),
+		// and CreateTags(), even if List() cannot return instances from the impaired AZ.
 		cache.New(cache.NoExpiration, cache.NoExpiration),
 	)
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -232,13 +232,10 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		placementGroupProvider,
 		zsProvider,
 		// Instance cache entries never expire. The cache is actively refreshed by the garbage
-		// collection controller's List() every 2 minutes, and entries are explicitly removed
-		// when Get() returns NotFound from EC2. NoExpiration ensures cached instances in zonally
-		// shifted AZs remain available for the zonal shift guards in Get(), Delete(), and
-		// CreateTags(), even if List() cannot return instances from the impaired AZ.
-		// TODO: Add a cache garbage collector that reconciles entries against EC2 and the API
-		// server, evicting entries for instances that no longer exist in either. Note: removing
-		// NodeClaim finalizers to bypass Karpenter's lifecycle management is not supported.
+		// collection controller's List() every 2 minutes, and stale entries are evicted by
+		// List() for instances no longer returned by EC2. NoExpiration ensures cached instances
+		// in zonally shifted AZs remain available for the zonal shift guards in Get(), Delete(),
+		// and CreateTags(), even if List() cannot return instances from the impaired AZ.
 		cache.New(cache.NoExpiration, cache.NoExpiration),
 	)
 	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -211,8 +211,8 @@ func (p *DefaultProvider) Get(ctx context.Context, id string, opts ...Options) (
 	if len(instances) != 1 {
 		return nil, fmt.Errorf("expected a single instance, %w", err)
 	}
-	p.instanceCache.SetDefault(id, instances[0])
-	return instances[0], nil
+	p.instanceCache.SetDefault(id, instances[id])
+	return instances[id], nil
 }
 
 func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
@@ -246,14 +246,13 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 		out.Reservations = append(out.Reservations, page.Reservations...)
 	}
 	instances, err := instancesFromOutput(ctx, out)
-	liveIDs := sets.New(lo.Map(instances, func(i *Instance, _ int) string { return i.ID })...)
-	for _, it := range instances {
-		p.instanceCache.SetDefault(it.ID, it)
+	for id, it := range instances {
+		p.instanceCache.SetDefault(id, it)
 	}
 	// Evict cached entries for instances no longer returned by EC2, unless they are in a
 	// zonally-shifted AZ where DescribeInstances may not return them.
 	for id, item := range p.instanceCache.Items() {
-		if liveIDs.Has(id) {
+		if _, live := instances[id]; live {
 			continue
 		}
 		if inst, ok := item.Object.(*Instance); ok && inst.ZoneID != "" && p.zonalshiftProvider.IsZonalShifted(ctx, inst.ZoneID) {
@@ -261,7 +260,7 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 		}
 		p.instanceCache.Delete(id)
 	}
-	return instances, cloudprovider.IgnoreNodeClaimNotFoundError(err)
+	return lo.Values(instances), cloudprovider.IgnoreNodeClaimNotFoundError(err)
 }
 
 func (p *DefaultProvider) Delete(ctx context.Context, id string) error {
@@ -760,7 +759,7 @@ func getCapacityReservationInterruptible(instanceTypes []*cloudprovider.Instance
 	return false
 }
 
-func instancesFromOutput(ctx context.Context, out *ec2.DescribeInstancesOutput) ([]*Instance, error) {
+func instancesFromOutput(ctx context.Context, out *ec2.DescribeInstancesOutput) (map[string]*Instance, error) {
 	if len(out.Reservations) == 0 {
 		return nil, cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("instance not found"))
 	}
@@ -770,11 +769,10 @@ func instancesFromOutput(ctx context.Context, out *ec2.DescribeInstancesOutput) 
 	if len(instances) == 0 {
 		return nil, cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("instance not found"))
 	}
-	// Get a consistent ordering for instances
-	sort.Slice(instances, func(i, j int) bool {
-		return aws.ToString(instances[i].InstanceId) < aws.ToString(instances[j].InstanceId)
-	})
-	return lo.Map(instances, func(i ec2types.Instance, _ int) *Instance { return NewInstance(ctx, i) }), nil
+	return lo.SliceToMap(instances, func(i ec2types.Instance) (string, *Instance) {
+		inst := NewInstance(ctx, i)
+		return inst.ID, inst
+	}), nil
 }
 
 func combineFleetErrors(fleetErrs []ec2types.CreateFleetError) (errs error) {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -246,8 +246,20 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 		out.Reservations = append(out.Reservations, page.Reservations...)
 	}
 	instances, err := instancesFromOutput(ctx, out)
+	liveIDs := sets.New(lo.Map(instances, func(i *Instance, _ int) string { return i.ID })...)
 	for _, it := range instances {
 		p.instanceCache.SetDefault(it.ID, it)
+	}
+	// Evict cached entries for instances no longer returned by EC2, unless they are in a
+	// zonally-shifted AZ where DescribeInstances may not return them.
+	for id, item := range p.instanceCache.Items() {
+		if liveIDs.Has(id) {
+			continue
+		}
+		if inst, ok := item.Object.(*Instance); ok && inst.ZoneID != "" && p.zonalshiftProvider.IsZonalShifted(ctx, inst.ZoneID) {
+			continue
+		}
+		p.instanceCache.Delete(id)
 	}
 	return instances, cloudprovider.IgnoreNodeClaimNotFoundError(err)
 }

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -930,4 +930,84 @@ var _ = Describe("InstanceProvider", func() {
 			})
 		})
 	})
+	Context("Cache Eviction", func() {
+		It("should evict cached instances that are no longer returned by List", func() {
+			// Store an instance in EC2 with the required tags for List() to find it
+			ec2Instance := test.EC2Instance(ec2types.Instance{
+				Placement: &ec2types.Placement{
+					AvailabilityZone:   aws.String("test-zone-1a"),
+					AvailabilityZoneId: aws.String("tstz1-1a"),
+				},
+				Tags: []ec2types.Tag{
+					{Key: aws.String(v1.NodePoolTagKey), Value: aws.String("default")},
+					{Key: aws.String(v1.LabelNodeClass), Value: aws.String("default")},
+					{Key: aws.String(v1.EKSClusterNameTagKey), Value: aws.String(options.FromContext(ctx).ClusterName)},
+				},
+			})
+			id := aws.ToString(ec2Instance.InstanceId)
+			awsEnv.EC2API.Instances.Store(id, ec2Instance)
+
+			// Populate the cache via Get
+			inst, err := awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inst.ID).To(Equal(id))
+
+			// Remove the instance from EC2 (simulates spot reclaim)
+			awsEnv.EC2API.Instances.Delete(id)
+
+			// Call List — this should evict the stale cache entry
+			_, err = awsEnv.InstanceProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Now Get without SkipCache should go to EC2 and return NotFound
+			_, err = awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).To(HaveOccurred())
+			Expect(corecloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
+		})
+		It("should not evict cached instances in a zonally shifted AZ when not returned by List", func() {
+			// Store an instance in the shifted zone and populate the cache
+			ec2Instance := test.EC2Instance(ec2types.Instance{
+				Placement: &ec2types.Placement{
+					AvailabilityZone:   aws.String("test-zone-1a"),
+					AvailabilityZoneId: aws.String("tstz1-1a"),
+				},
+				Tags: []ec2types.Tag{
+					{Key: aws.String(v1.NodePoolTagKey), Value: aws.String("default")},
+					{Key: aws.String(v1.LabelNodeClass), Value: aws.String("default")},
+					{Key: aws.String(v1.EKSClusterNameTagKey), Value: aws.String(options.FromContext(ctx).ClusterName)},
+				},
+			})
+			id := aws.ToString(ec2Instance.InstanceId)
+			awsEnv.EC2API.Instances.Store(id, ec2Instance)
+
+			// Populate the cache via Get
+			inst, err := awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inst.ID).To(Equal(id))
+
+			// Remove the instance from EC2
+			awsEnv.EC2API.Instances.Delete(id)
+
+			// Activate a zonal shift for tstz1-1a
+			awsEnv.ARCZonalShiftAPI.GetManagedResourceBehavior.Output.Set(&arczonalshift.GetManagedResourceOutput{
+				ZonalShifts: []arczonalshifttypes.ZonalShiftInResource{
+					{
+						AwayFrom:      aws.String("tstz1-1a"),
+						ExpiryTime:    aws.Time(time.Now().Add(time.Hour)),
+						AppliedStatus: arczonalshifttypes.AppliedStatusApplied,
+					},
+				},
+			})
+			Expect(awsEnv.ZonalShiftProvider.UpdateZonalShifts(ctx)).To(Succeed())
+
+			// List should NOT evict because the zone is shifted
+			_, err = awsEnv.InstanceProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get without SkipCache should still return the cached instance
+			inst, err = awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inst.ID).To(Equal(id))
+		})
+	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #9226

**Description**
The instance cache TTL was recently changed from 1 minute to `NoExpiration` to support zonal shift. However, `List()` only *adds* entries to the cache and never removes entries for instances that EC2 no longer returns. We rely on these instances being removed from the cache as part of node termination - https://github.com/kubernetes-sigs/karpenter/blob/7593c9c8e04d961788940047f70cd00411e83823/pkg/controllers/node/termination/controller.go#L117:L128

This can cause spot-interrupted, IODCR-interrupted, or manually terminated instances to persist as ghost Nodes / NodeClaims in some cases (I've only been able to do this by turning off graceful node shutdown).

This PR changes List() to remove entries for instances that EC2 no longer returns *if* we have not shifted out of the zone

**How was this change tested?**
* unit tests


#### Before PR
Interrupted instance through reclaiming capacity in IODCRs:
```
{"level":"INFO","time":"2026-06-09T17:12:43.743Z","logger":"controller","caller":"interruption/utils.go:160","message":"initiating delete from interruption message","commit":"f22f2ea-dirty","controller":"interruption","namespace":"","name":"","reconcileID":"5d8f172f-9ba1-4605-9c56-d17a3138af9b","queue":"ryanmist-karpenter","messageKind":"capacity_reservation_interrupted","NodeClaim":{"name":"iodcr-pool-ct6j7"},"action":"CordonAndDrain","Node":{"name":"ip-xxx-xxx-xx-87.us-west-2.compute.internal"}}
```
Instance is terminated, but the NodeClaim and Node are still around:
```
aws ec2 describe-instances --instance-ids i-08580c5bce70e890c | grep "State\": {" -A 3
                    "State": {
                        "Code": 48,
                        "Name": "terminated"
                    },
```
```
k get nodeclaim
NAME               TYPE        CAPACITY   ZONE         NODE                                          READY   AGE
iodcr-pool-ct6j7   m5.xlarge   reserved   us-west-2c   ip-xxx-xxx-xx-87.us-west-2.compute.internal   True    15m

k get node
NAME                                           STATUS     ROLES    AGE    VERSION
ip-xxx-xx-xx-87.us-west-2.compute.internal    NotReady   <none>   14m    v1.36.1-eks-3385e9b
```

#### After PR
Interrupted instance through reclaiming capacity in IODCRs:
```
{"level":"INFO","time":"2026-06-09T18:34:15.836Z","logger":"controller","caller":"interruption/utils.go:160","message":"initiating delete from interruption message","commit":"af2924f-dirty","controller":"interruption","namespace":"","name":"","reconcileID":"8a2d659d-314d-40b5-89b8-bedc5759a1fb","queue":"ryanmist-karpenter","messageKind":"capacity_reservation_interrupted","NodeClaim":{"name":"iodcr-pool-fzhrg"},"action":"CordonAndDrain","Node":{"name":"ip-xxx-xxx-xx-52.us-west-2.compute.internal"}}
```

Instance is terminated, and the NodeClaim and Node are removed shortly after:
```
aws ec2 describe-instances --instance-ids i-06164f09161e05aa2 | grep "State\": {" -A 3
                    "State": {
                        "Code": 48,
                        "Name": "terminated"
                    },
```
```
k get nodeclaim iodcr-pool-fzhrg
Error from server (NotFound): nodeclaims.karpenter.sh "iodcr-pool-fzhrg" not found

k get node ip-xxx-xxx-xx-52.us-west-2.compute.internal
Error from server (NotFound): nodes "ip-xxx-xxx-xx-52.us-west-2.compute.internal" not found
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.