### PR TITLE
fix: add debug logging to AL2 DescribeImageQuery (#7723)

### DIFF
--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -25,6 +25,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/samber/lo"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -64,8 +65,10 @@ func (a AL2) DescribeImageQuery(ctx context.Context, ssmProvider ssm.Provider, k
 			IsMutable: amiVersion == v1.AliasVersionLatest,
 		})
 		if err != nil {
+			log.FromContext(ctx).WithValues("ssmParameter", path).V(1).Error(err, "failed to resolve AMI id from SSM parameter")
 			continue
 		}
+		log.FromContext(ctx).WithValues("ssmParameter", path, "id", imageID).V(1).Info("resolved AMI id from SSM parameter")
 		ids[imageID] = variants
 	}
 	// Failed to discover any AMIs, we should short circuit AMI discovery


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #7723 <!-- issue number -->

**Description**
Adds debug-level logging to `AL2.DescribeImageQuery` in `pkg/providers/amifamily/al2.go`. Previously, both successful and failed SSM parameter lookups were silent — failures were swallowed with a bare `continue`, giving no visibility into which AMI variants were attempted or why they failed.

- Logs each SSM parameter lookup failure at `V(1)` (debug) with the parameter path and error.
- Logs each successful SSM parameter resolution at `V(1)` with the parameter path and resolved AMI ID.

**How was this change tested?**
- `go build ./pkg/providers/amifamily/...` — passes
- `go vet ./pkg/providers/amifamily/...` — clean
- Note: the full Ginkgo test suite for this package requires a local kubebuilder/etcd control-plane binary, which wasn't available in my environment, so I could not run it locally. This is a logging-only change and does not alter existing control flow or return values.


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.