### PR TITLE
feat: make cluster-name tag key configurable via `--cluster-name-tag-key`

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -98,6 +98,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.13.0 \
 | settings.clusterCABundle | string | `""` | Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server. |
 | settings.clusterEndpoint | string | `""` | Cluster endpoint. If not set, will be discovered during startup (EKS only). |
 | settings.clusterName | string | `""` | Cluster name. |
+| settings.clusterNameTagKey | string | `""` | The tag key used to identify the cluster name on Karpenter-managed AWS resources. Defaults to `eks:eks-cluster-name` when unset. Do NOT change this if you are running on EKS, as it would break resource discovery and the IAM permissions provided by the getting-started CloudFormation template. |
 | settings.disableClusterStateObservability | bool | `false` | Disable cluster state metrics and events. |
 | settings.disableDryRun | bool | `false` | Disable dry run validation for EC2NodeClasses. |
 | settings.eksControlPlane | bool | `false` | Marking this true means that your cluster is running with an EKS control plane and Karpenter should attempt to discover cluster details from the DescribeCluster API. |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -149,6 +149,10 @@ spec:
           {{- end }}
             - name: CLUSTER_NAME
               value: "{{ required "Chart cannot be installed without a valid settings.clusterName!" (tpl .Values.settings.clusterName .) }}"
+          {{- with .Values.settings.clusterNameTagKey }}
+            - name: CLUSTER_NAME_TAG_KEY
+              value: "{{ tpl (toString .) $ }}"
+          {{- end }}
           {{- with .Values.settings.clusterEndpoint }}
             - name: CLUSTER_ENDPOINT
               value: "{{ tpl (toString .) $ }}"

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -194,6 +194,9 @@ settings:
   clusterCABundle: ""
   # -- Cluster name.
   clusterName: ""
+  # -- The tag key used to identify the cluster name on Karpenter-managed AWS resources. Defaults to `eks:eks-cluster-name` when unset.
+  # Do NOT change this if you are running on EKS, as it would break resource discovery and the IAM permissions provided by the getting-started CloudFormation template.
+  clusterNameTagKey: ""
   # -- Cluster endpoint. If not set, will be discovered during startup (EKS only).
   clusterEndpoint: ""
   # -- If true then assume we can't reach AWS services which don't have a VPC endpoint.

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -621,10 +621,10 @@ func (in *EC2NodeClass) InstanceProfileRole() string {
 	return in.Spec.Role
 }
 
-func (in *EC2NodeClass) InstanceProfileTags(clusterName string, region string) map[string]string {
+func (in *EC2NodeClass) InstanceProfileTags(clusterName, clusterNameTagKey, region string) map[string]string {
 	return lo.Assign(in.Spec.Tags, map[string]string{
 		fmt.Sprintf("kubernetes.io/cluster/%s", clusterName): "owned",
-		EKSClusterNameTagKey:   clusterName,
+		clusterNameTagKey:      clusterName,
 		LabelNodeClass:         in.Name,
 		v1.LabelTopologyRegion: region,
 	})

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -124,7 +124,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 	if nodeClassReady != nil && nodeClassReady.ObservedGeneration != nodeClass.Generation {
 		return nil, cloudprovider.NewNodeClassNotReadyError(fmt.Errorf("nodeclass status has not been reconciled against the latest spec"))
 	}
-	tags, err := utils.GetTags(nodeClass, nodeClaim, options.FromContext(ctx).ClusterName)
+	tags, err := utils.GetTags(nodeClass, nodeClaim, options.FromContext(ctx).ClusterName, options.FromContext(ctx).ClusterNameTagKey)
 	if err != nil {
 		return nil, cloudprovider.NewNodeClassNotReadyError(err)
 	}

--- a/pkg/controllers/nodeclaim/tagging/controller.go
+++ b/pkg/controllers/nodeclaim/tagging/controller.go
@@ -104,9 +104,9 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 
 func (c *Controller) tagInstance(ctx context.Context, nc *karpv1.NodeClaim, id string) error {
 	tags := map[string]string{
-		v1.NameTagKey:           nc.Status.NodeName,
-		v1.NodeClaimTagKey:      nc.Name,
-		v1.EKSClusterNameTagKey: options.FromContext(ctx).ClusterName,
+		v1.NameTagKey:      nc.Status.NodeName,
+		v1.NodeClaimTagKey: nc.Name,
+		options.FromContext(ctx).ClusterNameTagKey: options.FromContext(ctx).ClusterName,
 	}
 
 	// Remove tags which have been already populated

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -87,7 +87,7 @@ func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeC
 				ctx,
 				newProfileName,
 				nodeClass.InstanceProfileRole(),
-				nodeClass.InstanceProfileTags(options.FromContext(ctx).ClusterName, ip.region),
+				nodeClass.InstanceProfileTags(options.FromContext(ctx).ClusterName, options.FromContext(ctx).ClusterNameTagKey, ip.region),
 				instanceprofile.FormatPath("karpenter", ip.region, options.FromContext(ctx).ClusterName, string(nodeClass.UID)),
 			); err != nil {
 				// If we failed Create, we may have successfully created the instance profile but failed to either attach the new

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -159,7 +159,7 @@ func (v *Validation) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) 
 			},
 		},
 	}
-	tags, err := utils.GetTags(nodeClass, nodeClaim, options.FromContext(ctx).ClusterName)
+	tags, err := utils.GetTags(nodeClass, nodeClaim, options.FromContext(ctx).ClusterName, options.FromContext(ctx).ClusterNameTagKey)
 	if err != nil {
 		nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(v1.ConditionTypeValidationSucceeded, ConditionReasonTagValidationFailed, err.Error())
 		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("validating tags, %w", err))

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -25,6 +25,7 @@ import (
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/utils/env"
 
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/utils"
 )
 
@@ -37,6 +38,7 @@ type optionsKey struct{}
 type Options struct {
 	ClusterCABundle         string
 	ClusterName             string
+	ClusterNameTagKey       string
 	ClusterEndpoint         string
 	IsolatedVPC             bool
 	EKSControlPlane         bool
@@ -52,6 +54,7 @@ type Options struct {
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.ClusterCABundle, "cluster-ca-bundle", env.WithDefaultString("CLUSTER_CA_BUNDLE", ""), "Cluster CA bundle for nodes to use for TLS connections with the API server. If not set, this is taken from the controller's TLS configuration.")
 	fs.StringVar(&o.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "[REQUIRED] The kubernetes cluster name for resource discovery.")
+	fs.StringVar(&o.ClusterNameTagKey, "cluster-name-tag-key", env.WithDefaultString("CLUSTER_NAME_TAG_KEY", v1.EKSClusterNameTagKey), "The tag key used to identify the cluster name on Karpenter-managed AWS resources. Defaults to 'eks:eks-cluster-name'. Do NOT change this if you are running on EKS, as it would break resource discovery and the IAM permissions provided by the getting-started CloudFormation template.")
 	fs.StringVar(&o.ClusterEndpoint, "cluster-endpoint", env.WithDefaultString("CLUSTER_ENDPOINT", ""), "The external kubernetes cluster endpoint for new nodes to connect with. If not specified, will discover the cluster endpoint using DescribeCluster API.")
 	fs.BoolVarWithEnv(&o.IsolatedVPC, "isolated-vpc", "ISOLATED_VPC", false, "If true, then assume we can't reach AWS services which don't have a VPC endpoint. This also has the effect of disabling look-ups to the AWS on-demand pricing endpoint.")
 	fs.BoolVarWithEnv(&o.EKSControlPlane, "eks-control-plane", "EKS_CONTROL_PLANE", false, "Marking this true means that your cluster is running with an EKS control plane and Karpenter should attempt to discover cluster details from the DescribeCluster API ")

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -29,6 +29,7 @@ func (o *Options) Validate() error {
 		o.validateVMMemoryOverheadPercent(),
 		o.validateReservedENIs(),
 		o.validateRequiredFields(),
+		o.validateClusterNameTagKey(),
 		o.validateAMIRefreshInterval(),
 		o.validateSubnetRefreshInterval(),
 	)
@@ -78,6 +79,17 @@ func (o *Options) validateReservedENIs() error {
 func (o *Options) validateRequiredFields() error {
 	if o.ClusterName == "" {
 		return fmt.Errorf("missing field, cluster-name")
+	}
+	return nil
+}
+
+func (o *Options) validateClusterNameTagKey() error {
+	// AWS tag keys are limited to 128 characters and may not be empty.
+	if o.ClusterNameTagKey == "" {
+		return fmt.Errorf("cluster-name-tag-key cannot be empty")
+	}
+	if len(o.ClusterNameTagKey) > 128 {
+		return fmt.Errorf("cluster-name-tag-key cannot be longer than 128 characters")
 	}
 	return nil
 }

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Options", func() {
 		err := opts.Parse(fs,
 			"--cluster-ca-bundle", "env-bundle",
 			"--cluster-name", "env-cluster",
+			"--cluster-name-tag-key", "rosa:rosa-cluster-name",
 			"--cluster-endpoint", "https://env-cluster",
 			"--isolated-vpc",
 			"--vm-memory-overhead-percent", "0.1",
@@ -71,6 +72,7 @@ var _ = Describe("Options", func() {
 		expectOptionsEqual(opts, test.Options(test.OptionsFields{
 			ClusterCABundle:         lo.ToPtr("env-bundle"),
 			ClusterName:             lo.ToPtr("env-cluster"),
+			ClusterNameTagKey:       lo.ToPtr("rosa:rosa-cluster-name"),
 			ClusterEndpoint:         lo.ToPtr("https://env-cluster"),
 			IsolatedVPC:             lo.ToPtr(true),
 			VMMemoryOverheadPercent: lo.ToPtr[float64](0.1),
@@ -84,6 +86,7 @@ var _ = Describe("Options", func() {
 	It("should correctly fallback to env vars when CLI flags aren't set", func() {
 		os.Setenv("CLUSTER_CA_BUNDLE", "env-bundle")
 		os.Setenv("CLUSTER_NAME", "env-cluster")
+		os.Setenv("CLUSTER_NAME_TAG_KEY", "rosa:rosa-cluster-name")
 		os.Setenv("CLUSTER_ENDPOINT", "https://env-cluster")
 		os.Setenv("ISOLATED_VPC", "true")
 		os.Setenv("VM_MEMORY_OVERHEAD_PERCENT", "0.1")
@@ -101,6 +104,7 @@ var _ = Describe("Options", func() {
 		expectOptionsEqual(opts, test.Options(test.OptionsFields{
 			ClusterCABundle:         lo.ToPtr("env-bundle"),
 			ClusterName:             lo.ToPtr("env-cluster"),
+			ClusterNameTagKey:       lo.ToPtr("rosa:rosa-cluster-name"),
 			ClusterEndpoint:         lo.ToPtr("https://env-cluster"),
 			IsolatedVPC:             lo.ToPtr(true),
 			VMMemoryOverheadPercent: lo.ToPtr[float64](0.1),
@@ -138,6 +142,15 @@ var _ = Describe("Options", func() {
 			err := opts.Parse(fs, "--cluster-name", "test-cluster", "--cluster-endpoint", "00000000000000000000000.gr7.us-west-2.eks.amazonaws.com")
 			Expect(err).To(HaveOccurred())
 		})
+		It("should fail when cluster-name-tag-key is empty", func() {
+			err := opts.Parse(fs, "--cluster-name", "test-cluster", "--cluster-name-tag-key", "")
+			Expect(err).To(HaveOccurred())
+		})
+		It("should default cluster-name-tag-key when not specified", func() {
+			err := opts.Parse(fs, "--cluster-name", "test-cluster")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(opts.ClusterNameTagKey).To(Equal("eks:eks-cluster-name"))
+		})
 		It("should fail when vmMemoryOverheadPercent is negative", func() {
 			err := opts.Parse(fs, "--cluster-name", "test-cluster", "--vm-memory-overhead-percent", "-0.01")
 			Expect(err).To(HaveOccurred())
@@ -161,6 +174,7 @@ func expectOptionsEqual(optsA *options.Options, optsB *options.Options) {
 	GinkgoHelper()
 	Expect(optsA.ClusterCABundle).To(Equal(optsB.ClusterCABundle))
 	Expect(optsA.ClusterName).To(Equal(optsB.ClusterName))
+	Expect(optsA.ClusterNameTagKey).To(Equal(optsB.ClusterNameTagKey))
 	Expect(optsA.ClusterEndpoint).To(Equal(optsB.ClusterEndpoint))
 	Expect(optsA.IsolatedVPC).To(Equal(optsB.IsolatedVPC))
 	Expect(optsA.VMMemoryOverheadPercent).To(Equal(optsB.VMMemoryOverheadPercent))

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -229,7 +229,7 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 				Values: []string{v1.NodeClassTagKey},
 			},
 			{
-				Name:   aws.String(fmt.Sprintf("tag:%s", v1.EKSClusterNameTagKey)),
+				Name:   aws.String(fmt.Sprintf("tag:%s", karpopts.FromContext(ctx).ClusterNameTagKey)),
 				Values: []string{karpopts.FromContext(ctx).ClusterName},
 			},
 			instanceStateFilter,

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -434,12 +434,13 @@ func cpuOptions(cpuOptions *v1.CPUOptions) *ec2types.LaunchTemplateCpuOptionsReq
 // Any error during hydration will result in a panic
 func (p *DefaultProvider) hydrateCache(ctx context.Context) {
 	clusterName := options.FromContext(ctx).ClusterName
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("tag-key", v1.EKSClusterNameTagKey, "tag-value", clusterName))
+	clusterNameTagKey := options.FromContext(ctx).ClusterNameTagKey
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("tag-key", clusterNameTagKey, "tag-value", clusterName))
 
 	paginator := ec2.NewDescribeLaunchTemplatesPaginator(p.ec2api, &ec2.DescribeLaunchTemplatesInput{
 		Filters: []ec2types.Filter{
 			{
-				Name:   aws.String(fmt.Sprintf("tag:%s", v1.EKSClusterNameTagKey)),
+				Name:   aws.String(fmt.Sprintf("tag:%s", clusterNameTagKey)),
 				Values: []string{clusterName},
 			},
 		},
@@ -488,7 +489,7 @@ func (p *DefaultProvider) DeleteAll(ctx context.Context, nodeClass *v1.EC2NodeCl
 	paginator := ec2.NewDescribeLaunchTemplatesPaginator(p.ec2api, &ec2.DescribeLaunchTemplatesInput{
 		Filters: []ec2types.Filter{
 			{
-				Name:   aws.String(fmt.Sprintf("tag:%s", v1.EKSClusterNameTagKey)),
+				Name:   aws.String(fmt.Sprintf("tag:%s", options.FromContext(ctx).ClusterNameTagKey)),
 				Values: []string{clusterName},
 			},
 			{

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -129,6 +129,6 @@ type TestNodeClass struct {
 	v1.EC2NodeClass
 }
 
-func (t *TestNodeClass) InstanceProfileTags(clusterName string) map[string]string {
+func (t *TestNodeClass) InstanceProfileTags(clusterName, clusterNameTagKey string) map[string]string {
 	return nil
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -21,12 +21,14 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 )
 
 type OptionsFields struct {
 	ClusterCABundle         *string
 	ClusterName             *string
+	ClusterNameTagKey       *string
 	ClusterEndpoint         *string
 	IsolatedVPC             *bool
 	EKSControlPlane         *bool
@@ -48,6 +50,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 	return &options.Options{
 		ClusterCABundle:         lo.FromPtrOr(opts.ClusterCABundle, ""),
 		ClusterName:             lo.FromPtrOr(opts.ClusterName, "test-cluster"),
+		ClusterNameTagKey:       lo.FromPtrOr(opts.ClusterNameTagKey, v1.EKSClusterNameTagKey),
 		ClusterEndpoint:         lo.FromPtrOr(opts.ClusterEndpoint, "https://test-cluster"),
 		IsolatedVPC:             lo.FromPtrOr(opts.IsolatedVPC, false),
 		EKSControlPlane:         lo.FromPtrOr(opts.EKSControlPlane, false),

--- a/pkg/utils/suite_test.go
+++ b/pkg/utils/suite_test.go
@@ -19,6 +19,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -40,5 +42,37 @@ var _ = Describe("GetNodeClassHash", func() {
 		}
 		hash := utils.GetNodeClassHash(nodeClass)
 		Expect(hash).To(Equal("test-uid-123-5"))
+	})
+})
+
+var _ = Describe("GetTags", func() {
+	var nodeClass *v1.EC2NodeClass
+	var nodeClaim *karpv1.NodeClaim
+	BeforeEach(func() {
+		nodeClass = &v1.EC2NodeClass{ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclass"}}
+		nodeClaim = &karpv1.NodeClaim{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{karpv1.NodePoolLabelKey: "test-nodepool"},
+		}}
+	})
+	It("should tag resources with the default cluster-name tag key", func() {
+		tags, err := utils.GetTags(nodeClass, nodeClaim, "test-cluster", v1.EKSClusterNameTagKey)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tags).To(HaveKeyWithValue(v1.EKSClusterNameTagKey, "test-cluster"))
+	})
+	It("should tag resources with a custom cluster-name tag key", func() {
+		tags, err := utils.GetTags(nodeClass, nodeClaim, "test-cluster", "rosa:rosa-cluster-name")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tags).To(HaveKeyWithValue("rosa:rosa-cluster-name", "test-cluster"))
+		Expect(tags).ToNot(HaveKey(v1.EKSClusterNameTagKey))
+	})
+	It("should reject user-supplied tags matching the configured cluster-name tag key", func() {
+		nodeClass.Spec.Tags = map[string]string{"rosa:rosa-cluster-name": "user-value"}
+		_, err := utils.GetTags(nodeClass, nodeClaim, "test-cluster", "rosa:rosa-cluster-name")
+		Expect(err).To(HaveOccurred())
+	})
+	It("should still reject the default eks:eks-cluster-name tag even when a custom key is configured", func() {
+		nodeClass.Spec.Tags = map[string]string{v1.EKSClusterNameTagKey: "user-value"}
+		_, err := utils.GetTags(nodeClass, nodeClaim, "test-cluster", "rosa:rosa-cluster-name")
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -97,9 +97,15 @@ func WithDefaultFloat64(key string, def float64) float64 {
 	return f
 }
 
-func GetTags(nodeClass *v1.EC2NodeClass, nodeClaim *karpv1.NodeClaim, clusterName string) (map[string]string, error) {
+func GetTags(nodeClass *v1.EC2NodeClass, nodeClaim *karpv1.NodeClaim, clusterName, clusterNameTagKey string) (map[string]string, error) {
 	var invalidTags []string
 	for key := range nodeClass.Spec.Tags {
+		// The configured cluster-name tag key is reserved for Karpenter even when it has been
+		// overridden away from the default (which is already covered by RestrictedTagPatterns).
+		if key == clusterNameTagKey {
+			invalidTags = append(invalidTags, key)
+			continue
+		}
 		for _, exp := range v1.RestrictedTagPatterns {
 			if exp.MatchString(key) {
 				invalidTags = append(invalidTags, key)
@@ -116,7 +122,7 @@ func GetTags(nodeClass *v1.EC2NodeClass, nodeClaim *karpv1.NodeClaim, clusterNam
 	staticTags := map[string]string{
 		fmt.Sprintf("kubernetes.io/cluster/%s", clusterName): "owned",
 		karpv1.NodePoolLabelKey:                              nodeClaim.Labels[karpv1.NodePoolLabelKey],
-		v1.EKSClusterNameTagKey:                              clusterName,
+		clusterNameTagKey:                                    clusterName,
 		v1.LabelNodeClass:                                    nodeClass.Name,
 	}
 	return lo.Assign(nodeClass.Spec.Tags, staticTags), nil

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -4,6 +4,10 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
+  ClusterNameTagKey:
+    Type: String
+    Default: "eks:eks-cluster-name"
+    Description: "The tag key used to identify the cluster name on Karpenter-managed resources. Leave this as the default 'eks:eks-cluster-name' when running on EKS. Only override it (to match Karpenter's --cluster-name-tag-key) if you are running Karpenter outside of EKS."
 Resources:
   KarpenterNodeRole:
     Type: "AWS::IAM::Role"
@@ -87,7 +91,7 @@ Resources:
               "Condition": {
                 "StringEquals": {
                   "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+                  "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}"
                 },
                 "StringLike": {
                   "aws:RequestTag/karpenter.sh/nodepool": "*"
@@ -109,7 +113,7 @@ Resources:
               "Condition": {
                 "StringEquals": {
                   "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+                  "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}",
                   "ec2:CreateAction": [
                     "RunInstances",
                     "CreateFleet",
@@ -134,11 +138,11 @@ Resources:
                   "aws:ResourceTag/karpenter.sh/nodepool": "*"
                 },
                 "StringEqualsIfExists": {
-                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+                  "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}"
                 },
                 "ForAllValues:StringEquals": {
                   "aws:TagKeys": [
-                    "eks:eks-cluster-name",
+                    "${ClusterNameTagKey}",
                     "karpenter.sh/nodeclaim",
                     "Name"
                   ]
@@ -202,7 +206,7 @@ Resources:
               "Condition": {
                 "StringEquals": {
                   "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+                  "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}",
                   "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
                 },
                 "StringLike": {
@@ -222,7 +226,7 @@ Resources:
                   "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
                   "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
                   "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+                  "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}",
                   "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
                 },
                 "StringLike": {

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -34,6 +34,12 @@ A lot of the object naming that is done by `cloudformation.yaml` is based on the
 * Cluster name: With a username of `bob` the Getting Started Guide would name your cluster `bob-karpenter-demo`
 That name would then be appended to any name below where `${ClusterName}` is included.
 
+* Cluster name tag key: The `${ClusterNameTagKey}` parameter controls the tag key Karpenter uses to associate AWS resources with your cluster. It defaults to `eks:eks-cluster-name`, which matches Karpenter's default behavior on EKS.
+
+{{% alert title="Warning" color="warning" %}}
+Leave `${ClusterNameTagKey}` as the default `eks:eks-cluster-name` when running on EKS. Only override it if you run Karpenter outside of EKS and have set the controller's `--cluster-name-tag-key` flag (env `CLUSTER_NAME_TAG_KEY`) to a matching value. The CloudFormation parameter and the controller flag must always agree, otherwise the IAM conditions below will not match the tags Karpenter applies and node provisioning will fail.
+{{% /alert %}}
+
 * Partition: Any time an ARN is used, it includes the [partition name](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html) to identify where the object is found. In most cases, that partition name is `aws`. However, it could also be `aws-cn` (for China Regions) or `aws-us-gov` (for AWS GovCloud US Regions).
 
 ## Node Authorization
@@ -165,7 +171,7 @@ For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read 
 
 The AllowScopedEC2InstanceActionsWithTags Sid allows the
 [RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html), [CreateFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html), and [CreateLaunchTemplate](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateLaunchTemplate.html)
-actions requested by the Karpenter controller to create all `fleet`, `instance`, `volume`, `network-interface`, `launch-template` or `spot-instances-request` EC2 resources (for the partition and region). It also requires that the `kubernetes.io/cluster/${ClusterName}` tag be set to `owned`, `aws:RequestTag/eks:eks-cluster-name` be set to `"${ClusterName}`, and a `karpenter.sh/nodepool` tag be set to any value. This ensures that Karpenter is only allowed to create instances for a single EKS cluster.
+actions requested by the Karpenter controller to create all `fleet`, `instance`, `volume`, `network-interface`, `launch-template` or `spot-instances-request` EC2 resources (for the partition and region). It also requires that the `kubernetes.io/cluster/${ClusterName}` tag be set to `owned`, `aws:RequestTag/${ClusterNameTagKey}` be set to `"${ClusterName}`, and a `karpenter.sh/nodepool` tag be set to any value. This ensures that Karpenter is only allowed to create instances for a single EKS cluster.
 
 ```json
 {
@@ -187,7 +193,7 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
   "Condition": {
     "StringEquals": {
       "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+      "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}"
     },
     "StringLike": {
       "aws:RequestTag/karpenter.sh/nodepool": "*"
@@ -200,7 +206,7 @@ actions requested by the Karpenter controller to create all `fleet`, `instance`,
 
 The AllowScopedResourceCreationTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html)
 actions on `fleet`, `instance`, `volume`, `network-interface`, `launch-template` and `spot-instances-request` resources, While making `RunInstance`, `CreateFleet`, or `CreateLaunchTemplate` calls. Additionally, this ensures that resources can't be tagged arbitrarily by Karpenter after they are created.
-Conditions that must be met include that `aws:RequestTag/kubernetes.io/cluster/${ClusterName}` be set to `owned` and `aws:RequestTag/eks:eks-cluster-name` be set to `${ClusterName}`.
+Conditions that must be met include that `aws:RequestTag/kubernetes.io/cluster/${ClusterName}` be set to `owned` and `aws:RequestTag/${ClusterNameTagKey}` be set to `${ClusterName}`.
 
 ```json
 {
@@ -218,7 +224,7 @@ Conditions that must be met include that `aws:RequestTag/kubernetes.io/cluster/$
   "Condition": {
     "StringEquals": {
       "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+      "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}",
       "ec2:CreateAction": [
         "RunInstances",
         "CreateFleet",
@@ -235,7 +241,7 @@ Conditions that must be met include that `aws:RequestTag/kubernetes.io/cluster/$
 #### AllowScopedResourceTagging
 
 The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `kubernetes.io/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
-Likewise, `RequestTag/eks:eks-cluster-name` must be set to `${ClusterName}`, if it exists, and `TagKeys` must equal `eks:eks-cluster-name`, `karpenter.sh/nodeclaim`, and `Name`, for all values.
+Likewise, `RequestTag/${ClusterNameTagKey}` must be set to `${ClusterName}`, if it exists, and `TagKeys` must equal `${ClusterNameTagKey}`, `karpenter.sh/nodeclaim`, and `Name`, for all values.
 ```json
 {
   "Sid": "AllowScopedResourceTagging",
@@ -250,11 +256,11 @@ Likewise, `RequestTag/eks:eks-cluster-name` must be set to `${ClusterName}`, if 
       "aws:ResourceTag/karpenter.sh/nodepool": "*"
     },
     "StringEqualsIfExists": {
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+      "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}"
     },
     "ForAllValues:StringEquals": {
       "aws:TagKeys": [
-        "eks:eks-cluster-name",
+        "${ClusterNameTagKey}",
         "karpenter.sh/nodeclaim",
         "Name"
       ]
@@ -331,7 +337,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 #### AllowScopedInstanceProfileCreationActions
 
 The AllowScopedInstanceProfileCreationActions Sid gives the Karpenter controller permission to create a new instance profile with [`iam:CreateInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html),
-provided that the request is made to a cluster with `RequestTag` `kubernetes.io/cluster/${ClusterName}` set to `owned`, the `eks:eks-cluster-name` set to `${ClusterName}`, and `topology.kubernetes.io/region` set to the current region.
+provided that the request is made to a cluster with `RequestTag` `kubernetes.io/cluster/${ClusterName}` set to `owned`, the `${ClusterNameTagKey}` set to `${ClusterName}`, and `topology.kubernetes.io/region` set to the current region.
 Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures that Karpenter can generate instance profiles on your behalf based on roles specified in your `EC2NodeClasses` that you use to configure Karpenter.
 
 ```json
@@ -345,7 +351,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
   "Condition": {
     "StringEquals": {
       "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+      "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}",
       "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
     },
     "StringLike": {
@@ -357,7 +363,7 @@ Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures t
 
 #### AllowScopedInstanceProfileTagActions
 
-The AllowScopedInstanceProfileTagActions Sid gives the Karpenter controller permission to tag an instance profile with [`iam:TagInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagInstanceProfile.html), provided that `ResourceTag` attributes `kubernetes.io/cluster/${ClusterName}` is set to `owned` and `topology.kubernetes.io/region` is set to the current region and `RequestTag` attributes `kubernetes.io/cluster/${ClusterName}` is set to `owned`, `eks:eks-cluster-name` is set to `${ClusterName}`, and `topology.kubernetes.io/region` is set to the current region.
+The AllowScopedInstanceProfileTagActions Sid gives the Karpenter controller permission to tag an instance profile with [`iam:TagInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagInstanceProfile.html), provided that `ResourceTag` attributes `kubernetes.io/cluster/${ClusterName}` is set to `owned` and `topology.kubernetes.io/region` is set to the current region and `RequestTag` attributes `kubernetes.io/cluster/${ClusterName}` is set to `owned`, `${ClusterNameTagKey}` is set to `${ClusterName}`, and `topology.kubernetes.io/region` is set to the current region.
 Also, `ResourceTag/karpenter.k8s.aws/ec2nodeclass` and `RequestTag/karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures that Karpenter is only able to act on instance profiles that it provisions for this cluster.
 
 ```json
@@ -373,7 +379,7 @@ Also, `ResourceTag/karpenter.k8s.aws/ec2nodeclass` and `RequestTag/karpenter.k8s
       "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
       "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
       "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-      "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+      "aws:RequestTag/${ClusterNameTagKey}": "${ClusterName}",
       "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
     },
     "StringLike": {

--- a/website/content/en/preview/reference/settings.md
+++ b/website/content/en/preview/reference/settings.md
@@ -18,6 +18,7 @@ Karpenter surfaces environment variables and CLI parameters to allow you to conf
 | CLUSTER_CA_BUNDLE | \-\-cluster-ca-bundle | Cluster CA bundle for nodes to use for TLS connections with the API server. If not set, this is taken from the controller's TLS configuration.|
 | CLUSTER_ENDPOINT | \-\-cluster-endpoint | The external kubernetes cluster endpoint for new nodes to connect with. If not specified, will discover the cluster endpoint using DescribeCluster API.|
 | CLUSTER_NAME | \-\-cluster-name | [REQUIRED] The kubernetes cluster name for resource discovery.|
+| CLUSTER_NAME_TAG_KEY | \-\-cluster-name-tag-key | The tag key used to identify the cluster name on Karpenter-managed AWS resources. Defaults to 'eks:eks-cluster-name'. Do NOT change this if you are running on EKS, as it would break resource discovery and the IAM permissions provided by the getting-started CloudFormation template. (default = eks:eks-cluster-name)|
 | CPU_REQUESTS | \-\-cpu-requests | CPU requests in millicores on the container running the controller. (default = 1000)|
 | DISABLE_CLUSTER_STATE_OBSERVABILITY | \-\-disable-cluster-state-observability | Disable cluster state metrics and events|
 | DISABLE_CONTROLLER_WARMUP | \-\-disable-controller-warmup | Disable controller warmup which starts controller sources before leader election is won. Controller warmup pre-populates caches and improves leader failover time.|


### PR DESCRIPTION
Fixes #9127

**Description**

Karpenter hardcodes the `eks:eks-cluster-name` tag key when it tags and discovers its AWS resources. For operators running Karpenter outside of EKS (e.g. ROSA), this tags resources as belonging to a nonexistent EKS cluster, which is confusing for inventory/filtering and (as noted in #9127) generates user/support questions.

This PR makes the key configurable while keeping the default — and therefore EKS behavior — unchanged.

- New option `--cluster-name-tag-key` (env `CLUSTER_NAME_TAG_KEY`, helm `settings.clusterNameTagKey`), defaulting to `eks:eks-cluster-name`. Validated as non-empty and ≤128 chars.
- The configured key is threaded through every runtime tag/filter site: `utils.GetTags`, `EC2NodeClass.InstanceProfileTags`, launch template hydrate/delete, instance `List`, and the NodeClaim tagging controller.
- `GetTags` additionally rejects the *configured* key as a user-supplied tag at runtime (in addition to the existing `RestrictedTagPatterns`).
- The getting-started CloudFormation template gains a matching `ClusterNameTagKey` parameter (default unchanged), so the scoped IAM `RequestTag`/`TagKeys` conditions follow the configured key. The controller flag and the CloudFormation parameter must agree.

**Design note for reviewers**

The static CEL validation on `EC2NodeClass.spec.tags` is intentionally left rejecting `eks:eks-cluster-name` always, so EKS users keep their static protection. When a custom key is configured, a user-set tag matching it passes admission but is rejected at provisioning time by the validation controller (surfaced on the EC2NodeClass status). This matches the trade-off the issue author explicitly acknowledged ("giving up the ability to statically protect the tag with validation"). Happy to switch to a different approach (e.g. dropping the static CEL) if maintainers prefer.

Per the maintainer's earlier comment, a callout was added telling EKS users not to change this, since changing it would break resource discovery and the scoped IAM permissions.

**How was this change tested?**

- `go build ./...`, `go vet`, `gofmt -l` clean.
- `go test` (envtest 1.34.x) green for: `pkg/operator/options`, `pkg/utils`, `pkg/controllers/nodeclaim/tagging`, `pkg/controllers/nodeclass` (+hash/garbagecollection), `pkg/cloudprovider`, `pkg/providers/launchtemplate`, `pkg/providers/instance`.
- Added unit tests: `GetTags` default/custom-key/reject paths and options default/empty-key validation.
- `helm template` verified the `CLUSTER_NAME_TAG_KEY` env is emitted only when set (default render unchanged), and the CloudFormation YAML still parses.
- `settings.md` regenerated via `hack/docs/configuration_gen`.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.