### PR TITLE
chore: fix typos in code comments, error strings, and test names

### DIFF
--- a/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
@@ -941,7 +941,7 @@ var _ = Describe("CEL/Validation", func() {
 				}
 				Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
 			})
-			It("should fail when imageGCLowThresholdPercent is greather than imageGCHighThresheldPercent", func() {
+			It("should fail when imageGCLowThresholdPercent is greater than imageGCHighThresholdPercent", func() {
 				nc.Spec.Kubelet = &v1.KubeletConfiguration{
 					ImageGCHighThresholdPercent: lo.ToPtr(int32(50)),
 					ImageGCLowThresholdPercent:  lo.ToPtr(int32(60)),

--- a/pkg/batcher/describeinstances.go
+++ b/pkg/batcher/describeinstances.go
@@ -103,7 +103,7 @@ func execDescribeInstancesBatch(ec2api sdk.EC2API) BatchExecutor[ec2.DescribeIns
 
 		// Some or all instances may have failed to be described due to eventual consistency or transient zonal issue.
 		// A single instance lookup failure can result in all of an availability zone's instances failing to describe.
-		// So we try to describe them individually now. This should be rare and only results in a handfull of extra calls per batch than without batching.
+		// So we try to describe them individually now. This should be rare and only results in a handful of extra calls per batch than without batching.
 		var wg sync.WaitGroup
 		for instanceID := range missingInstanceIDs {
 			wg.Go(func() {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -31,7 +31,7 @@ const (
 	UnavailableOfferingsTTL = 3 * time.Minute
 	// CapacityReservationAvailabilityTTL is the time we will persist cached capacity availability. Nominally, this is
 	// updated every minute, but we want to persist the data longer in the event of an EC2 API outage. 24 hours was the
-	// compormise made for API outage reseliency and gargage collecting entries for orphaned reservations.
+	// compromise made for API outage resiliency and garbage collecting entries for orphaned reservations.
 	CapacityReservationAvailabilityTTL = 24 * time.Hour
 	// InstanceTypesZonesAndOfferingsTTL is the time before we refresh instance types, zones, and offerings at EC2
 	InstanceTypesZonesAndOfferingsTTL = 5 * time.Minute

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -90,7 +90,7 @@ func NewUnavailableOfferings() *UnavailableOfferings {
 	return uo
 }
 
-// SeqNum returns a sequence number for an instance type to capture whether the offering cache has changed for the intance type
+// SeqNum returns a sequence number for an instance type to capture whether the offering cache has changed for the instance type
 func (u *UnavailableOfferings) SeqNum(instanceType ec2types.InstanceType) uint64 {
 	u.offeringCacheSeqNumMu.RLock()
 	defer u.offeringCacheSeqNumMu.RUnlock()

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -198,7 +198,7 @@ func (p *DefaultProvider) amis(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 				// and GPU instances. In that case, we'll have a set of requirements for each, and will create one "image" for each.
 				for _, reqs := range query.RequirementsForImageWithArchitecture(lo.FromPtr(image.ImageId), arch) {
 					// Checks and store for AMIs
-					// Following checks are needed in order to always priortize non deprecated AMIs
+					// Following checks are needed in order to always prioritize non deprecated AMIs
 					// If we already have an image with the same set of requirements, but this image (candidate) is newer, replace the previous (existing) image.
 					// If we already have an image with the same set of requirements which is deprecated, but this image (candidate) is newer or non deprecated, replace the previous (existing) image
 					reqsHash := lo.Must(hashstructure.Hash(reqs.NodeSelectorRequirements(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true}))

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3210,7 +3210,7 @@ var _ = Describe("InstanceTypeProvider", func() {
 
 				instanceTypes, err := awsEnv.InstanceTypesProvider.List(ctx, nodeClass)
 				Expect(err).To(BeNil())
-				// dl1.24xlarge only suppports 4 EFAs
+				// dl1.24xlarge only supports 4 EFAs
 				dl1Instance, ok := lo.Find(instanceTypes, func(it *corecloudprovider.InstanceType) bool {
 					return it.Name == "dl1.24xlarge"
 				})

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -240,7 +240,7 @@ func (p *DefaultProvider) UpdateOnDemandPricing(ctx context.Context) error {
 
 	err := multierr.Append(onDemandErr, onDemandMetalErr)
 	if err != nil {
-		return fmt.Errorf("retreiving on-demand pricing data, %w", err)
+		return fmt.Errorf("retrieving on-demand pricing data, %w", err)
 	}
 
 	if len(onDemandPrices) == 0 || len(onDemandMetalPrices) == 0 {


### PR DESCRIPTION
Fixes #N/A

**Description**

While reading through the AWS provider to get familiar with the codebase, I came across a handful of typos in code comments, a couple of error/log strings, and some test descriptions, so I cleaned them up.

Spelling-only — no behavior changes, and nothing touches generated code, CRDs, or public API docs. A few examples: "compormise/reseliency/gargage" in a cache comment, "intance", "priortize", "retreiving" (an error string in the pricing provider), "handfull", and a couple of test-name typos.

**How was this change tested?**

No functional change, so no new tests. `make test` passes locally.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
