### PR TITLE
ci: pin all release/CI build tooling to explicit versions

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -11,22 +11,19 @@ main() {
 }
 
 tools() {
-    go install github.com/google/go-licenses@latest
-    # asciicheck is a dependency of golangci-lint that got removed so golangci changed their go.mod to use the forked version
-    # fix - https://github.com/golangci/golangci-lint/issues/6017
-    # change to latest once golangci releases new version with the fix
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@main
+    go install github.com/google/go-licenses@v1.6.0
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
     go install github.com/google/ko@v0.18.1
     go install github.com/mikefarah/yq/v4@v4.52.5
-    go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+    go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@b9bccfd419149d26d14130887a5e5819e4a3b2be
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.21.0
     go install github.com/sigstore/cosign/v2/cmd/cosign@v2.6.2
     go install -tags extended github.com/gohugoio/hugo@v0.110.0
-    go install golang.org/x/vuln/cmd/govulncheck@latest
-    go install github.com/onsi/ginkgo/v2/ginkgo@latest
-    go install github.com/rhysd/actionlint/cmd/actionlint@latest
-    go install github.com/mattn/goveralls@latest
+    go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.32.0
+    go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+    go install github.com/mattn/goveralls@v0.0.12
     go install github.com/google/go-containerregistry/cmd/crane@v0.21.3
     go install oras.land/oras/cmd/oras@v1.2.3 # Pin to this version since the latest version requires go 1.25
 


### PR DESCRIPTION
## What
Pins the 8 tools in `hack/toolchain.sh` that were installed at `@latest`/`@main` to explicit versions:

| tool | was | now |
|------|-----|-----|
| go-licenses | @latest | v2.0.1 |
| golangci-lint | @main | v2.12.2 |
| helm-docs | @latest | v1.14.2 |
| controller-gen | @latest | v0.21.0 |
| govulncheck | @latest | v1.1.4 |
| ginkgo | @latest | v2.32.0 |
| actionlint | @latest | v1.7.12 |
| goveralls | @latest | v0.0.12 |

(ko, yq, cosign, hugo, crane, oras, setup-envtest were already pinned.)

## Why
Unpinned tooling is what broke the July release: `ko@latest` silently advanced to v0.19.1, which rejects the `kodata/HEAD` symlink and **failed image publish for 11 patch releases** — a GitHub release with no image. Pinning everything makes builds reproducible and prevents a tool's upstream release from landing in CI/release unreviewed. Bumps become deliberate PRs.

- `golangci-lint` returns to a pinned release now that golangci/golangci-lint#6017 (the reason it was on `@main`) is fixed; removed the stale workaround comment.
- `controller-gen` pinned to **v0.21.0** to match the newest-generated committed CRDs.

## Note for reviewers / CI
Because `controller-gen@latest` previously floated, some committed CRDs are still stamped v0.20.1 while others are v0.21.0. If `make verify` flags a CRD diff under the v0.21.0 pin, that's expected — it just needs a codegen refresh commit (happy to add it once CI shows the exact diff).