### PR TITLE
docs: clarify Kubernetes 1.34 compatibility for Karpenter 1.6

### DIFF
--- a/hack/docs/compatibilitymatrix_gen/compatibility.yaml
+++ b/hack/docs/compatibilitymatrix_gen/compatibility.yaml
@@ -74,6 +74,9 @@ compatibility:
     maxK8sVersion: 1.33
   - appVersion: 1.6.x
     minK8sVersion: 1.26
+    maxK8sVersion: 1.33
+  - appVersion: 1.6.6
+    minK8sVersion: 1.26
     maxK8sVersion: 1.34
   - appVersion: 1.7.x
     minK8sVersion: 1.26

--- a/website/content/en/preview/upgrading/compatibility.md
+++ b/website/content/en/preview/upgrading/compatibility.md
@@ -13,11 +13,16 @@ Before you begin upgrading Karpenter, consider Karpenter compatibility issues re
 
 ## Compatibility Matrix
 
+The matrix shows the minimum Karpenter patch version needed for each Kubernetes
+version. Patch releases within a Karpenter minor version can expand the
+supported Kubernetes version range, so upgrade to at least the listed Karpenter
+version before upgrading Kubernetes.
+
 [comment]: <> (the content below is generated from hack/docs/compatibilitymatrix_gen/main.go)
 
-| Kubernetes |   1.30   |   1.31    |  1.32   |  1.33   |  1.34   |  1.35   |   1.36   |
-|------------|----------|-----------|---------|---------|---------|---------|----------|
-| karpenter  | \>= 0.37 | \>= 1.0.5 | \>= 1.2 | \>= 1.5 | \>= 1.6 | \>= 1.9 | \>= 1.13 |
+| Kubernetes |   1.30   |   1.31    |  1.32   |  1.33   |   1.34    |  1.35   |   1.36   |
+|------------|----------|-----------|---------|---------|-----------|---------|----------|
+| karpenter  | \>= 0.37 | \>= 1.0.5 | \>= 1.2 | \>= 1.5 | \>= 1.6.6 | \>= 1.9 | \>= 1.13 |
 
 [comment]: <> (end docs generated content from hack/docs/compatibilitymatrix_gen/main.go)
 


### PR DESCRIPTION
## What

- Clarifies that the compatibility matrix reports the minimum Karpenter patch
  version needed for each Kubernetes version.
- Keeps the Karpenter 1.6 minor range capped at Kubernetes 1.33 until the
  1.6.6 patch release.
- Regenerates the compatibility matrix so Kubernetes 1.34 shows `>= 1.6.6`.

## Why

Karpenter v1.6.0 has `MaxK8sVersion = "1.33"`, while v1.6.6 has
`MaxK8sVersion = "1.34"`. The previous matrix entry showed Kubernetes 1.34 as
supported by `>= 1.6`, which can lead users to upgrade Kubernetes to 1.34 while
still running Karpenter 1.6.0.

Addresses #9205.

## Testing

- `go run hack/docs/compatibilitymatrix_gen/main.go website/content/en/preview/upgrading/compatibility.md hack/docs/compatibilitymatrix_gen/compatibility.yaml 7`
- `go run tools/kompat/cmd/kompat/main.go --k8s-version 1.34 hack/docs/compatibilitymatrix_gen/compatibility.yaml`
- `go test ./hack/docs/compatibilitymatrix_gen`
- `(cd tools/kompat && go test ./...)`
- `git diff --check`
