### PR TITLE
docs: flag native ODCR default-on as a breaking change in 1.6.0 upgrade guide

### DIFF
--- a/website/content/en/docs/contributing/documentation-updates.md
+++ b/website/content/en/docs/contributing/documentation-updates.md
@@ -7,6 +7,6 @@ description: >
 ---
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
-- Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
+- Documentation updates for an unreleased change should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process at the next release (not when the change merges).
+- Fixes or corrections to already-released documentation should also be applied directly to website/content/en/docs/ (so they appear on the live site before the next release) and backported to every other affected version under website/content/en/ *besides* the /docs/ folder.
 - Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.
-- If your update applies to more than just the current version of Karpenter, please backport your changes into all of the versions under website/content/en/ *besides* the /docs/ folder

--- a/website/content/en/docs/upgrading/upgrade-guide.md
+++ b/website/content/en/docs/upgrading/upgrade-guide.md
@@ -209,7 +209,9 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 {{% /alert %}}
 
 * Native ODCR support has graduated to beta and is enabled by default.
-  If you were previously using open ODCRs with Karpenter and have not already migrated to native ODCR support, review the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}) before upgrading.
+  {{% alert title="Warning: breaking change for open ODCR users" color="warning" %}}
+  If you use ODCRs with `open` instance eligibility but have **not** set `spec.capacityReservationSelectorTerms` on your EC2NodeClasses, Karpenter stops using those reservations after this upgrade and falls back to on-demand — leaving reservations unused but still billed. Configure it **before** upgrading; see the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}).
+  {{% /alert %}}
 * Support a new configuration option `MinValuesPolicy` which controls how the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met). Default is 'Strict' to preserve existing behavior.
 * Support a new configuration option `DisableDryRun` which disables the dry run calls made during EC2NodeClass validation (1.6.2+).
 

--- a/website/content/en/preview/contributing/documentation-updates.md
+++ b/website/content/en/preview/contributing/documentation-updates.md
@@ -7,6 +7,6 @@ description: >
 ---
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
-- Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
+- Documentation updates for an unreleased change should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process at the next release (not when the change merges).
+- Fixes or corrections to already-released documentation should also be applied directly to website/content/en/docs/ (so they appear on the live site before the next release) and backported to every other affected version under website/content/en/ *besides* the /docs/ folder.
 - Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.
-- If your update applies to more than just the current version of Karpenter, please backport your changes into all of the versions under website/content/en/ *besides* the /docs/ folder

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -196,7 +196,9 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 {{% /alert %}}
 
 * Native ODCR support has graduated to beta and is enabled by default.
-  If you were previously using open ODCRs with Karpenter and have not already migrated to native ODCR support, review the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}) before upgrading.
+  {{% alert title="Warning: breaking change for open ODCR users" color="warning" %}}
+  If you use ODCRs with `open` instance eligibility but have **not** set `spec.capacityReservationSelectorTerms` on your EC2NodeClasses, Karpenter stops using those reservations after this upgrade and falls back to on-demand — leaving reservations unused but still billed. Configure it **before** upgrading; see the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}).
+  {{% /alert %}}
 * Support a new configuration option `MinValuesPolicy` which controls how the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met). Default is 'Strict' to preserve existing behavior.
 * Support a new configuration option `DisableDryRun` which disables the dry run calls made during EC2NodeClass validation (1.6.2+).
 

--- a/website/content/en/v1.11/contributing/documentation-updates.md
+++ b/website/content/en/v1.11/contributing/documentation-updates.md
@@ -7,6 +7,6 @@ description: >
 ---
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
-- Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
+- Documentation updates for an unreleased change should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process at the next release (not when the change merges).
+- Fixes or corrections to already-released documentation should also be applied directly to website/content/en/docs/ (so they appear on the live site before the next release) and backported to every other affected version under website/content/en/ *besides* the /docs/ folder.
 - Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.
-- If your update applies to more than just the current version of Karpenter, please backport your changes into all of the versions under website/content/en/ *besides* the /docs/ folder

--- a/website/content/en/v1.11/upgrading/upgrade-guide.md
+++ b/website/content/en/v1.11/upgrading/upgrade-guide.md
@@ -181,7 +181,9 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 {{% /alert %}}
 
 * Native ODCR support has graduated to beta and is enabled by default.
-  If you were previously using open ODCRs with Karpenter and have not already migrated to native ODCR support, review the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}) before upgrading.
+  {{% alert title="Warning: breaking change for open ODCR users" color="warning" %}}
+  If you use ODCRs with `open` instance eligibility but have **not** set `spec.capacityReservationSelectorTerms` on your EC2NodeClasses, Karpenter stops using those reservations after this upgrade and falls back to on-demand — leaving reservations unused but still billed. Configure it **before** upgrading; see the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}).
+  {{% /alert %}}
 * Support a new configuration option `MinValuesPolicy` which controls how the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met). Default is 'Strict' to preserve existing behavior.
 * Support a new configuration option `DisableDryRun` which disables the dry run calls made during EC2NodeClass validation (1.6.2+).
 

--- a/website/content/en/v1.12/contributing/documentation-updates.md
+++ b/website/content/en/v1.12/contributing/documentation-updates.md
@@ -7,6 +7,6 @@ description: >
 ---
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
-- Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
+- Documentation updates for an unreleased change should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process at the next release (not when the change merges).
+- Fixes or corrections to already-released documentation should also be applied directly to website/content/en/docs/ (so they appear on the live site before the next release) and backported to every other affected version under website/content/en/ *besides* the /docs/ folder.
 - Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.
-- If your update applies to more than just the current version of Karpenter, please backport your changes into all of the versions under website/content/en/ *besides* the /docs/ folder

--- a/website/content/en/v1.12/upgrading/upgrade-guide.md
+++ b/website/content/en/v1.12/upgrading/upgrade-guide.md
@@ -196,7 +196,9 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 {{% /alert %}}
 
 * Native ODCR support has graduated to beta and is enabled by default.
-  If you were previously using open ODCRs with Karpenter and have not already migrated to native ODCR support, review the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}) before upgrading.
+  {{% alert title="Warning: breaking change for open ODCR users" color="warning" %}}
+  If you use ODCRs with `open` instance eligibility but have **not** set `spec.capacityReservationSelectorTerms` on your EC2NodeClasses, Karpenter stops using those reservations after this upgrade and falls back to on-demand — leaving reservations unused but still billed. Configure it **before** upgrading; see the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}).
+  {{% /alert %}}
 * Support a new configuration option `MinValuesPolicy` which controls how the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met). Default is 'Strict' to preserve existing behavior.
 * Support a new configuration option `DisableDryRun` which disables the dry run calls made during EC2NodeClass validation (1.6.2+).
 

--- a/website/content/en/v1.13/contributing/documentation-updates.md
+++ b/website/content/en/v1.13/contributing/documentation-updates.md
@@ -7,6 +7,6 @@ description: >
 ---
 
 - Documentation for https://karpenter.sh/docs/ is built under website/content/en/preview/.
-- Documentation updates should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process after the change has been merged.
+- Documentation updates for an unreleased change should be made to the "preview" directory. Your changes will be promoted to website/content/en/docs/ by an automated process at the next release (not when the change merges).
+- Fixes or corrections to already-released documentation should also be applied directly to website/content/en/docs/ (so they appear on the live site before the next release) and backported to every other affected version under website/content/en/ *besides* the /docs/ folder.
 - Previews for your changes are built and available a few minutes after you push. Look for the "Amplify Preview URL" link in a comment in your PR.
-- If your update applies to more than just the current version of Karpenter, please backport your changes into all of the versions under website/content/en/ *besides* the /docs/ folder

--- a/website/content/en/v1.13/upgrading/upgrade-guide.md
+++ b/website/content/en/v1.13/upgrading/upgrade-guide.md
@@ -209,7 +209,9 @@ Karpenter `1.1.0` drops the support for `v1beta1` APIs.
 {{% /alert %}}
 
 * Native ODCR support has graduated to beta and is enabled by default.
-  If you were previously using open ODCRs with Karpenter and have not already migrated to native ODCR support, review the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}) before upgrading.
+  {{% alert title="Warning: breaking change for open ODCR users" color="warning" %}}
+  If you use ODCRs with `open` instance eligibility but have **not** set `spec.capacityReservationSelectorTerms` on your EC2NodeClasses, Karpenter stops using those reservations after this upgrade and falls back to on-demand — leaving reservations unused but still billed. Configure it **before** upgrading; see the [native ODCR support guide]({{< relref "../tasks/odcrs" >}}).
+  {{% /alert %}}
 * Support a new configuration option `MinValuesPolicy` which controls how the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met). Default is 'Strict' to preserve existing behavior.
 * Support a new configuration option `DisableDryRun` which disables the dry run calls made during EC2NodeClass validation (1.6.2+).
 


### PR DESCRIPTION
Fixes #N/A

**Description**

The `1.6.0` upgrade-guide entry noting native ODCR support is "enabled by default" reads as an informational bullet, so users upgrading across the `1.6.0` boundary can miss that open ODCRs stop being used unless `spec.capacityReservationSelectorTerms` is configured first — leaving reservations unused but still billed while nodes fall back to on-demand. This converts the bullet into a `warning` alert box naming the required pre-upgrade action and the impact of inaction.

The fix is applied to `preview/`, `docs/`, and the maintained `v1.11`–`v1.13` directories, so it shows on the live https://karpenter.sh/docs/ site immediately rather than only after the next release.

While here, this also corrects the `contributing/documentation-updates.md` note. Per `hack/release/common.sh`, `docs/` is regenerated from `preview/` only at **release** time (not on merge), so fixes to already-released docs must be applied to `docs/` (and maintained `vX.Y/` dirs) directly, not to `preview/` alone. The note previously implied merge-time promotion.

**How was this change tested?**

Docs-only change. Verified on the PR's Amplify preview that the `/preview/` path renders the warning box; confirmed the `{{% alert %}}` shortcode usage matches other blocks in the file.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.