### PR TITLE
docs: make compatibility-matrix generation idempotent + dedupe rows

### DIFF
--- a/hack/docs/compatibilitymatrix_gen/compatibility.yaml
+++ b/hack/docs/compatibilitymatrix_gen/compatibility.yaml
@@ -94,13 +94,7 @@ compatibility:
   - appVersion: 1.12.x
     minK8sVersion: 1.26
     maxK8sVersion: 1.35
-  - appVersion: 1.12.x
-    minK8sVersion: 1.26
-    maxK8sVersion: 1.35
   - appVersion: 1.13.x
-    minK8sVersion: 1.26
-    maxK8sVersion: 1.36
-  - appVersion: 1.14.x
     minK8sVersion: 1.26
     maxK8sVersion: 1.36
   - appVersion: 1.14.x

--- a/hack/docs/version_compatibility_gen/main.go
+++ b/hack/docs/version_compatibility_gen/main.go
@@ -48,6 +48,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Idempotency: this runs on every release, including re-tags and patch releases of a
+	// minor whose row already exists. Skip the append if this version is already present,
+	// otherwise the matrix accumulates duplicate rows.
+	if strings.Contains(string(yamlFile), fmt.Sprintf("appVersion: %s.x", v)) {
+		log.Printf("appVersion %s.x already present in %s; skipping append", v, os.Args[1])
+		os.Exit(0)
+	}
+
 	log.Println("writing output to", os.Args[1])
 	f, err := os.Create(os.Args[1])
 	if err != nil {


### PR DESCRIPTION
## Problem
`hack/docs/version_compatibility_gen` runs on every release and **unconditionally appends** the release version to `compatibility.yaml`. Re-tags and re-runs accumulate duplicate rows — on `main` today, **1.12.x and 1.14.x each appear twice**.

## Fix
- **Idempotent append:** skip when the version's `appVersion: X.Y.x` row is already present.
- **Dedupe:** remove the existing duplicate 1.12.x / 1.14.x entries.
- Regenerating `compatibility.md` from the deduped source is a no-op (the rendered matrix collapses by minimum version), so no doc churn.

## Testing (local)
- `go vet` passes.
- Functional: running the generator for an existing version (v1.14.0) is now a no-op; a new version (v1.15.0) appends exactly once; a second run for v1.15.0 is a no-op.

Relates to the release-process retro item on keeping the compatibility matrix correct at release time.