### PR TITLE
fix: wire AWS SDK client timeout into operator config

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -109,7 +109,7 @@ type Operator struct {
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
-	cfg := prometheusv2.WithPrometheusMetrics(WithUserAgent(lo.Must(config.LoadDefaultConfig(ctx))), crmetrics.Registry)
+	cfg := prometheusv2.WithPrometheusMetrics(WithUserAgent(lo.Must(config.LoadDefaultConfig(ctx, config.WithHTTPClient(NewAWSSDKHTTPClient())))), crmetrics.Registry)
 	cfg.APIOptions = append(cfg.APIOptions, middleware.StructuredErrorHandler)
 	if cfg.Region == "" {
 		log.FromContext(ctx).V(1).Info("retrieving region from IMDS")


### PR DESCRIPTION
Fixes #N/A

**Description**

Follow-up to #9318. That PR added the `NewAWSSDKHTTPClient()` helper (a `BuildableClient` with a 4m `DefaultAWSSDKClientTimeout`) but never wired it into the AWS SDK config the operator actually uses, so no client picked up the timeout.

This passes the timeout-bearing HTTP client into `config.LoadDefaultConfig` via `config.WithHTTPClient(...)` at the single place the operator builds its config (`NewOperator`), so all downstream AWS clients (EC2, EKS, ARC Zonal Shift, etc.) inherit the 4-minute client timeout.

**How was this change tested?**

`go build ./pkg/operator/...` and `go vet ./pkg/operator/...`

**Does this change impact docs?**
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
