### PR TITLE
chore: NodeClass status condition on misconfigured spec.instanceProfile

### DIFF
--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -55,6 +55,7 @@ const (
 	ConditionReasonCreateFleetAuthFailed          = "CreateFleetAuthCheckFailed"
 	ConditionReasonCreateLaunchTemplateAuthFailed = "CreateLaunchTemplateAuthCheckFailed"
 	ConditionReasonRunInstancesAuthFailed         = "RunInstancesAuthCheckFailed"
+	ConditionReasonInstanceProfileNotFound        = "InstanceProfileNotFound"
 	ConditionReasonDependenciesNotReady           = "DependenciesNotReady"
 	ConditionReasonTagValidationFailed            = "TagValidationFailed"
 	ConditionReasonDryRunDisabled                 = "DryRunDisabled"
@@ -311,9 +312,27 @@ func (v *Validation) validateRunInstancesAuthorization(
 		}
 	}
 
-	// If we get InstanceProfile NotFound, but we have a resolved instance profile in the status,
-	// this means there is most likely an eventual consistency issue and we just need to requeue
-	if awserrors.IsInstanceProfileNotFound(firstSubnetErr) || awserrors.IsRateLimitedError(firstSubnetErr) || awserrors.IsServerError(firstSubnetErr) {
+	if awserrors.IsInstanceProfileNotFound(firstSubnetErr) {
+		// When spec.instanceProfile is explicitly set, there's no eventual consistency to wait for —
+		// the named profile simply doesn't exist.
+		if nodeClass.Spec.InstanceProfile != nil {
+			message := fmt.Sprintf("Instance profile %q not found", lo.FromPtr(nodeClass.Spec.InstanceProfile))
+			v.cache.SetDefault(v.cacheKey(nodeClass, tags), validationCacheEntry{
+				reason:  ConditionReasonInstanceProfileNotFound,
+				message: message,
+			})
+			nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(
+				v1.ConditionTypeValidationSucceeded,
+				ConditionReasonInstanceProfileNotFound,
+				message,
+			)
+			return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
+		}
+		// If we get InstanceProfile NotFound, but we have a resolved instance profile in the status,
+		// this means there is most likely an eventual consistency issue and we just need to requeue
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if awserrors.IsRateLimitedError(firstSubnetErr) || awserrors.IsServerError(firstSubnetErr) {
 		return reconcile.Result{Requeue: true}, nil
 	}
 	if awserrors.IgnoreUnauthorizedOperationError(firstSubnetErr) != nil {

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -313,20 +313,15 @@ func (v *Validation) validateRunInstancesAuthorization(
 	}
 
 	if awserrors.IsInstanceProfileNotFound(firstSubnetErr) {
-		// When spec.instanceProfile is explicitly set, there's no eventual consistency to wait for —
-		// the named profile simply doesn't exist.
+		// When spec.instanceProfile is explicitly set, surface the error for visibility but don't
+		// cache it — the profile may be created concurrently and could be an eventual consistency issue
 		if nodeClass.Spec.InstanceProfile != nil {
-			message := fmt.Sprintf("Instance profile %q not found", lo.FromPtr(nodeClass.Spec.InstanceProfile))
-			v.cache.SetDefault(v.cacheKey(nodeClass, tags), validationCacheEntry{
-				reason:  ConditionReasonInstanceProfileNotFound,
-				message: message,
-			})
 			nodeClass.StatusConditions(status.WithClock(v.clk)).SetFalse(
 				v1.ConditionTypeValidationSucceeded,
 				ConditionReasonInstanceProfileNotFound,
-				message,
+				fmt.Sprintf("Instance profile %q not found", lo.FromPtr(nodeClass.Spec.InstanceProfile)),
 			)
-			return reconcile.Result{RequeueAfter: requeueAfterTime}, nil
+			return reconcile.Result{Requeue: true}, nil
 		}
 		// If we get InstanceProfile NotFound, but we have a resolved instance profile in the status,
 		// this means there is most likely an eventual consistency issue and we just need to requeue

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -321,7 +321,6 @@ func (v *Validation) validateRunInstancesAuthorization(
 				ConditionReasonInstanceProfileNotFound,
 				fmt.Sprintf("Instance profile %q not found", lo.FromPtr(nodeClass.Spec.InstanceProfile)),
 			)
-			return reconcile.Result{Requeue: true}, nil
 		}
 		// If we get InstanceProfile NotFound, but we have a resolved instance profile in the status,
 		// this means there is most likely an eventual consistency issue and we just need to requeue

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -299,6 +299,32 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
 			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsTrue()).To(BeTrue())
 		})
+		It("should set validation condition to false when spec.instanceProfile does not exist", func() {
+			nodeClass.Spec.Role = ""
+			nodeClass.Spec.InstanceProfile = lo.ToPtr("nonexistent-profile")
+			nodeClass.Status.InstanceProfile = "nonexistent-profile"
+			awsEnv.EC2API.RunInstancesBehavior.Error.Set(&smithy.GenericAPIError{
+				Code:    "InvalidParameterValue",
+				Message: "Value (nonexistent-profile) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name",
+			}, fake.MaxCalls(4))
+			ExpectApplied(ctx, env.Client, nodeClass)
+			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(nodeclass.ConditionReasonInstanceProfileNotFound))
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Message).To(ContainSubstring("nonexistent-profile"))
+		})
+		It("should requeue when instance profile not found with spec.role", func() {
+			awsEnv.EC2API.RunInstancesBehavior.Error.Set(&smithy.GenericAPIError{
+				Code:    "InvalidParameterValue",
+				Message: "Value (test-profile) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name",
+			}, fake.MaxCalls(4))
+			ExpectApplied(ctx, env.Client, nodeClass)
+			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			// With spec.role, we treat this as eventual consistency — validation stays unknown/unchanged, not false
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeFalse())
+		})
 		Context("Windows AMI Validation", func() {
 			DescribeTable(
 				"should fallback to static instance types when windows ami is used",


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Previously, with misconfigured `spec.instanceProfile` the EC2NodeClass would remain in `AwaitingReconciliation` and `ValidationSucceeded` succeeded as `Unknown`. This PR adds a `InstanceProfileNotFound` status condition for when `spec.instanceProfile` is misconfigured. This check does not apply for `spec.Role` as `InstanceProfileNotFound` is expected due to eventual consistency delays. 

**Note**: We cannot simply use IAM GetInstanceProfile as that endpoint is not supported in isolated VPCs.

**How was this change tested?**
* unit tests
* manual testing

NodeClass
```
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: default-no-profile
spec:
  instanceProfile: "not-a-real-profile"
...
```

Status Condition
```
  - lastTransitionTime: "2026-07-13T20:49:06Z"
    message: Instance profile "not-a-real-profile" not found
    observedGeneration: 1
    reason: InstanceProfileNotFound
    status: "False"
    type: ValidationSucceeded
  - lastTransitionTime: "2026-07-13T20:49:06Z"
    message: ValidationSucceeded=False
    observedGeneration: 1
    reason: UnhealthyDependents
    status: "False"
    type: Ready
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.