### PR TITLE
feat: Set EnclaveOptions.Enabled in launch template

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -138,6 +138,7 @@ var (
 	ResourceAWSPodENI          corev1.ResourceName = "vpc.amazonaws.com/pod-eni"
 	ResourcePrivateIPv4Address corev1.ResourceName = "vpc.amazonaws.com/PrivateIPv4Address"
 	ResourceEFA                corev1.ResourceName = "vpc.amazonaws.com/efa"
+	ResourceNIPSlots           corev1.ResourceName = "eks.amazonaws.com/nip-slots"
 
 	LabelCapacityReservationID                = apis.Group + "/capacity-reservation-id"
 	LabelCapacityReservationType              = apis.Group + "/capacity-reservation-type"

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -84,6 +84,7 @@ type LaunchTemplate struct {
 	InstanceTypes                    []*cloudprovider.InstanceType `hash:"ignore"`
 	DetailedMonitoring               bool
 	EFACount                         int
+	EnclaveEnabled                   bool
 	NetworkInterfaces                []*ResolvedNetworkInterface
 	CapacityType                     string
 	CapacityReservationID            string
@@ -336,6 +337,7 @@ func (r DefaultResolver) resolveLaunchTemplates(
 			Tenancy:                          tenancyType,
 			PlacementGroupID:                 placementGroupID,
 			PlacementGroupPartition:          placementGroupPartition,
+			EnclaveEnabled:                   lo.Contains(lo.Keys(nodeClaim.Spec.Resources.Requests), v1.ResourceNIPSlots),
 			ConnectionTracking:               nodeClass.Spec.ConnectionTracking,
 		}
 		if len(resolved.BlockDeviceMappings) == 0 {

--- a/pkg/providers/amifamily/suite_test.go
+++ b/pkg/providers/amifamily/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/version"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1236,6 +1237,42 @@ var _ = Describe("AMIResolver", func() {
 		Entry("should be nil for isob", "us-isob-east-1", nil),
 		Entry("should be nil for isof", "us-isof-south-1", nil),
 	)
+	Context("EnclaveEnabled", func() {
+		It("should set EnclaveEnabled to false by default when no resources are requested", func() {
+			amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
+			launchTemplates, err := amiResolver.Resolve(nodeClass, nodeClaim, instanceTypes, karpv1.CapacityTypeOnDemand, string(ec2types.TenancyDefault), &amifamily.Options{ClusterName: "test"}, "", 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(launchTemplates).ToNot(BeEmpty())
+			lo.ForEach(launchTemplates, func(lt *amifamily.LaunchTemplate, _ int) {
+				Expect(lt.EnclaveEnabled).To(BeFalse())
+			})
+		})
+		It("should set EnclaveEnabled to true when ResourceNIPSlots is in the NodeClaim's resource requests", func() {
+			nodeClaim.Spec.Resources.Requests = corev1.ResourceList{
+				v1.ResourceNIPSlots: resource.MustParse("1"),
+			}
+			amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
+			launchTemplates, err := amiResolver.Resolve(nodeClass, nodeClaim, instanceTypes, karpv1.CapacityTypeOnDemand, string(ec2types.TenancyDefault), &amifamily.Options{ClusterName: "test"}, "", 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(launchTemplates).ToNot(BeEmpty())
+			lo.ForEach(launchTemplates, func(lt *amifamily.LaunchTemplate, _ int) {
+				Expect(lt.EnclaveEnabled).To(BeTrue())
+			})
+		})
+		It("should set EnclaveEnabled to false when only other resources are requested (not ResourceNIPSlots)", func() {
+			nodeClaim.Spec.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			}
+			amiResolver := amifamily.NewDefaultResolver(fake.DefaultRegion)
+			launchTemplates, err := amiResolver.Resolve(nodeClass, nodeClaim, instanceTypes, karpv1.CapacityTypeOnDemand, string(ec2types.TenancyDefault), &amifamily.Options{ClusterName: "test"}, "", 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(launchTemplates).ToNot(BeEmpty())
+			lo.ForEach(launchTemplates, func(lt *amifamily.LaunchTemplate, _ int) {
+				Expect(lt.EnclaveEnabled).To(BeFalse())
+			})
+		})
+	})
 })
 
 func ExpectConsistsOfAMIQueries(expected, actual []amifamily.DescribeImageQuery) {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -514,12 +514,13 @@ var _ = Describe("LaunchTemplate Provider", func() {
 				{DetailedMonitoring: true},
 				{EFACount: 12},
 				{CapacityType: "spot"},
+				{EnclaveEnabled: true},
 			}
 			launchtemplateResult := []string{}
 			for _, lt := range launchtemplates {
 				launchtemplateResult = append(launchtemplateResult, launchtemplate.LaunchTemplateName(lt))
 			}
-			Expect(len(launchtemplateResult)).To(BeNumerically("==", 6))
+			Expect(len(launchtemplateResult)).To(BeNumerically("==", 7))
 			Expect(lo.Uniq(launchtemplateResult)).To(Equal(launchtemplateResult))
 		})
 		It("should not generate different launch template names based on instance types", func() {
@@ -2413,6 +2414,50 @@ eviction-max-pod-grace-period = 10
 			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
 			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
 				Expect(aws.ToBool(ltInput.LaunchTemplateData.Monitoring.Enabled)).To(BeTrue())
+			})
+		})
+	})
+	Context("Enclave Options", func() {
+		It("should default enclave options to disabled", func() {
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically("==", 5))
+			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
+				Expect(aws.ToBool(ltInput.LaunchTemplateData.EnclaveOptions.Enabled)).To(BeFalse())
+			})
+		})
+		It("should enable enclave options when nip-slots is in the nodeclaim's resource requests", func() {
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+			// Build a NodeClaim with nip-slots already in Spec.Resources.Requests,
+			// simulating what the scheduler sets when pods request that resource
+			nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
+				Spec: karpv1.NodeClaimSpec{
+					Resources: karpv1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							v1.ResourceNIPSlots: resource.MustParse("1"),
+						},
+					},
+					NodeClassRef: &karpv1.NodeClassReference{
+						Group: "karpenter.k8s.aws",
+						Kind:  "EC2NodeClass",
+						Name:  nodeClass.Name,
+					},
+				},
+			})
+
+			instanceTypes, err := awsEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instanceTypes).ToNot(BeEmpty())
+
+			_, err = awsEnv.LaunchTemplateProvider.EnsureAll(ctx, nodeClass, nodeClaim, instanceTypes, karpv1.CapacityTypeOnDemand, nodeClass.Spec.Tags, "default")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.Len()).To(BeNumerically(">=", 1))
+			awsEnv.EC2API.CreateLaunchTemplateBehavior.CalledWithInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
+				Expect(aws.ToBool(ltInput.LaunchTemplateData.EnclaveOptions.Enabled)).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/providers/launchtemplate/types.go
+++ b/pkg/providers/launchtemplate/types.go
@@ -137,6 +137,9 @@ func (b *CreateLaunchTemplateInputBuilder) Build(ctx context.Context) *ec2.Creat
 			NetworkInterfaces: networkInterfaces,
 			TagSpecifications: launchTemplateDataTags,
 			Placement:         b.buildPlacement(),
+			EnclaveOptions: &ec2types.LaunchTemplateEnclaveOptionsRequest{
+				Enabled: lo.ToPtr(b.options.EnclaveEnabled),
+			},
 		},
 		TagSpecifications: []ec2types.TagSpecification{
 			{


### PR DESCRIPTION
**Description**
This PR sets EnclaveOptions.enabled to true if requested on NodeClaim. If nodeClaim requests, and Karpenter will launch an EC2 instance with `enclaveOptions` set to enabled.

**How was this change tested?**
make test & locally tested on a dev cluster.

Requested the setting on the pod, saw that it got populated from node claim to the EC2 launch templates

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.