### PR TITLE
ci: keep the GitHub "Latest" release badge on the newest version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,32 @@ jobs:
         with:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
           prerelease: false
+      # GitHub marks the most-recently-published release as "Latest". When we cut a
+      # patch for an older minor (a backport), that patch steals the "Latest" badge from
+      # the true newest version. Recompute the highest semver across all releases and
+      # (re)mark it Latest so /releases/latest always points at the newest version.
+      - name: Correct the Latest release badge
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const releases = await github.paginate(github.rest.repos.listReleases, { owner, repo, per_page: 100 });
+            const semver = t => {
+              const m = /^v(\d+)\.(\d+)\.(\d+)$/.exec(t); // stable releases only; skip rc/alpha/beta
+              return m ? [ +m[1], +m[2], +m[3] ] : null;
+            };
+            const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+            const stable = releases
+              .filter(r => !r.draft && !r.prerelease && semver(r.tag_name))
+              .sort((a, b) => cmp(semver(b.tag_name), semver(a.tag_name)));
+            if (stable.length === 0) { core.info('No stable releases found; leaving Latest unchanged.'); return; }
+            const newest = stable[0];
+            if (newest.make_latest === 'true') {
+              core.info(`Latest is already ${newest.tag_name}; nothing to do.`);
+              return;
+            }
+            core.info(`Marking ${newest.tag_name} as Latest (was on a different release).`);
+            await github.rest.repos.updateRelease({ owner, repo, release_id: newest.id, make_latest: 'true' });
       - uses: ./.github/actions/install-deps
         with:
           use-cache: false


### PR DESCRIPTION
## Problem
GitHub marks the most-recently-**published** release as "Latest" (a timestamp heuristic). When we cut a patch for an older minor (a backport), that release steals the "Latest" badge.

**This happened in the July release:** the v1.0–v1.10 patch batch left `/releases/latest` pointing at **v1.10.1** while **v1.14.0** was the true latest — directly contradicting karpenter.sh, which says 1.14 is latest. (Fixed manually at the time with `gh release edit v1.14.0 --latest`.)

## Fix
Add a step to the release workflow (right after the release is created) that recomputes the highest **stable** semver (`vX.Y.Z`, ignoring rc/alpha/beta) across all releases and (re)marks it `make_latest`.

- **Idempotent:** no-op when the newest release already holds the badge, so normal minor releases are unaffected — it only self-corrects after an older-minor backport.
- Uses `actions/github-script` (already used elsewhere in this workflow).

## Testing
YAML validated; embedded script syntax-checked under the async wrapper github-script uses. Behavior will exercise on the next release; logic is a straightforward highest-semver sort + conditional `updateRelease`.