### PR TITLE
chore: bump sigs.k8s.io/karpenter to v1.7.2

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- with .Values.additionalAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- with .Values.additionalAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodeoverlays.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- with .Values.additionalAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.1
-	sigs.k8s.io/karpenter v1.7.1
+	sigs.k8s.io/karpenter v1.7.2
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ sigs.k8s.io/controller-runtime v0.22.1 h1:Ah1T7I+0A7ize291nJZdS1CabF/lB4E++WizgV
 sigs.k8s.io/controller-runtime v0.22.1/go.mod h1:FwiwRjkRPbiN+zp2QRp7wlTCzbUXxZ/D4OzuQUDwBHY=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/karpenter v1.7.1 h1:KoAWzWG4dEjaW33KtXKnGySAPDnIMwRrLZUndaeAjoY=
-sigs.k8s.io/karpenter v1.7.1/go.mod h1:fqk7MeJYRNfMPcOZGv/BtsPR/Hq170J4D2GoU3IVHYA=
+sigs.k8s.io/karpenter v1.7.2 h1:JxPLTCIZaESTzRmaUKWI66PDOksscqhQC21PAyXH7U0=
+sigs.k8s.io/karpenter v1.7.2/go.mod h1:qhi5mvRksCeSGwbOVMd0WjKfKsmZFZ8NkPjHq0l2plg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodeoverlays.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
bumps karpenter dependency to `v1.7.2` to consume upstream patch.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.