### PR TITLE
docs: clarify DaemonSet overhead is used for sizing, not reserved

### DIFF
--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -131,6 +131,21 @@ spec:
 Security groups for pods are [currently unsupported for Windows nodes](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html)
 {{% /alert %}}
 
+### DaemonSet overhead
+
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
+requests, and picks an instance type large enough for the total.
+
+This overhead is only used to size the node. Karpenter does not reserve
+that capacity on the node after it joins the cluster, and it does not bind
+pods itself.
+
+{{% alert title="Note" color="primary" %}}
+To guarantee DaemonSets get their capacity, give them a
+[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+{{% /alert %}}
+
 ## Selecting nodes
 
 With `nodeSelector` you can ask for a node that matches selected key-value pairs.

--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -133,17 +133,16 @@ Security groups for pods are [currently unsupported for Windows nodes](https://d
 
 ### DaemonSet overhead
 
-When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
-requests, and picks an instance type large enough for the total.
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own requests, and picks an instance type large enough for the total.
 
-This overhead is only used to size the node. Karpenter does not reserve
-that capacity on the node after it joins the cluster, and it does not bind
-pods itself.
+This overhead is only used to size the node.
+Karpenter does not reserve that capacity on the node after it joins the cluster, and it does not bind pods itself.
 
 {{% alert title="Note" color="primary" %}}
-To guarantee DaemonSets get their capacity, give them a
-[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
-higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+Options to help DaemonSet pods get that capacity include:
+
+* [Startup taints]({{<ref "./nodepools/#spectemplatespecstartuptaints" >}}) will keep workload pods off the node until an external agent removes them, so DaemonSets that tolerate those taints will schedule first.
+* Setting a sufficiently high [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) on your DaemonSet pods will cause kube-scheduler to preempt lower-priority pods to make room for them. This is best-effort: pods of equal or higher priority will never be preempted, and PodDisruptionBudgets are only honored on a best-effort basis.
 {{% /alert %}}
 
 ## Selecting nodes

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -131,6 +131,21 @@ spec:
 Security groups for pods are [currently unsupported for Windows nodes](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html)
 {{% /alert %}}
 
+### DaemonSet overhead
+
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
+requests, and picks an instance type large enough for the total.
+
+This overhead is only used to size the node. Karpenter does not reserve
+that capacity on the node after it joins the cluster, and it does not bind
+pods itself.
+
+{{% alert title="Note" color="primary" %}}
+To guarantee DaemonSets get their capacity, give them a
+[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+{{% /alert %}}
+
 ## Selecting nodes
 
 With `nodeSelector` you can ask for a node that matches selected key-value pairs.

--- a/website/content/en/v1.0/concepts/scheduling.md
+++ b/website/content/en/v1.0/concepts/scheduling.md
@@ -123,6 +123,21 @@ spec:
 Security groups for pods are [currently unsupported for Windows nodes](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html)
 {{% /alert %}}
 
+### DaemonSet overhead
+
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
+requests, and picks an instance type large enough for the total.
+
+This overhead is only used to size the node. Karpenter does not reserve
+that capacity on the node after it joins the cluster, and it does not bind
+pods itself.
+
+{{% alert title="Note" color="primary" %}}
+To guarantee DaemonSets get their capacity, give them a
+[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+{{% /alert %}}
+
 ## Selecting nodes
 
 With `nodeSelector` you can ask for a node that matches selected key-value pairs.

--- a/website/content/en/v1.0/concepts/scheduling.md
+++ b/website/content/en/v1.0/concepts/scheduling.md
@@ -125,17 +125,16 @@ Security groups for pods are [currently unsupported for Windows nodes](https://d
 
 ### DaemonSet overhead
 
-When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
-requests, and picks an instance type large enough for the total.
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own requests, and picks an instance type large enough for the total.
 
-This overhead is only used to size the node. Karpenter does not reserve
-that capacity on the node after it joins the cluster, and it does not bind
-pods itself.
+This overhead is only used to size the node.
+Karpenter does not reserve that capacity on the node after it joins the cluster, and it does not bind pods itself.
 
 {{% alert title="Note" color="primary" %}}
-To guarantee DaemonSets get their capacity, give them a
-[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
-higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+Options to help DaemonSet pods get that capacity include:
+
+* [Startup taints]({{<ref "./nodepools/#spectemplatespecstartuptaints" >}}) will keep workload pods off the node until an external agent removes them, so DaemonSets that tolerate those taints will schedule first.
+* Setting a sufficiently high [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) on your DaemonSet pods will cause kube-scheduler to preempt lower-priority pods to make room for them. This is best-effort: pods of equal or higher priority will never be preempted, and PodDisruptionBudgets are only honored on a best-effort basis.
 {{% /alert %}}
 
 ## Selecting nodes

--- a/website/content/en/v1.12/concepts/scheduling.md
+++ b/website/content/en/v1.12/concepts/scheduling.md
@@ -131,6 +131,21 @@ spec:
 Security groups for pods are [currently unsupported for Windows nodes](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html)
 {{% /alert %}}
 
+### DaemonSet overhead
+
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
+requests, and picks an instance type large enough for the total.
+
+This overhead is only used to size the node. Karpenter does not reserve
+that capacity on the node after it joins the cluster, and it does not bind
+pods itself.
+
+{{% alert title="Note" color="primary" %}}
+To guarantee DaemonSets get their capacity, give them a
+[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+{{% /alert %}}
+
 ## Selecting nodes
 
 With `nodeSelector` you can ask for a node that matches selected key-value pairs.

--- a/website/content/en/v1.12/concepts/scheduling.md
+++ b/website/content/en/v1.12/concepts/scheduling.md
@@ -133,17 +133,16 @@ Security groups for pods are [currently unsupported for Windows nodes](https://d
 
 ### DaemonSet overhead
 
-When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
-requests, and picks an instance type large enough for the total.
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own requests, and picks an instance type large enough for the total.
 
-This overhead is only used to size the node. Karpenter does not reserve
-that capacity on the node after it joins the cluster, and it does not bind
-pods itself.
+This overhead is only used to size the node.
+Karpenter does not reserve that capacity on the node after it joins the cluster, and it does not bind pods itself.
 
 {{% alert title="Note" color="primary" %}}
-To guarantee DaemonSets get their capacity, give them a
-[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
-higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+Options to help DaemonSet pods get that capacity include:
+
+* [Startup taints]({{<ref "./nodepools/#spectemplatespecstartuptaints" >}}) will keep workload pods off the node until an external agent removes them, so DaemonSets that tolerate those taints will schedule first.
+* Setting a sufficiently high [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) on your DaemonSet pods will cause kube-scheduler to preempt lower-priority pods to make room for them. This is best-effort: pods of equal or higher priority will never be preempted, and PodDisruptionBudgets are only honored on a best-effort basis.
 {{% /alert %}}
 
 ## Selecting nodes

--- a/website/content/en/v1.13/concepts/scheduling.md
+++ b/website/content/en/v1.13/concepts/scheduling.md
@@ -131,6 +131,21 @@ spec:
 Security groups for pods are [currently unsupported for Windows nodes](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html)
 {{% /alert %}}
 
+### DaemonSet overhead
+
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
+requests, and picks an instance type large enough for the total.
+
+This overhead is only used to size the node. Karpenter does not reserve
+that capacity on the node after it joins the cluster, and it does not bind
+pods itself.
+
+{{% alert title="Note" color="primary" %}}
+To guarantee DaemonSets get their capacity, give them a
+[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+{{% /alert %}}
+
 ## Selecting nodes
 
 With `nodeSelector` you can ask for a node that matches selected key-value pairs.

--- a/website/content/en/v1.13/concepts/scheduling.md
+++ b/website/content/en/v1.13/concepts/scheduling.md
@@ -133,17 +133,16 @@ Security groups for pods are [currently unsupported for Windows nodes](https://d
 
 ### DaemonSet overhead
 
-When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
-requests, and picks an instance type large enough for the total.
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own requests, and picks an instance type large enough for the total.
 
-This overhead is only used to size the node. Karpenter does not reserve
-that capacity on the node after it joins the cluster, and it does not bind
-pods itself.
+This overhead is only used to size the node.
+Karpenter does not reserve that capacity on the node after it joins the cluster, and it does not bind pods itself.
 
 {{% alert title="Note" color="primary" %}}
-To guarantee DaemonSets get their capacity, give them a
-[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
-higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+Options to help DaemonSet pods get that capacity include:
+
+* [Startup taints]({{<ref "./nodepools/#spectemplatespecstartuptaints" >}}) will keep workload pods off the node until an external agent removes them, so DaemonSets that tolerate those taints will schedule first.
+* Setting a sufficiently high [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) on your DaemonSet pods will cause kube-scheduler to preempt lower-priority pods to make room for them. This is best-effort: pods of equal or higher priority will never be preempted, and PodDisruptionBudgets are only honored on a best-effort basis.
 {{% /alert %}}
 
 ## Selecting nodes

--- a/website/content/en/v1.14/concepts/scheduling.md
+++ b/website/content/en/v1.14/concepts/scheduling.md
@@ -131,6 +131,21 @@ spec:
 Security groups for pods are [currently unsupported for Windows nodes](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html)
 {{% /alert %}}
 
+### DaemonSet overhead
+
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
+requests, and picks an instance type large enough for the total.
+
+This overhead is only used to size the node. Karpenter does not reserve
+that capacity on the node after it joins the cluster, and it does not bind
+pods itself.
+
+{{% alert title="Note" color="primary" %}}
+To guarantee DaemonSets get their capacity, give them a
+[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+{{% /alert %}}
+
 ## Selecting nodes
 
 With `nodeSelector` you can ask for a node that matches selected key-value pairs.

--- a/website/content/en/v1.14/concepts/scheduling.md
+++ b/website/content/en/v1.14/concepts/scheduling.md
@@ -133,17 +133,16 @@ Security groups for pods are [currently unsupported for Windows nodes](https://d
 
 ### DaemonSet overhead
 
-When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own
-requests, and picks an instance type large enough for the total.
+When Karpenter calculates the size of a node for a set of pending pods, it adds the resource requests of every DaemonSet that would run on that node to the pods' own requests, and picks an instance type large enough for the total.
 
-This overhead is only used to size the node. Karpenter does not reserve
-that capacity on the node after it joins the cluster, and it does not bind
-pods itself.
+This overhead is only used to size the node.
+Karpenter does not reserve that capacity on the node after it joins the cluster, and it does not bind pods itself.
 
 {{% alert title="Note" color="primary" %}}
-To guarantee DaemonSets get their capacity, give them a
-[PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
-higher than your workloads with `preemptionPolicy: PreemptLowerPriority`.
+Options to help DaemonSet pods get that capacity include:
+
+* [Startup taints]({{<ref "./nodepools/#spectemplatespecstartuptaints" >}}) will keep workload pods off the node until an external agent removes them, so DaemonSets that tolerate those taints will schedule first.
+* Setting a sufficiently high [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) on your DaemonSet pods will cause kube-scheduler to preempt lower-priority pods to make room for them. This is best-effort: pods of equal or higher priority will never be preempted, and PodDisruptionBudgets are only honored on a best-effort basis.
 {{% /alert %}}
 
 ## Selecting nodes


### PR DESCRIPTION
Signed-off-by: Vincent Creusot <vincent.creusot@gmail.com>

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #9269  <!-- issue number -->

**Description**
Added a small paragraph explaining that Karpenter only uses the Daemonset overhead to size the nodes and do not reserve the space

**How was this change tested?**
Checked on preview

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.