### PR TITLE
docs: backport minValues example fixes to v1.0 and v1.12

### DIFF
--- a/website/content/en/v1.0/concepts/nodepools.md
+++ b/website/content/en/v1.0/concepts/nodepools.md
@@ -268,8 +268,8 @@ There is currently a limit of 100 on the total number of requirements on both th
 
 Along with the combination of [key,operator,values] in the requirements, Karpenter also supports `minValues` in the NodePool requirements block, allowing the scheduler to be aware of user-specified flexibility minimums while scheduling pods to a cluster. If Karpenter cannot meet this minimum flexibility for each key when scheduling a pod, it will fail the scheduling loop for that NodePool, either falling back to another NodePool which meets the pod requirements or failing scheduling the pod altogether.
 
-For example, the below spec will use spot instance type for all provisioned instances and enforces `minValues` to various keys where it is defined
-i.e at least 2 unique instance families from [c,m,r], 5 unique instance families [eg: "m5","m5d","r4","c5","c5d","c4" etc], 10 unique instance types [eg: "c5.2xlarge","c4.xlarge" etc] is required for scheduling the pods.
+For spot instances, you should specify `karpenter.sh/capacity-type: spot` in your requirements. For example, the below spec will use spot instance type for all provisioned instances and enforces `minValues` to various keys where it is defined
+i.e at least 2 unique instance categories from [c,m,r], 5 unique instance families [eg: "m5","m5d","r4","c5","c5d","c4" etc], 10 unique instance types [eg: "c5.2xlarge","c4.xlarge" etc] are required for scheduling the pods.
 
 ```yaml
 spec:
@@ -282,6 +282,9 @@ spec:
         - key: kubernetes.io/os
           operator: In
           values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
         - key: karpenter.k8s.aws/instance-category
           operator: In
           values: ["c", "m", "r"]

--- a/website/content/en/v1.12/concepts/nodepools.md
+++ b/website/content/en/v1.12/concepts/nodepools.md
@@ -299,7 +299,7 @@ There is currently a limit of 100 on the total number of requirements on both th
 Along with the combination of [key,operator,values] in the requirements, Karpenter also supports `minValues` in the NodePool requirements block, allowing the scheduler to be aware of user-specified flexibility minimums while scheduling pods to a cluster. Depending on the policy configured via the flag `--min-values-policy` or environment variable `MIN_VALUES_POLICY`, if Karpenter cannot meet this minimum flexibility for each key when scheduling a pod, it will either fail the scheduling loop for that NodePool, either falling back to another NodePool which meets the pod requirements or failing scheduling the pod altogether (when policy is set to `Strict`) or relax `minValues` until they can be met (when policy is set to `BestEffort`).
 
 For spot instances, you should specify `karpenter.sh/capacity-type: spot` in your requirements. For example, the below spec will use spot instance type for all provisioned instances and enforces `minValues` to various keys where it is defined
-i.e at least 2 unique instance families from [c,m,r], 5 unique instance families [eg: "m5","m5d","r4","c5","c5d","c4" etc], 10 unique instance types [eg: "c5.2xlarge","c4.xlarge" etc] is required for scheduling the pods.
+i.e at least 2 unique instance categories from [c,m,r], 5 unique instance families [eg: "m5","m5d","r4","c5","c5d","c4" etc], 10 unique instance types [eg: "c5.2xlarge","c4.xlarge" etc] are required for scheduling the pods.
 
 ```yaml
 spec:


### PR DESCRIPTION
## Summary

- Backport corrected minValues prose and spot `capacity-type` example to versioned NodePool docs
- Align `v1.0/` and `v1.12/` with the live `/docs/` page (already fixed in #8900 and #8999)

## Context

kubernetes-sigs/karpenter#2548 reported mismatches between minValues prose and examples. The current docs site is fixed; this backports the remaining corrections to older versioned doc trees.

## Test plan

- [ ] Review `website/content/en/v1.0/concepts/nodepools.md` Min Values section
- [ ] Review `website/content/en/v1.12/concepts/nodepools.md` Min Values section

Fixes kubernetes-sigs/karpenter#2548