### PR TITLE
perf: precompute offering cache keys

### DIFF
--- a/pkg/providers/instancetype/offering/base_resolver.go
+++ b/pkg/providers/instancetype/offering/base_resolver.go
@@ -60,9 +60,13 @@ func (r *BaseResolver) ResolveOfferings(
 	allZones sets.Set[string],
 	shiftedZones sets.Set[string],
 	pg *placementgroup.PlacementGroup,
+	rc *ResolveContext,
 ) cloudprovider.Offerings {
 	itZones := sets.New(it.Requirements.Get(corev1.LabelTopologyZone).Values()...)
-	zoneInfo := nodeClass.ZoneInfo()
+	// ZoneInfo and the cache-key builder are pre-computed once per InjectOfferings call and passed
+	// in via ResolveContext, since they're constant across instance types and expensive to recompute.
+	zoneInfo := rc.ZoneInfo
+	keyBuilder := rc.cacheKeyBuilder
 	// Not all instance types are compatible with the NodeClass.
 	// In the event it is not, we mark the offering as unavailable.
 	isCompatibleWithNodeClass := compatibility.IsCompatibleWithNodeClass(instanceTypeInfo, nodeClass, pg)
@@ -73,7 +77,8 @@ func (r *BaseResolver) ResolveOfferings(
 		lastSeqNum = 0
 	}
 	seqNum := r.UnavailableOfferings.SeqNum(ec2types.InstanceType(it.Name))
-	if ofs, ok := r.Cache.Get(cacheKeyFromInstanceType(it, nodeClass, shiftedZones)); ok && lastSeqNum == seqNum {
+	cacheKey := keyBuilder.cacheKeyFromInstanceType(it)
+	if ofs, ok := r.Cache.Get(cacheKey); ok && lastSeqNum == seqNum {
 		offerings = append(offerings, ofs.([]*cloudprovider.Offering)...)
 	} else {
 		var pgOpts []awscache.UnavailableOfferingsOption
@@ -135,35 +140,31 @@ func (r *BaseResolver) ResolveOfferings(
 				cachedOfferings = append(cachedOfferings, offering)
 			}
 		}
-		r.Cache.SetDefault(cacheKeyFromInstanceType(it, nodeClass, shiftedZones), cachedOfferings)
+		r.Cache.SetDefault(cacheKey, cachedOfferings)
 		r.LastUnavailableOfferingsSeqNum.Store(ec2types.InstanceType(it.Name), seqNum)
 		offerings = append(offerings, cachedOfferings...)
 	}
 	return offerings
 }
 
-// cacheKeyFromInstanceType generates a cache key based on instance type, node class, and shifted zones.
-func cacheKeyFromInstanceType(it *cloudprovider.InstanceType, nodeClass NodeClass, shiftedZones sets.Set[string]) string {
-	zonesHash, _ := hashstructure.Hash(
-		it.Requirements.Get(corev1.LabelTopologyZone).Values(),
-		hashstructure.FormatV2,
-		&hashstructure.HashOptions{SlicesAsSets: true},
-	)
-	capacityTypesHash, _ := hashstructure.Hash(
-		it.Requirements.Get(karpv1.CapacityTypeLabelKey).Values(),
-		hashstructure.FormatV2,
-		&hashstructure.HashOptions{SlicesAsSets: true},
-	)
+// capacityTypesKey is used as a map key for pre-computed capacity type hashes.
+type capacityTypesKey struct {
+	hasOnDemand bool
+	hasSpot     bool
+}
+
+// cacheKeyBuilder pre-computes some cache key components to avoid redundant hashing.
+type cacheKeyBuilder struct {
+	baseSuffix          string                      // non-instance-type specific hashes
+	capacityTypesHashes map[capacityTypesKey]uint64 // capacity requirements -> hash
+}
+
+func newCacheKeyBuilder(nodeClass NodeClass, zoneInfo []v1.ZoneInfo, shiftedZones sets.Set[string], pg *placementgroup.PlacementGroup) *cacheKeyBuilder {
 	networkInterfaceHash, _ := hashstructure.Hash(nodeClass.NetworkInterfaces(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	subnetsHash, _ := hashstructure.Hash(
-		lo.Reduce(nodeClass.ZoneInfo(), func(agg []string, i v1.ZoneInfo, _ int) []string {
+		lo.Reduce(zoneInfo, func(agg []string, i v1.ZoneInfo, _ int) []string {
 			return append(agg, i.SubnetIDs...)
 		}, []string{}),
-		hashstructure.FormatV2,
-		&hashstructure.HashOptions{SlicesAsSets: true},
-	)
-	placementGroupPartitionsHash, _ := hashstructure.Hash(
-		it.Requirements.Get(v1.LabelPlacementGroupPartition).Values(),
 		hashstructure.FormatV2,
 		&hashstructure.HashOptions{SlicesAsSets: true},
 	)
@@ -172,18 +173,77 @@ func cacheKeyFromInstanceType(it *cloudprovider.InstanceType, nodeClass NodeClas
 		hashstructure.FormatV2,
 		&hashstructure.HashOptions{SlicesAsSets: true},
 	)
-
 	connectionTrackingHash, _ := hashstructure.Hash(nodeClass.ConnectionTracking() != nil, hashstructure.FormatV2, nil)
+	var placementGroupHash uint64
+	if pg != nil {
+		placementGroupHash, _ = hashstructure.Hash(pg.ID, hashstructure.FormatV2, nil)
+	}
 
-	return fmt.Sprintf(
-		"%s-%016x-%016x-%016x-%016x-%016x-%016x-%016x",
-		it.Name,
-		zonesHash,
-		capacityTypesHash,
-		networkInterfaceHash,
-		subnetsHash,
-		placementGroupPartitionsHash,
-		shiftedZonesHash,
-		connectionTrackingHash,
+	b := &cacheKeyBuilder{
+		baseSuffix: fmt.Sprintf(
+			"%016x-%016x-%016x-%016x-%016x",
+			networkInterfaceHash,
+			subnetsHash,
+			shiftedZonesHash,
+			connectionTrackingHash,
+			placementGroupHash,
+		),
+		capacityTypesHashes: make(map[capacityTypesKey]uint64, 4),
+	}
+	for _, hasOnDemand := range []bool{false, true} {
+		for _, hasSpot := range []bool{false, true} {
+			capacityTypes := []string{}
+			if hasOnDemand {
+				capacityTypes = append(capacityTypes, karpv1.CapacityTypeOnDemand)
+			}
+			if hasSpot {
+				capacityTypes = append(capacityTypes, karpv1.CapacityTypeSpot)
+			}
+			hash, _ := hashstructure.Hash(
+				capacityTypes,
+				hashstructure.FormatV2,
+				&hashstructure.HashOptions{SlicesAsSets: true},
+			)
+			b.capacityTypesHashes[capacityTypesKey{hasOnDemand: hasOnDemand, hasSpot: hasSpot}] = hash
+		}
+	}
+	return b
+}
+
+func (b *cacheKeyBuilder) cacheKeyFromInstanceType(it *cloudprovider.InstanceType) string {
+	zonesHash, _ := hashstructure.Hash(
+		it.Requirements.Get(corev1.LabelTopologyZone).Values(),
+		hashstructure.FormatV2,
+		&hashstructure.HashOptions{SlicesAsSets: true},
 	)
+
+	capacityTypes := it.Requirements.Get(karpv1.CapacityTypeLabelKey).Values()
+	var capacityTypesHash uint64
+	if key, ok := capacityTypesKeyFor(capacityTypes); ok {
+		capacityTypesHash = b.capacityTypesHashes[key]
+	} else {
+		// we try to use the pre-computed capacity types hash but fallback
+		// on unknown capacity type combinations (i.e. reserved)
+		capacityTypesHash, _ = hashstructure.Hash(
+			capacityTypes,
+			hashstructure.FormatV2,
+			&hashstructure.HashOptions{SlicesAsSets: true},
+		)
+	}
+	return fmt.Sprintf("%s-%016x-%016x-%s", it.Name, zonesHash, capacityTypesHash, b.baseSuffix)
+}
+
+func capacityTypesKeyFor(capacityTypes []string) (capacityTypesKey, bool) {
+	var key capacityTypesKey
+	for _, ct := range capacityTypes {
+		switch ct {
+		case karpv1.CapacityTypeOnDemand:
+			key.hasOnDemand = true
+		case karpv1.CapacityTypeSpot:
+			key.hasSpot = true
+		default:
+			return capacityTypesKey{}, false
+		}
+	}
+	return key, true
 }

--- a/pkg/providers/instancetype/offering/offering.go
+++ b/pkg/providers/instancetype/offering/offering.go
@@ -49,7 +49,15 @@ type Provider interface {
 // to each instance type. Resolvers are called in registration order, each receiving
 // the offerings produced by the previous step.
 type OfferingResolver interface {
-	ResolveOfferings(ctx context.Context, it *cloudprovider.InstanceType, offerings cloudprovider.Offerings, instanceTypeInfo ec2types.InstanceTypeInfo, nodeClass NodeClass, allZones sets.Set[string], shiftedZones sets.Set[string], pg *placementgroup.PlacementGroup) cloudprovider.Offerings
+	ResolveOfferings(ctx context.Context, it *cloudprovider.InstanceType, offerings cloudprovider.Offerings, instanceTypeInfo ec2types.InstanceTypeInfo, nodeClass NodeClass, allZones sets.Set[string], shiftedZones sets.Set[string], pg *placementgroup.PlacementGroup, rc *ResolveContext) cloudprovider.Offerings
+}
+
+// ResolveContext carries values that are computed once per InjectOfferings call and shared
+// across every instance type and resolver. Passing it explicitly (rather than recomputing it
+// inside each resolver for every instance type) avoids redundant work.
+type ResolveContext struct {
+	ZoneInfo        []v1.ZoneInfo    // NodeClass zonal information
+	cacheKeyBuilder *cacheKeyBuilder // pre-computed NodeClass cache key components
 }
 
 type NodeClass interface {
@@ -139,12 +147,18 @@ func (p *DefaultProvider) InjectOfferings(
 	var its []*cloudprovider.InstanceType
 	shiftedZones := p.zonalshiftProvider.ShiftedZones()
 
+	zoneInfo := nodeClass.ZoneInfo()
+	rc := &ResolveContext{
+		ZoneInfo:        zoneInfo,
+		cacheKeyBuilder: newCacheKeyBuilder(nodeClass, zoneInfo, shiftedZones, pg),
+	}
+
 	for _, it := range instanceTypes {
 		info := instanceTypeInfo[ec2types.InstanceType(it.Name)]
 		// Run offering resolvers in order (base → reserved → PG → extensions)
 		var offerings cloudprovider.Offerings
 		for _, resolver := range p.resolvers {
-			offerings = resolver.ResolveOfferings(ctx, it, offerings, info, nodeClass, allZones, shiftedZones, pg)
+			offerings = resolver.ResolveOfferings(ctx, it, offerings, info, nodeClass, allZones, shiftedZones, pg, rc)
 		}
 		// NOTE: By making this copy one level deep, we can modify the offerings without mutating the results from previous
 		// GetInstanceTypes calls. This should still be done with caution - it is currently done here in the provider, and

--- a/pkg/providers/instancetype/offering/placement_group_resolver.go
+++ b/pkg/providers/instancetype/offering/placement_group_resolver.go
@@ -41,6 +41,7 @@ func (r *PlacementGroupResolver) ResolveOfferings(
 	_ sets.Set[string],
 	_ sets.Set[string],
 	pg *placementgroup.PlacementGroup,
+	_ *ResolveContext,
 ) cloudprovider.Offerings {
 	if pg == nil || pg.Strategy != placementgroup.StrategyPartition {
 		return offerings

--- a/pkg/providers/instancetype/offering/reserved_capacity_resolver.go
+++ b/pkg/providers/instancetype/offering/reserved_capacity_resolver.go
@@ -54,13 +54,14 @@ func (r *ReservedCapacityResolver) ResolveOfferings(
 	allZones sets.Set[string],
 	shiftedZones sets.Set[string],
 	pg *placementgroup.PlacementGroup,
+	rc *ResolveContext,
 ) cloudprovider.Offerings {
 	if !options.FromContext(ctx).FeatureGates.ReservedCapacity {
 		return offerings
 	}
 
 	itZones := sets.New(it.Requirements.Get(corev1.LabelTopologyZone).Values()...)
-	zoneInfo := nodeClass.ZoneInfo()
+	zoneInfo := rc.ZoneInfo
 	isCompatibleWithNodeClass := compatibility.IsCompatibleWithNodeClass(instanceTypeInfo, nodeClass, pg)
 
 	capacityReservations := nodeClass.CapacityReservations()

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3553,6 +3553,7 @@ func (r *fakeOfferingResolver) ResolveOfferings(
 	_ sets.Set[string],
 	_ sets.Set[string],
 	_ *placementgroup.PlacementGroup,
+	_ *offering.ResolveContext,
 ) corecloudprovider.Offerings {
 	r.called = true
 	baseOfferings := make([]*corecloudprovider.Offering, len(offerings))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

### Description
Following up on https://github.com/aws/karpenter-provider-aws/pull/9117 after the offerings pipelines refactor.

The change:
- Refactors the offerings cache as a large portition of CPU time while provisioning is spent there:
non-instance-type granular hashes are computed once per node class, not per instance type.
pre-computes capacity type caches

### Perf Testing (Provisioning)
> 3 NodePools, 3 NodeClass, 1000 pods -> profiled 180 seconds of provisioning

#### Summary

**Note**: This is just one run. I tried to line it up with timing after controller start to ensure cache TTLs we're roughly the same.

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total CPU samples | 93.42s (51.9% util) | 47.28s (26.3% util) | ~49% less CPU |
| InjectOfferings (cum) | 50.61s | 21.91s | −28.7s (−57%) |
| BaseResolver.ResolveOfferings | 39.83s | 16.66s | −58% |
| ReservedCapacityResolver | 8.07s | 3.24s | −60% |
| cacheKeyFromInstanceType | 24.60s | 7.48s | −70% |
| EC2NodeClass.ZoneInfo | 14.61s (15.6%) | 0.04s | gone |
| hashstructure.Hash (total) | 6.92s | 1.32s | −81% |

#### Before
<img width="2559" height="607" alt="image" src="https://github.com/user-attachments/assets/66f8b285-d5ab-41de-b633-1c41eda8293e" />
<img width="1162" height="460" alt="image" src="https://github.com/user-attachments/assets/a9f56fdd-55d7-434e-bf8c-f4a8b81ff1a1" />


#### After 
<img width="2562" height="535" alt="image" src="https://github.com/user-attachments/assets/0ee610d2-9b33-422b-845b-7920c913d969" />
<img width="1167" height="459" alt="image" src="https://github.com/user-attachments/assets/b960fe65-0b0e-4a02-8d14-4de19ffeb6b3" />


### Perf Testing (Baseline)
> 3 NodePools, 3 NodeClass, 0 pods

#### Summary

Roughly ~`0.07` cores -> ~`0.04` cores (-40%)

#### Before 
<img width="1166" height="462" alt="image" src="https://github.com/user-attachments/assets/4878a33a-4444-44e1-bec1-196c1e040c99" />

#### After
<img width="1162" height="463" alt="image" src="https://github.com/user-attachments/assets/748753db-3697-4df0-97b7-3a39f8730038" />



### How was this change tested?
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.