### PR TITLE
fix: degrade gracefully when zonal shift validation fails at startup

### DIFF
--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -131,10 +131,17 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		arczonalshiftAPI := arczonalshift.NewFromConfig(cfg)
 		clusterArn, err := ValidateZonalShiftEnablement(ctx, eksapi, arczonalshiftAPI)
 		if err != nil {
-			// Resource is not found/registered in Zonal Shift. Throw an error.
-			panic(fmt.Sprintf("Unable to find Cluster %v in Zonal Shift. Please check that the cluster is enabled for Zonal Shift and roles have appropriate permissions %v", clusterArn, err))
+			// Zonal shift is an optional resiliency feature. If the cluster is not
+			// registered with ARC zonal shift (or the controller role lacks
+			// arc-zonal-shift permissions), degrade to the no-op provider instead of
+			// panicking: a crash-looping controller stops all node provisioning, which
+			// is a worse availability outcome than running without zonal shift.
+			log.FromContext(ctx).Error(err, "disabling zonal shift support",
+				"hint", "register the cluster for ARC zonal shift and grant arc-zonal-shift permissions to the controller role, or set settings.enableZonalShift to false")
+			zsProvider = zonalshiftprovider.NewNoopProvider()
+		} else {
+			zsProvider = zonalshiftprovider.NewProvider(arczonalshiftAPI, operator.Clock, clusterArn)
 		}
-		zsProvider = zonalshiftprovider.NewProvider(arczonalshiftAPI, operator.Clock, clusterArn)
 	} else {
 		zsProvider = zonalshiftprovider.NewNoopProvider()
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -146,10 +146,17 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		arczonalshiftAPI := arczonalshift.NewFromConfig(cfg)
 		clusterArn, err := ValidateZonalShiftEnablement(ctx, eksapi, arczonalshiftAPI)
 		if err != nil {
-			// Resource is not found/registered in Zonal Shift. Throw an error.
-			panic(fmt.Sprintf("Unable to find Cluster %v in Zonal Shift. Please check that the cluster is enabled for Zonal Shift and roles have appropriate permissions %v", clusterArn, err))
+			// Zonal shift is an optional resiliency feature. If the cluster is not
+			// registered with ARC zonal shift (or the controller role lacks
+			// arc-zonal-shift permissions), degrade to the no-op provider instead of
+			// panicking: a crash-looping controller stops all node provisioning, which
+			// is a worse availability outcome than running without zonal shift.
+			log.FromContext(ctx).Error(err, "disabling zonal shift support",
+				"hint", "register the cluster for ARC zonal shift and grant arc-zonal-shift permissions to the controller role, or set settings.enableZonalShift to false")
+			zsProvider = zonalshiftprovider.NewNoopProvider()
+		} else {
+			zsProvider = zonalshiftprovider.NewProvider(arczonalshiftAPI, operator.Clock, clusterArn)
 		}
-		zsProvider = zonalshiftprovider.NewProvider(arczonalshiftAPI, operator.Clock, clusterArn)
 	} else {
 		zsProvider = zonalshiftprovider.NewNoopProvider()
 	}


### PR DESCRIPTION
Fixes #N/A

**Description**

When `settings.enableZonalShift` is true but the cluster is not registered with ARC zonal shift, or the controller role lacks `arc-zonal-shift:GetManagedResource`, `NewOperator` panics (`pkg/operator/operator.go:152`) and the controller crash-loops, so all node provisioning stops. The panic message also always prints an empty cluster ARN, because `ValidateZonalShiftEnablement` returns `""` on error.

The panic was a deliberate choice in #9042 review. Two things were not on the table then:

- the same API failure after startup is already tolerated: `pkg/providers/arczonalshift/arczonalshift.go:99-109` logs the hydration error and `IsZonalShifted` returns false, so the fail-fast guarantee only holds at startup;
- terraform-aws-modules/terraform-aws-eks ships `examples/karpenter` with `enableZonalShift: true` and no `zonal_shift_config` (3bc989bd75), so anyone bumping the chart from that example hits the crash loop.

This extracts the provider construction into `NewZonalShiftProvider`, logs the validation error at ERROR with the cluster name and an actionable message, and falls back to the no-op provider, matching what the provider already does at runtime. The kwok operator gets the same change. This does not touch the `eks:DescribeCluster` nil dereference in #9151; that is #9153.

**How was this change tested?**

Three new specs in `pkg/operator`: zonal shift disabled returns the no-op provider without calling ARC; a registered cluster returns the default provider and calls `GetManagedResource` once with the cluster ARN; an unregistered cluster does not panic, returns the no-op provider, and `IsZonalShifted` reports false. `go test ./pkg/operator/` passes, `go build`, `go vet` and `gofmt` are clean.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
