### PR TITLE
ci: pin ko to v0.18.1 to fix release image publish (release-v1.9.x)

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -16,7 +16,7 @@ tools() {
     # fix - https://github.com/golangci/golangci-lint/issues/6017
     # change to latest once golangci releases new version with the fix
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@main
-    go install github.com/google/ko@latest
+    go install github.com/google/ko@v0.18.1
     go install github.com/mikefarah/yq/v4@latest
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@b9bccfd419149d26d14130887a5e5819e4a3b2be


### PR DESCRIPTION
ko`@latest` now resolves to **v0.19.1**, which rejects the `cmd/controller/kodata/HEAD` → `.git/HEAD` symlink ("outside the kodata root") and fails `make release` at the image-publish step. This blocked the controller-image publish for today's SDK-timeout patch release on this branch (GitHub release created, but no image in ECR).

`release-v1.11.x`+ already pin `ko@v0.18.1`; this applies the same one-line pin so the StableRelease workflow can publish images.

Verified locally on a faithful checkout of `release-v1.10.x`: ko v0.19.1 reproduces the exact CI error (exit 1), ko v0.18.1 builds the controller image successfully (exit 0).