### PR TITLE
ci: honor lifecycle/frozen label in StaleBot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,6 +18,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been inactive for 14 days. StaleBot will close this stale issue after 14 more days of inactivity.'
           only-issue-labels: 'triage/needs-information'
+          exempt-issue-labels: 'lifecycle/frozen'
           stale-issue-label: 'lifecycle/stale'
           close-issue-label: 'lifecycle/closed'
           only-pr-labels: 'ignore' # Ignore this step for PRs
@@ -30,6 +31,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been inactive for 7 days and is marked as "triage/solved". StaleBot will close this stale issue after 7 more days of inactivity.'
           only-issue-labels: 'triage/solved'
+          exempt-issue-labels: 'lifecycle/frozen'
           stale-issue-label: 'lifecycle/stale'
           close-issue-label: 'lifecycle/closed'
           only-pr-labels: 'ignore' # Ignore this step for PRs


### PR DESCRIPTION
## Description

Adds `exempt-issue-labels: 'lifecycle/frozen'` to both steps in `.github/workflows/stale.yaml` so issues labeled `lifecycle/frozen` are never marked stale or closed by StaleBot.

## How was this change tested?

Config-only change to the StaleBot workflow. `exempt-issue-labels` is a documented input of `actions/stale`.

## Does this change impact docs?

- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: link to issue
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)