### PR TITLE
fix: Ensure Zonal Shift cache is hydrated

### DIFF
--- a/pkg/providers/arczonalshift/arczonalshift.go
+++ b/pkg/providers/arczonalshift/arczonalshift.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
@@ -42,6 +43,7 @@ type DefaultProvider struct {
 	arcZonalShiftAPI sdk.ARCZonalShiftAPI
 	clk              clock.Clock
 	clusterArn       string
+	hydrated         atomic.Bool
 }
 
 type shiftStatus struct {
@@ -59,8 +61,6 @@ func NewProvider(client sdk.ARCZonalShiftAPI, clk clock.Clock, clusterArn string
 }
 
 func (p *DefaultProvider) UpdateZonalShifts(ctx context.Context) error {
-	p.Lock()
-	defer p.Unlock()
 
 	input := &arczonalshift.GetManagedResourceInput{ResourceIdentifier: &p.clusterArn}
 	result, err := p.arcZonalShiftAPI.GetManagedResource(ctx, input)
@@ -68,8 +68,9 @@ func (p *DefaultProvider) UpdateZonalShifts(ctx context.Context) error {
 		return fmt.Errorf("getting zonal shifts: %w", err)
 	}
 	activeZonalShifts := result.ZonalShifts
-	shiftStatuses := make(map[string]shiftStatus)
 
+	p.Lock()
+	shiftStatuses := make(map[string]shiftStatus)
 	for _, shift := range activeZonalShifts {
 		shiftStatuses[*shift.AwayFrom] = shiftStatus{
 			shiftExpiry: *shift.ExpiryTime,
@@ -84,6 +85,7 @@ func (p *DefaultProvider) UpdateZonalShifts(ctx context.Context) error {
 			p.zonalShiftStatuses[zone] = status
 		}
 	}
+	p.Unlock()
 	log.FromContext(ctx).V(1).Info(fmt.Sprintf("successfully updated zonal shifts %#v", shiftStatuses))
 	return nil
 }
@@ -94,7 +96,21 @@ func (p *DefaultProvider) Reset() {
 	p.zonalShiftStatuses = make(map[string]shiftStatus)
 }
 
+func (p *DefaultProvider) ensureHydrated(ctx context.Context) {
+	if p.hydrated.Load() {
+		return
+	}
+
+	if err := p.UpdateZonalShifts(ctx); err != nil {
+		log.FromContext(ctx).Error(err, "failed to hydrate zonal shift cache")
+		return
+	}
+	p.hydrated.Store(true)
+}
+
 func (p *DefaultProvider) IsZonalShifted(ctx context.Context, zoneId string) bool {
+	p.ensureHydrated(ctx)
+
 	p.RLock()
 	defer p.RUnlock()
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Ensure Zonal Shift cache is hydrated before returning a zonal shift status. 


**How was this change tested?**

make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.