### PR TITLE
fix: Spot pricing isolatedVpc fix

### DIFF
--- a/pkg/controllers/providers/pricing/suite_test.go
+++ b/pkg/controllers/providers/pricing/suite_test.go
@@ -534,4 +534,18 @@ var _ = Describe("Pricing", func() {
 			}
 		})
 	})
+	Context("Isolated VPC", func() {
+		It("should not call on demand pricing API when in isolated-vpc", func() {
+			provider := pricing.NewDefaultProvider(awsEnv.PricingAPI, awsEnv.EC2API, fake.DefaultRegion, true)
+			err := provider.UpdateOnDemandPricing(ctx)
+			Expect(err).To(BeNil())
+			Expect(awsEnv.PricingAPI.GetProductsBehavior.CalledWithInput.Len()).To(Equal(0))
+		})
+		It("should not call spot pricing API when in isolated-vpc", func() {
+			provider := pricing.NewDefaultProvider(awsEnv.PricingAPI, awsEnv.EC2API, fake.DefaultRegion, true)
+			err := provider.UpdateSpotPricing(ctx)
+			Expect(err).To(BeNil())
+			Expect(awsEnv.EC2API.DescribeSpotPriceHistoryBehavior.CalledWithInput.Len()).To(Equal(0))
+		})
+	})
 })

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -386,6 +386,13 @@ func (p *DefaultProvider) onDemandPage(ctx context.Context, output *pricing.GetP
 
 // nolint: gocyclo
 func (p *DefaultProvider) UpdateSpotPricing(ctx context.Context) error {
+	if p.isolatedVPC {
+		if p.cm.HasChanged("spot-prices", nil) {
+			log.FromContext(ctx).V(1).Info("running in an isolated VPC, spot pricing information will not be updated")
+		}
+		return nil
+	}
+
 	prices := map[ec2types.InstanceType]zonal{}
 
 	p.muSpot.Lock()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number --> #8961


**Description**
Fixes issue #8961
When isolatedVpc is set to true it disables OnDemand pricing checks but does not disable SpotPricing checks- which results in errors in air gapped aws regions.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.