### PR TITLE
docs: Fix llms.txt absolute URLs

### DIFF
--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -76,6 +76,10 @@ params:
   github_repo: "https://github.com/aws/karpenter-provider-aws"
   github_subdir: website
   github_branch: main
+  # Canonical production host, used to build absolute URLs in llms.txt (the
+  # site's baseURL is "/", which yields root-relative links an LLM can't
+  # resolve). Deploy previews override baseURL and are preferred when absolute.
+  llms_base_url: "https://karpenter.sh"
   images:
     - banner.png
   version_menu: Releases

--- a/website/layouts/index.llms.txt
+++ b/website/layouts/index.llms.txt
@@ -7,6 +7,12 @@
   llms-pages.txt partial (kept as .txt so plain-text output isn't HTML-escaped).
 */ -}}
 {{- $latest := printf "v%s.%s" (index (split site.Params.latest_release_version ".") 0) (index (split site.Params.latest_release_version ".") 1) -}}
+{{- /* Prefer an absolute baseURL (deploy previews set one via -b); fall back to
+       the canonical production host so links resolve regardless of context. */ -}}
+{{- $base := site.Params.llms_base_url -}}
+{{- if or (hasPrefix site.BaseURL "http://") (hasPrefix site.BaseURL "https://") -}}
+{{- $base = strings.TrimSuffix "/" site.BaseURL -}}
+{{- end -}}
 # {{ site.Title }}
 
 > {{ site.Params.description }}
@@ -14,18 +20,18 @@
 {{ with site.GetPage "/docs" -}}
 {{ range .Sections.ByWeight }}
 ## {{ .Title }}
-{{- partial "llms-pages.txt" (dict "section" . "depth" 0) }}
+{{- partial "llms-pages.txt" (dict "section" . "depth" 0 "base" $base) }}
 {{ end }}
 {{- end }}
 
 ## Versions
 
-The links above point at the current stable release ({{ $latest }}), served under the `/docs/` path. The same documentation is archived for other releases under a version-prefixed path. To read any page for a specific version, replace the `/docs/` prefix in its URL with the version prefix below (and append `index.md` for the Markdown form).
+The links above point at the current stable release ({{ $latest }}), served under the `{{ $base }}/docs/` path. The same documentation is archived for other releases under a version-prefixed path. To read any page for a specific version, replace the `/docs/` prefix in its URL with the version prefix below (and append `index.md` for the Markdown form).
 
 Available versions:
-- `/docs/` — current stable release ({{ $latest }})
+- {{ $base }}/docs/ : current stable release ({{ $latest }})
 {{- range site.Params.versions }}
 {{- if ne . "preview" }}
-- `/{{ . }}/` — the {{ . }} release
+- {{ $base }}/{{ . }}/ : the {{ . }} release
 {{- end }}
 {{- end }}

--- a/website/layouts/partials/llms-pages.txt
+++ b/website/layouts/partials/llms-pages.txt
@@ -6,13 +6,15 @@
   Args (dict):
     section — the section page to walk
     depth   — current nesting depth (0 at the top level), drives indentation
+    base    — absolute URL prefix (e.g. https://karpenter.sh) prepended to links
 */ -}}
 {{- $section := .section -}}
+{{- $base := .base -}}
 {{- $indent := strings.Repeat .depth "  " -}}
 {{- range $section.RegularPages.ByWeight }}
-{{ $indent }}- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp | safeHTML }}{{ end }}
+{{ $indent }}- [{{ .Title }}]({{ $base }}{{ .RelPermalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp | safeHTML }}{{ end }}
 {{- end -}}
 {{- range $section.Sections.ByWeight }}
-{{ $indent }}- [{{ .Title }}]({{ .Permalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp | safeHTML }}{{ end }}
-{{- partial "llms-pages.txt" (dict "section" . "depth" (add $.depth 1)) -}}
+{{ $indent }}- [{{ .Title }}]({{ $base }}{{ .RelPermalink | replaceRE `/$` "/index.md" }}){{ with .Description }}: {{ . | plainify | chomp | safeHTML }}{{ end }}
+{{- partial "llms-pages.txt" (dict "section" . "depth" (add $.depth 1) "base" $base) -}}
 {{- end -}}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

The `llms.txt` file for the documentation website is incorrectly showing relative URLs, where they should be absolute. This was a divergence from local testing where it was showing absolute URLs but when published this is instead showing relative URLs.

**How was this change tested?**

Tested with:

1. No base URL provided (falls back to karpenter.sh)
2. Base URL provided to mirror preview site path

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.