### PR TITLE
fix: set MetadataOptions on the RunInstances dry-run request

### DIFF
--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -297,7 +297,7 @@ func (v *Validation) validateRunInstancesAuthorization(
 	// failures on individual subnets are already handled by the early-exit-on-success pattern.
 	var firstSubnetErr error
 	for i, subnet := range nodeClass.Status.Subnets {
-		runInstancesInput := getRunInstancesInput(tags, launchTemplate, amifamily.ResolveNetworkInterfaces(nodeClass.Spec.NetworkInterfaces), &subnet)
+		runInstancesInput := getRunInstancesInput(tags, launchTemplate, amifamily.ResolveNetworkInterfaces(nodeClass.Spec.NetworkInterfaces), &subnet, nodeClass.Spec.MetadataOptions)
 		if _, err = v.ec2api.RunInstances(ctx, runInstancesInput, func(o *ec2.Options) {
 			// Adding NopRetryer to avoid aggressive retry when rate limited
 			o.Retryer = aws.NopRetryer{}
@@ -372,6 +372,7 @@ func getRunInstancesInput(
 	launchTemplate *launchtemplate.LaunchTemplate,
 	networkInterfaces []*amifamily.ResolvedNetworkInterface,
 	subnet *v1.Subnet,
+	metadataOptions *v1.MetadataOptions,
 ) *ec2.RunInstancesInput {
 	return &ec2.RunInstancesInput{
 		DryRun:   lo.ToPtr(true),
@@ -382,6 +383,7 @@ func getRunInstancesInput(
 			Version:            lo.ToPtr("$Latest"),
 		},
 		InstanceType:      ec2types.InstanceType(launchTemplate.InstanceTypes[0].Name),
+		MetadataOptions:   getMetadataOptionsInput(metadataOptions),
 		NetworkInterfaces: getNetworkInterfacesInput(networkInterfaces, subnet),
 		TagSpecifications: []ec2types.TagSpecification{
 			{
@@ -397,6 +399,23 @@ func getRunInstancesInput(
 				Tags:         utils.EC2MergeTags(tags),
 			},
 		},
+	}
+}
+
+// getMetadataOptionsInput maps the NodeClass metadata options onto the dry-run RunInstances request.
+// EC2 only populates the ec2:MetadataHttpTokens condition key from request-level MetadataOptions, not from
+// the referenced launch template, so without this the dry-run authorization check is denied by SCPs that
+// require IMDSv2. The values mirror those set on the launch template (see pkg/providers/launchtemplate).
+func getMetadataOptionsInput(metadataOptions *v1.MetadataOptions) *ec2types.InstanceMetadataOptionsRequest {
+	if metadataOptions == nil {
+		return nil
+	}
+	return &ec2types.InstanceMetadataOptionsRequest{
+		HttpEndpoint:     ec2types.InstanceMetadataEndpointState(lo.FromPtr(metadataOptions.HTTPEndpoint)),
+		HttpProtocolIpv6: ec2types.InstanceMetadataProtocolState(lo.FromPtr(metadataOptions.HTTPProtocolIPv6)),
+		//nolint:gosec
+		HttpPutResponseHopLimit: lo.ToPtr(int32(lo.FromPtr(metadataOptions.HTTPPutResponseHopLimit))),
+		HttpTokens:              ec2types.HttpTokensState(lo.FromPtr(metadataOptions.HTTPTokens)),
 	}
 }
 

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -299,6 +299,27 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsTrue()).To(BeTrue())
 		})
+		It("should set MetadataOptions on the RunInstances dry-run input so SCPs conditioned on ec2:MetadataHttpTokens are evaluated", func() {
+			// Non-default httpProtocolIPv6 and httpPutResponseHopLimit values confirm the configured
+			// options are plumbed onto the request rather than coinciding with the field defaults.
+			nodeClass.Spec.MetadataOptions = &v1.MetadataOptions{
+				HTTPTokens:              lo.ToPtr("required"),
+				HTTPEndpoint:            lo.ToPtr("enabled"),
+				HTTPProtocolIPv6:        lo.ToPtr("enabled"),
+				HTTPPutResponseHopLimit: lo.ToPtr(int64(2)),
+			}
+			ExpectApplied(ctx, env.Client, nodeClass)
+			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsTrue()).To(BeTrue())
+
+			runInstancesInput := awsEnv.EC2API.RunInstancesBehavior.CalledWithInput.Pop()
+			Expect(runInstancesInput.MetadataOptions).ToNot(BeNil())
+			Expect(runInstancesInput.MetadataOptions.HttpTokens).To(Equal(ec2types.HttpTokensStateRequired))
+			Expect(runInstancesInput.MetadataOptions.HttpEndpoint).To(Equal(ec2types.InstanceMetadataEndpointStateEnabled))
+			Expect(runInstancesInput.MetadataOptions.HttpProtocolIpv6).To(Equal(ec2types.InstanceMetadataProtocolStateEnabled))
+			Expect(lo.FromPtr(runInstancesInput.MetadataOptions.HttpPutResponseHopLimit)).To(BeNumerically("==", 2))
+		})
 		Context("Windows AMI Validation", func() {
 			DescribeTable(
 				"should fallback to static instance types when windows ami is used",


### PR DESCRIPTION

Fixes #9018 

**Description**
Before marking an `EC2NodeClass` ready, the validation controller issues a `DryRun` `ec2:RunInstances`. That request references the launch template but sets no request-level `MetadataOptions`, so EC2 never populates the `ec2:MetadataHttpTokens` condition key for the dry run. An SCP that gates `ec2:RunInstances` on `ec2:MetadataHttpTokens = required` then denies the dry run, and the `EC2NodeClass` fails validation even though the real launch through `CreateFleet` satisfies the policy. The reporter confirmed this in CloudTrail: the `CreateLaunchTemplate` call carries the condition key, the `RunInstances` dry run does not.

EC2 derives `ec2:MetadataHttpTokens` from the request-level `MetadataOptions`, not from the referenced launch template. This change sets `MetadataOptions` on the dry-run `RunInstances` input through a new `getMetadataOptionsInput`, mirroring the mapping the launch template builder already uses in `pkg/providers/launchtemplate/types.go`. The values are read from `nodeClass.Spec.MetadataOptions`. `HTTPTokens`, the only field the condition key derives from, is copied unchanged from spec into the launch template by `amifamily.Resolve`, so the dry run and the real launch evaluate the same value. The CRD default of `httpTokens: required` means a NodeClass that omits `metadataOptions` still sends `required`, which is the reported case.

**How was this change tested?**
Unit test in `pkg/controllers/nodeclass/validation_test.go`: it sets `spec.metadataOptions`, reconciles the NodeClass, and asserts the dry-run `RunInstances` input carries those `MetadataOptions`. `httpProtocolIPv6` and `httpPutResponseHopLimit` use non-default values so a pass can't come from the fields happening to match their defaults.
```
go test ./pkg/controllers/nodeclass/... -run TestAPIs --ginkgo.focus="should set MetadataOptions on the RunInstances dry-run"
Ran 1 of 136 Specs in 6.290 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 135 Skipped
--- PASS: TestAPIs (6.29s)
ok      github.com/aws/karpenter-provider-aws/pkg/controllers/nodeclass 6.329s
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.