### PR TITLE
release-v1.12.x: cherry-pick AWS SDK client timeout fixes (#9318, #9320)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter-provider-aws
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -109,7 +109,7 @@ type Operator struct {
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
-	cfg := prometheusv2.WithPrometheusMetrics(WithUserAgent(lo.Must(config.LoadDefaultConfig(ctx))), crmetrics.Registry)
+	cfg := prometheusv2.WithPrometheusMetrics(WithUserAgent(lo.Must(config.LoadDefaultConfig(ctx, config.WithHTTPClient(NewAWSSDKHTTPClient())))), crmetrics.Registry)
 	cfg.APIOptions = append(cfg.APIOptions, middleware.StructuredErrorHandler)
 	if cfg.Region == "" {
 		log.FromContext(ctx).V(1).Info("retrieving region from IMDS")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
@@ -69,6 +71,10 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/subnet"
 	"github.com/aws/karpenter-provider-aws/pkg/providers/version"
 	"github.com/aws/karpenter-provider-aws/pkg/utils"
+)
+
+const (
+	DefaultAWSSDKClientTimeout = 4 * time.Minute
 )
 
 func init() {
@@ -375,4 +381,9 @@ func ValidateZonalShiftEnablement(ctx context.Context, eksAPI sdk.EKSAPI, arczon
 		return "", fmt.Errorf("cluster not registered to Zonal Shift %w", getManagedResourceErr)
 	}
 	return *clusterArn, nil
+}
+
+func NewAWSSDKHTTPClient() *awshttp.BuildableClient {
+	return awshttp.NewBuildableClient().
+		WithTimeout(DefaultAWSSDKClientTimeout)
 }


### PR DESCRIPTION
Backports the AWS SDK client timeout fix to `release-v1.12.x`:
- #9318 — add client timeout to aws client config
- #9320 — wire the AWS SDK client timeout into the operator config

Cherry-picked in order (#9320 depends on #9318's helper). Conflicts from branch drift were resolved to keep the branch's existing imports/preamble while applying only the fix (`NewAWSSDKHTTPClient()` helper + wiring it into `config.LoadDefaultConfig`). `go build` passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.