### PR TITLE
fix: e2e test failures due to missing Buffer CRDs

### DIFF
--- a/charts/karpenter/crds/autoscaling.x-k8s.io_capacitybuffers.yaml
+++ b/charts/karpenter/crds/autoscaling.x-k8s.io_capacitybuffers.yaml
@@ -1,0 +1,1 @@
+../../../pkg/apis/crds/autoscaling.x-k8s.io_capacitybuffers.yaml

--- a/test/hack/e2e_scripts/install_karpenter.sh
+++ b/test/hack/e2e_scripts/install_karpenter.sh
@@ -21,6 +21,7 @@ helm upgrade --install karpenter "${CHART}" \
   --set settings.featureGates.reservedCapacity=true \
   --set settings.featureGates.nodeOverlay=true \
   --set settings.featureGates.staticCapacity=true \
+  --set settings.featureGates.capacityBuffer=true \
   --set controller.resources.requests.cpu=5 \
   --set controller.resources.requests.memory=3Gi \
   --set controller.resources.limits.cpu=5 \


### PR DESCRIPTION

**Description**
Fixes the current CI failures due to missing Buffer CRDs

**How was this change tested?**

make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.