### PR TITLE
chore: remove dead code and wire up unused error-code constant

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -59,7 +59,7 @@ var (
 		"UnfulfillableCapacity",
 		"Unsupported",
 		"InsufficientFreeAddressesInSubnet",
-		"MaxFleetCountExceeded",
+		MaxFleetCountExceededErrorCode,
 		reservationCapacityExceededErrorCode,
 	)
 )
@@ -263,7 +263,7 @@ func ToReasonMessage(err error) (string, string) {
 	}
 	// ICE Errors come last in this list because we should return a generic ICE error if all of the errors that are returned from
 	// fleet are ICE errors
-	if strings.Contains(err.Error(), "MaxFleetCountExceeded") {
+	if strings.Contains(err.Error(), MaxFleetCountExceededErrorCode) {
 		return "FleetQuotaExceeded", "A fleet launch was requested but this would exceed your fleet request quota"
 	}
 	if strings.Contains(err.Error(), "PendingVerification") {

--- a/pkg/providers/instancetype/offering/offering.go
+++ b/pkg/providers/instancetype/offering/offering.go
@@ -41,10 +41,6 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/providers/pricing"
 )
 
-type Provider interface {
-	InjectOfferings(context.Context, []*cloudprovider.InstanceType, *v1.EC2NodeClass, []string) []*cloudprovider.InstanceType
-}
-
 // OfferingResolver is called during InjectOfferings to append additional offerings
 // to each instance type. Resolvers are called in registration order, each receiving
 // the offerings produced by the previous step.

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -49,12 +49,6 @@ var (
 	instanceTypeScheme = regexp.MustCompile(`(^[a-z]+)(\-[0-9]+tb)?([0-9]+).*\.`)
 )
 
-type ZoneData struct {
-	Name      string
-	ID        string
-	Available bool
-}
-
 type Resolver interface {
 	// CacheKey tells the InstanceType cache if something changes about the InstanceTypes or Offerings based on the NodeClass.
 	CacheKey(NodeClass) string


### PR DESCRIPTION
**Description**

Small cleanup removing dead code found while sweeping the codebase:

1. `offering.Provider` interface (`pkg/providers/instancetype/offering/offering.go`) — never implemented (`DefaultProvider.InjectOfferings` has a different signature) and never referenced anywhere else.
2. `ZoneData` struct (`pkg/providers/instancetype/types.go`) — never instantiated or referenced anywhere.
3. `MaxFleetCountExceededErrorCode` constant (`pkg/errors/errors.go`) — defined but never referenced by name; the two places that need this value had it hardcoded as a bare string literal instead. Wired both to use the constant, matching how every other error code in this file is referenced.

No behavior change — (1) and (2) are pure removals of unreachable code, (3) replaces literal strings with the constant that already held the same value.

**How was this change tested?**

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- `go test ./pkg/providers/instance/... ./pkg/providers/instancetype/...` — all passing (75 specs across 4 packages), including the existing test that exercises the `MaxFleetCountExceeded` error path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
