### PR TITLE
docs: fix security group selector example

### DIFF
--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -677,13 +677,11 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
 
 Select using multiple tag terms:

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -687,13 +687,11 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
 
 Select using multiple tag terms:

--- a/website/content/en/v1.10/concepts/nodeclasses.md
+++ b/website/content/en/v1.10/concepts/nodeclasses.md
@@ -663,13 +663,11 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
 
 Select using multiple tag terms:

--- a/website/content/en/v1.11/concepts/nodeclasses.md
+++ b/website/content/en/v1.11/concepts/nodeclasses.md
@@ -677,13 +677,11 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
 
 Select using multiple tag terms:

--- a/website/content/en/v1.12/concepts/nodeclasses.md
+++ b/website/content/en/v1.12/concepts/nodeclasses.md
@@ -677,13 +677,11 @@ spec:
         MyTag: '*'
 ```
 
-Select by name and tag (all criteria must match):
+Select by name:
 ```yaml
 spec:
   securityGroupSelectorTerms:
     - name: my-security-group
-      tags:
-        MyTag: '*' # matches all resources with the tag
 ```
 
 Select using multiple tag terms:


### PR DESCRIPTION
## Summary
- remove the misleading "name and tag" security group selector example from the nodeclasses docs
- keep the example set aligned with the actual selector behavior when `name` is used
- update the current, preview, and active versioned docs pages together

## Why
Addresses #9157. The previous example implied that `name` and `tags` were combined as AND criteria in a single term, which is misleading.

## Testing
- not run (docs-only change)