### PR TITLE
chore: emit NodePool events on zonal shift detection and clearing

### DIFF
--- a/pkg/cloudprovider/events/events.go
+++ b/pkg/cloudprovider/events/events.go
@@ -15,13 +15,14 @@ limitations under the License.
 package events
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"fmt"
 
-	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/events"
 )
 
-func NodePoolFailedToResolveNodeClass(nodePool *v1.NodePool) events.Event {
+func NodePoolFailedToResolveNodeClass(nodePool *karpv1.NodePool) events.Event {
 	return events.Event{
 		InvolvedObject: nodePool,
 		Type:           corev1.EventTypeWarning,
@@ -30,11 +31,33 @@ func NodePoolFailedToResolveNodeClass(nodePool *v1.NodePool) events.Event {
 	}
 }
 
-func NodeClaimFailedToResolveNodeClass(nodeClaim *v1.NodeClaim) events.Event {
+func NodeClaimFailedToResolveNodeClass(nodeClaim *karpv1.NodeClaim) events.Event {
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
 		Message:        "Failed resolving NodeClass",
 		DedupeValues:   []string{string(nodeClaim.UID)},
+	}
+}
+
+// NodePoolZonalShiftDetected is emitted when a zone the NodePool can provision into becomes shifted away from.
+func NodePoolZonalShiftDetected(nodePool *karpv1.NodePool, zoneName, zoneID string) events.Event {
+	return events.Event{
+		InvolvedObject: nodePool,
+		Type:           corev1.EventTypeWarning,
+		Reason:         "ZonalShiftActive",
+		Message:        fmt.Sprintf("Zonal shift detected: offerings in zone %s (%s) are unavailable for this NodePool", zoneName, zoneID),
+		DedupeValues:   []string{string(nodePool.UID), zoneID},
+	}
+}
+
+// NodePoolZonalShiftCleared is emitted when a previously shifted zone the NodePool can provision into is restored.
+func NodePoolZonalShiftCleared(nodePool *karpv1.NodePool, zoneName, zoneID string) events.Event {
+	return events.Event{
+		InvolvedObject: nodePool,
+		Type:           corev1.EventTypeNormal,
+		Reason:         "ZonalShiftCleared",
+		Message:        fmt.Sprintf("Zonal shift cleared: offerings in zone %s (%s) are restored for this NodePool", zoneName, zoneID),
+		DedupeValues:   []string{string(nodePool.UID), zoneID},
 	}
 }

--- a/pkg/controllers/arczonalshift/controller.go
+++ b/pkg/controllers/arczonalshift/controller.go
@@ -21,22 +21,41 @@ import (
 
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
 
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	cloudproviderevents "github.com/aws/karpenter-provider-aws/pkg/cloudprovider/events"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/arczonalshift"
 )
 
 type Controller struct {
+	kubeClient            client.Client
+	recorder              events.Recorder
 	arczonalshiftProvider arczonalshift.Provider
+
+	previousShiftedZones sets.Set[string] // zone-id
 }
 
 func NewController(
+	kubeClient client.Client,
+	recorder events.Recorder,
 	arczonalshiftProvider arczonalshift.Provider,
 ) *Controller {
 	return &Controller{
+		kubeClient:            kubeClient,
+		recorder:              recorder,
 		arczonalshiftProvider: arczonalshiftProvider,
+		previousShiftedZones:  sets.New[string](),
 	}
 }
 
@@ -47,7 +66,77 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		return reconciler.Result{}, fmt.Errorf("updating zonal shifts: %w", err)
 	}
 
+	currentShiftedZones := c.arczonalshiftProvider.ShiftedZones()
+	if !currentShiftedZones.Equal(c.previousShiftedZones) {
+		zoneInfosByNodePool, err := c.zoneInfosByNodePool(ctx)
+		if err != nil {
+			return reconciler.Result{}, fmt.Errorf("publishing zonal shift events: %w", err)
+		}
+		PublishZonalShiftEvents(c.recorder, c.previousShiftedZones, currentShiftedZones, zoneInfosByNodePool)
+	}
+	// Advance only after a successful publish, so a failed publish retries the same transitions next reconcile.
+	c.previousShiftedZones = currentShiftedZones
+
 	return reconciler.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+func (c *Controller) zoneInfosByNodePool(ctx context.Context) (map[*karpv1.NodePool][]v1.ZoneInfo, error) {
+	nodePools := &karpv1.NodePoolList{}
+	if err := c.kubeClient.List(ctx, nodePools); err != nil {
+		return nil, fmt.Errorf("listing nodepools, %w", err)
+	}
+	zoneInfosByNodePool := map[*karpv1.NodePool][]v1.ZoneInfo{}
+	for i := range nodePools.Items {
+		nodePool := &nodePools.Items[i]
+		if nodePool.Spec.Template.Spec.NodeClassRef == nil {
+			continue
+		}
+		nodeClass := &v1.EC2NodeClass{}
+		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePool.Spec.Template.Spec.NodeClassRef.Name}, nodeClass); err != nil {
+			return nil, fmt.Errorf("getting nodeclass %q for nodepool %q, %w", nodePool.Spec.Template.Spec.NodeClassRef.Name, nodePool.Name, err)
+		}
+		zoneInfosByNodePool[nodePool] = nodeClass.ZoneInfo()
+	}
+	return zoneInfosByNodePool, nil
+}
+
+// PublishZonalShiftEvents takes zoneInfosByNodePool as input so it stays decoupled from the concrete
+// NodeClass type a caller resolves it from.
+func PublishZonalShiftEvents(recorder events.Recorder, previous, current sets.Set[string], zoneInfosByNodePool map[*karpv1.NodePool][]v1.ZoneInfo) {
+	shifted := current.Difference(previous)
+	cleared := previous.Difference(current)
+	for nodePool, zoneInfos := range zoneInfosByNodePool {
+		requirements := scheduling.NewNodeSelectorRequirementsWithMinValues(nodePool.Spec.Template.Spec.Requirements...)
+		for zoneID := range shifted {
+			if zoneName, affected := zoneAffected(requirements, zoneInfos, zoneID); affected {
+				recorder.Publish(cloudproviderevents.NodePoolZonalShiftDetected(nodePool, zoneName, zoneID))
+			}
+		}
+		for zoneID := range cleared {
+			if zoneName, affected := zoneAffected(requirements, zoneInfos, zoneID); affected {
+				recorder.Publish(cloudproviderevents.NodePoolZonalShiftCleared(nodePool, zoneName, zoneID))
+			}
+		}
+	}
+}
+
+// zoneAffected returns the shifted zone's name and whether a NodePool with the given requirements can provision
+// into it. Shifts are keyed by zone ID while NodePool requirements are typically expressed by zone name, so
+// zoneInfos (from the NodeClass subnets) bridges the two. Empty requirements match any reachable zone.
+func zoneAffected(requirements scheduling.Requirements, zoneInfos []v1.ZoneInfo, shiftedZoneID string) (string, bool) {
+	zoneInfo, found := lo.Find(zoneInfos, func(zi v1.ZoneInfo) bool {
+		return zi.ZoneID == shiftedZoneID
+	})
+	if !found {
+		return "", false
+	}
+	if !requirements.Get(corev1.LabelTopologyZone).Has(zoneInfo.Zone) {
+		return "", false
+	}
+	if !requirements.Get(v1.LabelTopologyZoneID).Has(shiftedZoneID) {
+		return "", false
+	}
+	return zoneInfo.Zone, true
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/controllers/arczonalshift/suite_test.go
+++ b/pkg/controllers/arczonalshift/suite_test.go
@@ -1,0 +1,221 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package arczonalshift_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	arcsdk "github.com/aws/aws-sdk-go-v2/service/arczonalshift"
+	arczonalshifttypes "github.com/aws/aws-sdk-go-v2/service/arczonalshift/types"
+	"github.com/awslabs/operatorpkg/object"
+	"github.com/awslabs/operatorpkg/status"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+
+	"github.com/aws/karpenter-provider-aws/pkg/apis"
+	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/arczonalshift"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
+	"github.com/aws/karpenter-provider-aws/pkg/test"
+)
+
+var ctx context.Context
+var env *coretest.Environment
+var awsEnv *test.Environment
+var recorder *coretest.EventRecorder
+var controller *arczonalshift.Controller
+var nodeClass *v1.EC2NodeClass
+var nodePool *karpv1.NodePool
+
+func TestAWS(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ARCZonalShiftController")
+}
+
+var _ = BeforeSuite(func() {
+	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+	awsEnv = test.NewEnvironment(ctx, env)
+	recorder = coretest.NewEventRecorder()
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = BeforeEach(func() {
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+
+	// Fresh controller per spec so the previousShiftedZones transition state does not leak between tests.
+	controller = arczonalshift.NewController(env.Client, recorder, awsEnv.ZonalShiftProvider)
+
+	// Subnets supply the zone name <-> zone ID mapping the controller uses to translate shifts (keyed by zone
+	// ID) into NodePool zone requirements (keyed by zone name).
+	nodeClass = test.EC2NodeClass(v1.EC2NodeClass{
+		Status: v1.EC2NodeClassStatus{
+			Subnets: []v1.Subnet{
+				{ID: "subnet-test1", Zone: "test-zone-1a", ZoneID: "tstz1-1a"},
+				{ID: "subnet-test2", Zone: "test-zone-1b", ZoneID: "tstz1-1b"},
+				{ID: "subnet-test3", Zone: "test-zone-1c", ZoneID: "tstz1-1c"},
+			},
+		},
+	})
+	nodeClass.StatusConditions().SetTrue(status.ConditionReady)
+	nodePool = coretest.NodePool(karpv1.NodePool{
+		Spec: karpv1.NodePoolSpec{
+			Template: karpv1.NodeClaimTemplate{
+				Spec: karpv1.NodeClaimTemplateSpec{
+					NodeClassRef: &karpv1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.Name,
+					},
+				},
+			},
+		},
+	})
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+	awsEnv.Reset()
+	recorder.Reset()
+})
+
+// setShiftedZones configures the fake ARC API to report the given zone IDs as actively shifted away from.
+func setShiftedZones(zoneIDs ...string) {
+	shifts := lo.Map(zoneIDs, func(zoneID string, _ int) arczonalshifttypes.ZonalShiftInResource {
+		return arczonalshifttypes.ZonalShiftInResource{
+			AwayFrom:      aws.String(zoneID),
+			ExpiryTime:    aws.Time(awsEnv.Clock.Now().Add(time.Hour)),
+			AppliedStatus: arczonalshifttypes.AppliedStatusApplied,
+		}
+	})
+	awsEnv.ARCZonalShiftAPI.GetManagedResourceBehavior.Output.Set(&arcsdk.GetManagedResourceOutput{ZonalShifts: shifts})
+}
+
+var _ = Describe("ARCZonalShiftController", func() {
+	const detectedReason = "ZonalShiftActive"
+	const clearedReason = "ZonalShiftCleared"
+
+	It("should emit a Warning event on an affected NodePool when a zone shifts", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		setShiftedZones("tstz1-1a")
+		ExpectSingletonReconciled(ctx, controller)
+
+		Expect(recorder.Calls(detectedReason)).To(Equal(1))
+		Expect(recorder.DetectedEvent("Zonal shift detected: offerings in zone test-zone-1a (tstz1-1a) are unavailable for this NodePool")).To(BeTrue())
+	})
+
+	It("should emit a Normal event on an affected NodePool when a zone shift clears", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		setShiftedZones("tstz1-1a")
+		ExpectSingletonReconciled(ctx, controller)
+		Expect(recorder.Calls(detectedReason)).To(Equal(1))
+
+		setShiftedZones()
+		ExpectSingletonReconciled(ctx, controller)
+
+		Expect(recorder.Calls(clearedReason)).To(Equal(1))
+		Expect(recorder.DetectedEvent("Zonal shift cleared: offerings in zone test-zone-1a (tstz1-1a) are restored for this NodePool")).To(BeTrue())
+	})
+
+	It("should not emit an event on a NodePool restricted to different zones", func() {
+		nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+			{
+				Key:      corev1.LabelTopologyZone,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"test-zone-1b", "test-zone-1c"},
+			},
+		}
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		setShiftedZones("tstz1-1a")
+		ExpectSingletonReconciled(ctx, controller)
+
+		Expect(recorder.Calls(detectedReason)).To(Equal(0))
+	})
+
+	It("should emit an event on a NodePool with no zone restriction", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		setShiftedZones("tstz1-1a")
+		ExpectSingletonReconciled(ctx, controller)
+
+		Expect(recorder.Calls(detectedReason)).To(Equal(1))
+	})
+
+	It("should not emit an event for a shift in a zone the NodeClass does not resolve to", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		// nodePool has no zone restriction, but the NodeClass has no subnet in tstz1-1z.
+		setShiftedZones("tstz1-1z")
+		ExpectSingletonReconciled(ctx, controller)
+
+		Expect(recorder.Calls(detectedReason)).To(Equal(0))
+	})
+
+	It("should not emit events when there is no state change between reconciles", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		setShiftedZones("tstz1-1a")
+		ExpectSingletonReconciled(ctx, controller)
+		Expect(recorder.Calls(detectedReason)).To(Equal(1))
+
+		recorder.Reset()
+		ExpectSingletonReconciled(ctx, controller)
+		Expect(recorder.Calls(detectedReason)).To(Equal(0))
+		Expect(recorder.Calls(clearedReason)).To(Equal(0))
+	})
+
+	It("should only emit on NodePools affected by the shifted zone", func() {
+		restricted := coretest.NodePool(karpv1.NodePool{
+			Spec: karpv1.NodePoolSpec{
+				Template: karpv1.NodeClaimTemplate{
+					Spec: karpv1.NodeClaimTemplateSpec{
+						NodeClassRef: &karpv1.NodeClassReference{
+							Group: object.GVK(nodeClass).Group,
+							Kind:  object.GVK(nodeClass).Kind,
+							Name:  nodeClass.Name,
+						},
+						Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+							{
+								Key:      corev1.LabelTopologyZone,
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"test-zone-1b"},
+							},
+						},
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodePool, restricted, nodeClass)
+		setShiftedZones("tstz1-1a")
+		ExpectSingletonReconciled(ctx, controller)
+
+		Expect(recorder.Calls(detectedReason)).To(Equal(1))
+	})
+})

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -111,7 +111,7 @@ func NewControllers(
 		crcapacitytype.NewController(kubeClient, cloudProvider),
 		crexpiration.NewController(clk, kubeClient, cloudProvider, capacityReservationProvider),
 		metrics.NewController(kubeClient, cloudProvider),
-		arczonalshiftcontroller.NewController(zonalshiftProvider),
+		arczonalshiftcontroller.NewController(kubeClient, recorder, zonalshiftProvider),
 		interruption.NewInstanceStatusController(kubeClient, clk, cloudProvider, recorder, instanceStatusProvider),
 	}
 	// Instance profile garbage collection requires IAM API access. Skip registering the controller when running


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Adds some observability about zonal shift status to Nodepool

**How was this change tested?**

make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.