### PR TITLE
Add memory-manager-reserved-memory to BottlerocketKubernetes settings

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocket_test.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket_test.go
@@ -15,7 +15,10 @@ limitations under the License.
 package bootstrap
 
 import (
+	"context"
 	"testing"
+
+	"github.com/samber/lo"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,6 +37,91 @@ var _ = Describe("Bottlerocket", func() {
 
 			bottlerocket = Bottlerocket{EnableDefaultMountPaths: false}
 			Expect(bottlerocket.EnableDefaultMountPaths).To(BeFalse())
+		})
+	})
+
+	Describe("MemoryManagerReservedMemory", func() {
+		It("should unmarshal memory-manager-reserved-memory from TOML", func() {
+			userData := `
+[settings.kubernetes]
+"memory-manager-policy" = "Static"
+
+[settings.kubernetes.memory-manager-reserved-memory.0]
+enabled = true
+memory = "727Mi"
+`
+			config, err := NewBottlerocketConfig(context.Background(), &userData)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Settings.Kubernetes.MemoryManagerPolicy).ToNot(BeNil())
+			Expect(*config.Settings.Kubernetes.MemoryManagerPolicy).To(Equal("Static"))
+			Expect(config.Settings.Kubernetes.MemoryManagerReservedMemory).To(HaveKey("0"))
+			Expect(config.Settings.Kubernetes.MemoryManagerReservedMemory["0"].Enabled).To(BeTrue())
+			Expect(config.Settings.Kubernetes.MemoryManagerReservedMemory["0"].Memory).To(Equal("727Mi"))
+		})
+
+		It("should unmarshal hugepages fields", func() {
+			userData := `
+[settings.kubernetes]
+"memory-manager-policy" = "Static"
+
+[settings.kubernetes.memory-manager-reserved-memory.0]
+enabled = true
+memory = "727Mi"
+hugepages-2Mi = "64Mi"
+hugepages-1Gi = "2Gi"
+`
+			config, err := NewBottlerocketConfig(context.Background(), &userData)
+			Expect(err).ToNot(HaveOccurred())
+			entry := config.Settings.Kubernetes.MemoryManagerReservedMemory["0"]
+			Expect(entry.Enabled).To(BeTrue())
+			Expect(entry.Memory).To(Equal("727Mi"))
+			Expect(entry.HugePages2Mi).To(Equal("64Mi"))
+			Expect(entry.HugePages1Gi).To(Equal("2Gi"))
+		})
+
+		It("should round-trip through marshal/unmarshal", func() {
+			userData := `
+[settings.kubernetes]
+"memory-manager-policy" = "Static"
+
+[settings.kubernetes.memory-manager-reserved-memory.0]
+enabled = true
+memory = "727Mi"
+`
+			config, err := NewBottlerocketConfig(context.Background(), &userData)
+			Expect(err).ToNot(HaveOccurred())
+
+			out, err := config.MarshalTOML()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Re-parse using UnmarshalTOML (not toml.Unmarshal) since Settings is tagged toml:"-"
+			roundTrip, err := NewBottlerocketConfig(context.Background(), lo.ToPtr(string(out)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roundTrip.Settings.Kubernetes.MemoryManagerPolicy).ToNot(BeNil())
+			Expect(*roundTrip.Settings.Kubernetes.MemoryManagerPolicy).To(Equal("Static"))
+			Expect(roundTrip.Settings.Kubernetes.MemoryManagerReservedMemory).To(HaveKey("0"))
+			Expect(roundTrip.Settings.Kubernetes.MemoryManagerReservedMemory["0"].Enabled).To(BeTrue())
+			Expect(roundTrip.Settings.Kubernetes.MemoryManagerReservedMemory["0"].Memory).To(Equal("727Mi"))
+		})
+
+		It("should support multiple NUMA nodes", func() {
+			userData := `
+[settings.kubernetes]
+"memory-manager-policy" = "Static"
+
+[settings.kubernetes.memory-manager-reserved-memory.0]
+enabled = true
+memory = "400Mi"
+
+[settings.kubernetes.memory-manager-reserved-memory.1]
+enabled = true
+memory = "327Mi"
+`
+			config, err := NewBottlerocketConfig(context.Background(), &userData)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Settings.Kubernetes.MemoryManagerReservedMemory).To(HaveLen(2))
+			Expect(config.Settings.Kubernetes.MemoryManagerReservedMemory["0"].Memory).To(Equal("400Mi"))
+			Expect(config.Settings.Kubernetes.MemoryManagerReservedMemory["1"].Memory).To(Equal("327Mi"))
 		})
 	})
 })

--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -49,58 +49,66 @@ type BottlerocketSettings struct {
 
 // BottlerocketKubernetes is k8s specific configuration for bottlerocket api
 type BottlerocketKubernetes struct {
-	APIServer                          *string                                   `toml:"api-server"`
-	CloudProvider                      *string                                   `toml:"cloud-provider"`
-	ClusterCertificate                 *string                                   `toml:"cluster-certificate"`
-	ClusterName                        *string                                   `toml:"cluster-name"`
-	ClusterDNSIP                       *string                                   `toml:"cluster-dns-ip,omitempty"`
-	CredentialProviders                map[string]BottlerocketCredentialProvider `toml:"credential-providers,omitempty"`
-	NodeLabels                         map[string]string                         `toml:"node-labels,omitempty"`
-	NodeTaints                         map[string][]string                       `toml:"node-taints,omitempty"`
-	MaxPods                            *int                                      `toml:"max-pods,omitempty"`
-	StaticPods                         map[string]BottlerocketStaticPod          `toml:"static-pods,omitempty"`
-	EvictionHard                       map[string]string                         `toml:"eviction-hard,omitempty"`
-	EvictionSoft                       map[string]string                         `toml:"eviction-soft,omitempty"`
-	EvictionSoftGracePeriod            map[string]string                         `toml:"eviction-soft-grace-period,omitempty"`
-	EvictionMaxPodGracePeriod          *int                                      `toml:"eviction-max-pod-grace-period,omitempty"`
-	KubeReserved                       map[string]string                         `toml:"kube-reserved,omitempty"`
-	SystemReserved                     map[string]string                         `toml:"system-reserved,omitempty"`
-	AllowedUnsafeSysctls               []string                                  `toml:"allowed-unsafe-sysctls,omitempty"`
-	ServerTLSBootstrap                 *bool                                     `toml:"server-tls-bootstrap,omitempty"`
-	RegistryQPS                        *int                                      `toml:"registry-qps,omitempty"`
-	RegistryBurst                      *int                                      `toml:"registry-burst,omitempty"`
-	EventQPS                           *int                                      `toml:"event-qps,omitempty"`
-	EventBurst                         *int                                      `toml:"event-burst,omitempty"`
-	KubeAPIQPS                         *int                                      `toml:"kube-api-qps,omitempty"`
-	KubeAPIBurst                       *int                                      `toml:"kube-api-burst,omitempty"`
-	ContainerLogMaxSize                *string                                   `toml:"container-log-max-size,omitempty"`
-	ContainerLogMaxFiles               *int                                      `toml:"container-log-max-files,omitempty"`
-	CPUManagerPolicy                   *string                                   `toml:"cpu-manager-policy,omitempty"`
-	CPUManagerPolicyOptions            []string                                  `toml:"cpu-manager-policy-options,omitempty"`
-	CPUManagerReconcilePeriod          *string                                   `toml:"cpu-manager-reconcile-period,omitempty"`
-	MemoryManagerPolicy                *string                                   `toml:"memory-manager-policy,omitempty"`
-	TopologyManagerScope               *string                                   `toml:"topology-manager-scope,omitempty"`
-	TopologyManagerPolicy              *string                                   `toml:"topology-manager-policy,omitempty"`
-	TopologyManagerPolicyOptions       *BottlerocketTopologyManagerPolicyOptions `toml:"topology-manager-policy-options,omitempty"`
-	ImageGCHighThresholdPercent        *string                                   `toml:"image-gc-high-threshold-percent,omitempty"`
-	ImageGCLowThresholdPercent         *string                                   `toml:"image-gc-low-threshold-percent,omitempty"`
-	IdsPerPod                          *int                                      `toml:"ids-per-pod,omitempty"`
-	CPUCFSQuota                        *bool                                     `toml:"cpu-cfs-quota-enforced,omitempty"`
-	ShutdownGracePeriod                *string                                   `toml:"shutdown-grace-period,omitempty"`
-	ShutdownGracePeriodForCriticalPods *string                                   `toml:"shutdown-grace-period-for-critical-pods,omitempty"`
-	ClusterDomain                      *string                                   `toml:"cluster-domain,omitempty"`
-	SeccompDefault                     *bool                                     `toml:"seccomp-default,omitempty"`
-	PodPidsLimit                       *int                                      `toml:"pod-pids-limit,omitempty"`
-	DeviceOwnershipFromSecurityContext *bool                                     `toml:"device-ownership-from-security-context,omitempty"`
-	SingleProcessOOMKill               *bool                                     `toml:"single-process-oom-kill,omitempty"`
-	ContainerLogMaxWorkers             *int                                      `toml:"container-log-max-workers,omitempty"`
-	ContainerLogMonitorInterval        *string                                   `toml:"container-log-monitor-interval,omitempty"`
-	HostnameOverrideSource             *string                                   `toml:"hostname-override-source,omitempty"`
-	VerbosityLevel                     *uint32                                   `toml:"log-level,omitempty"`
+	APIServer                          *string                                            `toml:"api-server"`
+	CloudProvider                      *string                                            `toml:"cloud-provider"`
+	ClusterCertificate                 *string                                            `toml:"cluster-certificate"`
+	ClusterName                        *string                                            `toml:"cluster-name"`
+	ClusterDNSIP                       *string                                            `toml:"cluster-dns-ip,omitempty"`
+	CredentialProviders                map[string]BottlerocketCredentialProvider          `toml:"credential-providers,omitempty"`
+	NodeLabels                         map[string]string                                  `toml:"node-labels,omitempty"`
+	NodeTaints                         map[string][]string                                `toml:"node-taints,omitempty"`
+	MaxPods                            *int                                               `toml:"max-pods,omitempty"`
+	StaticPods                         map[string]BottlerocketStaticPod                   `toml:"static-pods,omitempty"`
+	EvictionHard                       map[string]string                                  `toml:"eviction-hard,omitempty"`
+	EvictionSoft                       map[string]string                                  `toml:"eviction-soft,omitempty"`
+	EvictionSoftGracePeriod            map[string]string                                  `toml:"eviction-soft-grace-period,omitempty"`
+	EvictionMaxPodGracePeriod          *int                                               `toml:"eviction-max-pod-grace-period,omitempty"`
+	KubeReserved                       map[string]string                                  `toml:"kube-reserved,omitempty"`
+	SystemReserved                     map[string]string                                  `toml:"system-reserved,omitempty"`
+	AllowedUnsafeSysctls               []string                                           `toml:"allowed-unsafe-sysctls,omitempty"`
+	ServerTLSBootstrap                 *bool                                              `toml:"server-tls-bootstrap,omitempty"`
+	RegistryQPS                        *int                                               `toml:"registry-qps,omitempty"`
+	RegistryBurst                      *int                                               `toml:"registry-burst,omitempty"`
+	EventQPS                           *int                                               `toml:"event-qps,omitempty"`
+	EventBurst                         *int                                               `toml:"event-burst,omitempty"`
+	KubeAPIQPS                         *int                                               `toml:"kube-api-qps,omitempty"`
+	KubeAPIBurst                       *int                                               `toml:"kube-api-burst,omitempty"`
+	ContainerLogMaxSize                *string                                            `toml:"container-log-max-size,omitempty"`
+	ContainerLogMaxFiles               *int                                               `toml:"container-log-max-files,omitempty"`
+	CPUManagerPolicy                   *string                                            `toml:"cpu-manager-policy,omitempty"`
+	CPUManagerPolicyOptions            []string                                           `toml:"cpu-manager-policy-options,omitempty"`
+	CPUManagerReconcilePeriod          *string                                            `toml:"cpu-manager-reconcile-period,omitempty"`
+	MemoryManagerPolicy                *string                                            `toml:"memory-manager-policy,omitempty"`
+	MemoryManagerReservedMemory        map[string]BottlerocketMemoryManagerReservedMemory `toml:"memory-manager-reserved-memory,omitempty"`
+	TopologyManagerScope               *string                                            `toml:"topology-manager-scope,omitempty"`
+	TopologyManagerPolicy              *string                                            `toml:"topology-manager-policy,omitempty"`
+	TopologyManagerPolicyOptions       *BottlerocketTopologyManagerPolicyOptions          `toml:"topology-manager-policy-options,omitempty"`
+	ImageGCHighThresholdPercent        *string                                            `toml:"image-gc-high-threshold-percent,omitempty"`
+	ImageGCLowThresholdPercent         *string                                            `toml:"image-gc-low-threshold-percent,omitempty"`
+	IdsPerPod                          *int                                               `toml:"ids-per-pod,omitempty"`
+	CPUCFSQuota                        *bool                                              `toml:"cpu-cfs-quota-enforced,omitempty"`
+	ShutdownGracePeriod                *string                                            `toml:"shutdown-grace-period,omitempty"`
+	ShutdownGracePeriodForCriticalPods *string                                            `toml:"shutdown-grace-period-for-critical-pods,omitempty"`
+	ClusterDomain                      *string                                            `toml:"cluster-domain,omitempty"`
+	SeccompDefault                     *bool                                              `toml:"seccomp-default,omitempty"`
+	PodPidsLimit                       *int                                               `toml:"pod-pids-limit,omitempty"`
+	DeviceOwnershipFromSecurityContext *bool                                              `toml:"device-ownership-from-security-context,omitempty"`
+	SingleProcessOOMKill               *bool                                              `toml:"single-process-oom-kill,omitempty"`
+	ContainerLogMaxWorkers             *int                                               `toml:"container-log-max-workers,omitempty"`
+	ContainerLogMonitorInterval        *string                                            `toml:"container-log-monitor-interval,omitempty"`
+	HostnameOverrideSource             *string                                            `toml:"hostname-override-source,omitempty"`
+	VerbosityLevel                     *uint32                                            `toml:"log-level,omitempty"`
 }
 type BottlerocketStaticPod struct {
 	Enabled  *bool   `toml:"enabled,omitempty"`
 	Manifest *string `toml:"manifest,omitempty"`
+}
+
+type BottlerocketMemoryManagerReservedMemory struct {
+	Enabled      bool   `toml:"enabled"`
+	Memory       string `toml:"memory,omitempty"`
+	HugePages2Mi string `toml:"hugepages-2Mi,omitempty"`
+	HugePages1Gi string `toml:"hugepages-1Gi,omitempty"`
 }
 
 // BottlerocketCredentialProvider is k8s specific configuration for Bottlerocket Kubelet image credential provider


### PR DESCRIPTION
**Description**
Adds `memory-manager-reserved-memory` field to the `BottlerocketKubernetes` settings struct to support kubelet memory manager Static policy.

Bottlerocket supports `settings.kubernetes.memory-manager-reserved-memory`: [v1.62.0](https://bottlerocket.dev/en/os/1.62.x/api/settings/kubernetes/#memory-manager-reserved-memory). This setting configures per-NUMA-node memory reservations required when `memory-manager-policy` is set to `Static`.

Without this field in the struct, `MarshalTOML()` overwrites `SettingsRaw["kubernetes"]` with the typed struct, dropping the unknown field and causing all kubernetes settings to revert to defaults.

The Bottlerocket [settings model](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/blob/develop/bottlerocket-settings-models/modeled-types/src/kubernetes.rs) requires each entry to have an `enabled` bool and flattened limit keys (`memory`, `hugepages-2Mi`, `hugepages-1Gi`).

**How was this change tested?**
Created an `EC2NodeClass` with memory manager Static policy and reserved-memory in user-data:
```toml
[settings.kubernetes]
"memory-manager-policy" = "Static"
"topology-manager-policy" = "best-effort"

[settings.kubernetes.memory-manager-reserved-memory.0]
enabled = true
memory = "727Mi"
```

Verified via kubelet configz endpoint on launched node:
```json
{
  "memoryManagerPolicy": "Static",
  "topologyManagerPolicy": "best-effort"
}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->