### PR TITLE
ci: fix flaky should use same launch template

### DIFF
--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -369,6 +369,13 @@ var _ = Describe("LaunchTemplate Provider", func() {
 				Effect:   "NoSchedule",
 			}
 
+			// Force each pod onto its own node via hostname anti-affinity so that a multi-GPU
+			// instance type can't pack both pods together
+			antiAffinityLabels := map[string]string{"test-group": "equivalent-constraints"}
+			antiAffinity := []corev1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: antiAffinityLabels},
+				TopologyKey:   corev1.LabelHostname,
+			}}
 			// constrain the packer to a single launch template type
 			rr := corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -380,7 +387,9 @@ var _ = Describe("LaunchTemplate Provider", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod1 := coretest.UnschedulablePod(coretest.PodOptions{
+				ObjectMeta:           metav1.ObjectMeta{Labels: antiAffinityLabels},
 				Tolerations:          []corev1.Toleration{t1, t2, t3},
+				PodAntiRequirements:  antiAffinity,
 				ResourceRequirements: rr,
 			})
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod1)
@@ -393,7 +402,9 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			}
 
 			pod2 := coretest.UnschedulablePod(coretest.PodOptions{
+				ObjectMeta:           metav1.ObjectMeta{Labels: antiAffinityLabels},
 				Tolerations:          []corev1.Toleration{t2, t3, t1},
+				PodAntiRequirements:  antiAffinity,
 				ResourceRequirements: rr,
 			})
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod2)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
`LaunchTemplate Provider Cache [It] should use same launch template for equivalent constraints` has been flaky and fails at https://github.com/ryan-mist/karpenter-provider-aws/blob/main/pkg/providers/launchtemplate/suite_test.go#L402 
with:
```
  [FAILED] Expected
      <int>: 0
  to equal
      <int>: 1
```
This means that a second LT is not being created. The reason for this is the second pod is able to land of the Node provisioned for the first pod.

This change adds hostname anti-affinity to the pods so this doesn't happen


e.g. https://github.com/aws/karpenter-provider-aws/actions/runs/30474382248/job/90652294817?pr=9458
```
LaunchTemplate Provider
/home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:128
  Cache
  /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:351
    should use same launch template for equivalent constraints
    /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:352
  > Enter [BeforeEach] TOP-LEVEL - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:117 @ 07/29/26 17:19:15.545
  < Exit [BeforeEach] TOP-LEVEL - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:117 @ 07/29/26 17:19:15.546 (1ms)
  > Enter [BeforeEach] LaunchTemplate Provider - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:131 @ 07/29/26 17:19:15.546
  < Exit [BeforeEach] LaunchTemplate Provider - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:131 @ 07/29/26 17:19:15.547 (1ms)
  > Enter [It] should use same launch template for equivalent constraints - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:352 @ 07/29/26 17:19:15.547
  [FAILED] Expected
      <int>: 0
  to equal
      <int>: 1
  In [It] at: /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:402 @ 07/29/26 17:19:17.757
  < Exit [It] should use same launch template for equivalent constraints - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:352 @ 07/29/26 17:19:17.757 (2.21s)
  > Enter [AfterEach] TOP-LEVEL - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:124 @ 07/29/26 17:19:17.757
  < Exit [AfterEach] TOP-LEVEL - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:124 @ 07/29/26 17:19:17.874 (117ms)
• [FAILED] [2.329 seconds]
LaunchTemplate Provider
/home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:128
  Cache
  /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:351
    [It] should use same launch template for equivalent constraints
    /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/pkg/providers/launchtemplate/suite_test.go:352
```

Test logs show that the second pod is scheduled onto the first NodeClaim created. Therefore no second launch template is created
```
    logger.go:146: 2026-07-29T17:19:15.546Z	DEBUG	subnet/subnet.go:124	discovered subnets	{"subnets": [{"id":"subnet-test1","zone":"test-zone-1a","zoneID":"tstz1-1a"},{"id":"subnet-test2","zone":"test-zone-1b","zoneID":"tstz1-1b"},{"id":"subnet-test3","zone":"test-zone-1c","zoneID":"tstz1-1c"},{"id":"subnet-test4","zone":"test-zone-1a-local","zoneID":"tstz1-1alocal"}]}
    logger.go:146: 2026-07-29T17:19:15.606Z	DEBUG	provisioning/provisioner.go:386	computing scheduling decision for provisionable pod(s)	{"pending-pods": 1, "deleting-pods": 0}
    logger.go:146: 2026-07-29T17:19:15.608Z	INFO	provisioning/provisioner.go:445	found provisionable pod(s)	{"Pods": "default/lightervoid-247-psaxebw4cz", "duration": "2.15669ms"}
    logger.go:146: 2026-07-29T17:19:15.608Z	INFO	scheduling/scheduler.go:330	computed new nodeclaim(s) to fit pod(s)	{"nodeclaims": 1, "pods": 1}
    logger.go:146: 2026-07-29T17:19:15.621Z	INFO	provisioning/provisioner.go:485	created nodeclaim	{"NodePool": {"name":"howlerrelic-245-krjv5wrlpv"}, "NodeClaim": {"name":"howlerrelic-245-krjv5wrlpv-tqqlf"}, "requests": {"cpu":"24","nvidia.com/gpu":"1","pods":"1"}, "instance-types": "g4dn.8xlarge, g5.12xlarge, p5.48xlarge"}
    logger.go:146: 2026-07-29T17:19:15.622Z	DEBUG	launchtemplate/launchtemplate.go:286	created launch template	{"launch-template-name": "karpenter.k8s.aws/8771036225166756170", "id": ""}
    logger.go:146: 2026-07-29T17:19:15.622Z	DEBUG	launchtemplate/launchtemplate.go:286	created launch template	{"launch-template-name": "karpenter.k8s.aws/1949198251921504062", "id": ""}
    logger.go:146: 2026-07-29T17:19:15.622Z	DEBUG	launchtemplate/launchtemplate.go:286	created launch template	{"launch-template-name": "karpenter.k8s.aws/1353204573706257767", "id": ""}
    logger.go:146: 2026-07-29T17:19:16.745Z	DEBUG	provisioning/provisioner.go:386	computing scheduling decision for provisionable pod(s)	{"pending-pods": 1, "deleting-pods": 0} ### THIS POD SHOULD SCHEDULE ON DIFFERENT NODE
    logger.go:146: 2026-07-29T17:19:17.875Z	DEBUG	subnet/subnet.go:124	discovered subnets	{"subnets": [{"id":"subnet-test1","zone":"test-zone-1a","zoneID":"tstz1-1a"},{"id":"subnet-test2","zone":"test-zone-1b","zoneID":"tstz1-1b"},{"id":"subnet-test3","zone":"test-zone-1c","zoneID":"tstz1-1c"},{"id":"subnet-test4","zone":"test-zone-1a-local","zoneID":"tstz1-1alocal"}]} ### THIS IS THE NEXT TEST CASE
```



**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.