### PR TITLE
fix: change github.com/imdario/mergo imports to dario.cat/mergo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws/karpenter-provider-aws
 go 1.26.5
 
 require (
+	dario.cat/mergo v1.0.0
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -27,7 +28,6 @@ require (
 	github.com/awslabs/operatorpkg/aws v0.0.0-20250414225955-b47cd315ffe9
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/uuid v1.6.0
-	github.com/imdario/mergo v0.3.16
 	github.com/jonathan-innis/aws-sdk-go-prometheus v0.1.1
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.32.0
@@ -97,6 +97,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00lCDlaYPg=

--- a/pkg/apis/v1/ec2nodeclass_hash_test.go
+++ b/pkg/apis/v1/ec2nodeclass_hash_test.go
@@ -15,7 +15,7 @@ limitations under the License.
 package v1_test
 
 import (
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -37,7 +37,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	opstatus "github.com/awslabs/operatorpkg/status"
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis"

--- a/pkg/controllers/capacityreservation/expiration/suite_test.go
+++ b/pkg/controllers/capacityreservation/expiration/suite_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/awslabs/operatorpkg/option"
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 	"k8s.io/client-go/tools/record"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"

--- a/pkg/controllers/nodeclass/hash/suite_test.go
+++ b/pkg/controllers/nodeclass/hash/suite_test.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 
 	"github.com/awslabs/operatorpkg/object"
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"

--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/awslabs/operatorpkg/option"
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -34,7 +34,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/awslabs/operatorpkg/object"
 	"github.com/awslabs/operatorpkg/status"
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -17,7 +17,7 @@ package test
 import (
 	"fmt"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	corev1 "k8s.io/api/core/v1"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/samber/lo"


### PR DESCRIPTION
Fixes #9294

### Description
This PR resolves the `go mod tidy` error caused by mismatched imports for the `mergo` package. The module declares its path as `dario.cat/mergo`, but it was previously required as `github.com/imdario/mergo`. 

By updating all imports from `"github.com/imdario/mergo"` to `"dario.cat/mergo"`, we eliminate the import mismatch and allow `go mod tidy` to succeed without workarounds.

### Testing
- `go mod tidy` executes successfully without errors.
- `go build ./...` compiles successfully.
