### PR TITLE
docs(metrics): clarify offering price estimate scope

### DIFF
--- a/pkg/controllers/metrics/metrics.go
+++ b/pkg/controllers/metrics/metrics.go
@@ -49,7 +49,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: cloudProviderSubsystem,
 			Name:      "instance_type_offering_price_estimate",
-			Help:      "Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.",
+			Help:      "Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone. This metric is not NodePool-specific; when NodeOverlays produce different prices across NodePools for the same offering labels, the emitted value reflects one reconciled estimate.",
 		},
 		[]string{
 			instanceTypeLabel,

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -377,7 +377,7 @@ Current count of nodes in cluster state
 ## Cloudprovider Metrics
 
 ### `karpenter_cloudprovider_instance_type_offering_price_estimate`
-Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone.
+Instance type offering estimated hourly price used when making informed decisions on node cost calculation, based on instance type, capacity type, and zone. This metric is not NodePool-specific; when NodeOverlays produce different prices across NodePools for the same offering labels, the emitted value reflects one reconciled estimate.
 - Stability Level: BETA
 
 ### `karpenter_cloudprovider_instance_type_offering_available`


### PR DESCRIPTION
### What

Clarifies the help text and generated metrics reference for `karpenter_cloudprovider_instance_type_offering_price_estimate`.

The metric is keyed by instance type, capacity type, and zone, but not by NodePool. When NodeOverlays produce different prices across NodePools for the same offering labels, the emitted metric should be interpreted as one reconciled estimate for that offering rather than a NodePool-specific stable price.

### Why

This documents the current behavior discussed in #9222 without changing NodeOverlay or metrics controller semantics.

### Tests

- Regenerated `website/content/en/preview/reference/metrics.md` with `hack/docs/metrics_gen/main.go`
- `KUBEBUILDER_ASSETS=/tmp/karpenter-envtest/bin/k8s/1.34.1-darwin-arm64 go test ./pkg/controllers/metrics`
- `git diff --check`