### PR TITLE
chore: add nodeclass user data size metric and better user data size error handling

### DIFF
--- a/hack/docs/metrics_gen/main.go
+++ b/hack/docs/metrics_gen/main.go
@@ -464,6 +464,7 @@ func getIdentMapping(identName string) (string, error) {
 		"cloudProviderSubsystem":       "cloudprovider",
 		"stateSubsystem":               "cluster_state",
 		"schedulerSubsystem":           "scheduler",
+		"nodeClassSubsystem":           "nodeclass",
 	}
 	if v, ok := identMapping[identName]; ok {
 		return v, nil

--- a/hack/docs/metrics_gen/main.go
+++ b/hack/docs/metrics_gen/main.go
@@ -464,7 +464,7 @@ func getIdentMapping(identName string) (string, error) {
 		"cloudProviderSubsystem":       "cloudprovider",
 		"stateSubsystem":               "cluster_state",
 		"schedulerSubsystem":           "scheduler",
-		"nodeClassSubsystem":           "nodeclass",
+		"nodeClassSubsystem":           "ec2nodeclasses",
 	}
 	if v, ok := identMapping[identName]; ok {
 		return v, nil

--- a/pkg/controllers/nodeclass/validation.go
+++ b/pkg/controllers/nodeclass/validation.go
@@ -67,12 +67,14 @@ const (
 	ConditionReasonKubeletExpressionEvalFailed    = "KubeletExpressionEvaluationFailed"
 	ConditionReasonKubeletExpressionsDisabled     = "KubeletExpressionsDisabled"
 	ConditionReasonDryRunDisabled                 = "DryRunDisabled"
+	ConditionReasonUserDataTooLarge               = "UserDataSizeLimitExceeded"
 )
 
 var ValidationConditionMessages = map[string]string{
 	ConditionReasonCreateFleetAuthFailed:          "Controller isn't authorized to call ec2:CreateFleet",
 	ConditionReasonCreateLaunchTemplateAuthFailed: "Controller isn't authorized to call ec2:CreateLaunchTemplate",
 	ConditionReasonRunInstancesAuthFailed:         "Controller isn't authorized to call ec2:RunInstances",
+	ConditionReasonUserDataTooLarge:               "ec2:CreateLaunchTemplate rejected the rendered user data as too large",
 }
 
 // validationCacheEntry stores a failed validation result with both the condition reason and the
@@ -291,6 +293,12 @@ func (v *Validation) validateCreateLaunchTemplateAuthorization(
 	if err != nil {
 		if awserrors.IsRateLimitedError(err) || awserrors.IsServerError(err) {
 			return nil, reconcile.Result{Requeue: true}, nil
+		}
+		if awserrors.IsUserDataTooLarge(err) {
+			log.FromContext(ctx).Error(err, "ec2:CreateLaunchTemplate rejected the rendered user data as exceeding the size limit")
+			_, reasonMessage := awserrors.ToReasonMessage(err)
+			v.updateCacheOnFailure(nodeClass, tags, ConditionReasonUserDataTooLarge, reasonMessage)
+			return nil, reconcile.Result{RequeueAfter: requeueAfterTime}, nil
 		}
 		if awserrors.IgnoreUnauthorizedOperationError(err) != nil {
 			// We should only ever receive UnauthorizedOperation so if we receive any other error it would be an unexpected state

--- a/pkg/controllers/nodeclass/validation_test.go
+++ b/pkg/controllers/nodeclass/validation_test.go
@@ -39,6 +39,7 @@ import (
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/controllers/nodeclass"
+	awserrors "github.com/aws/karpenter-provider-aws/pkg/errors"
 	"github.com/aws/karpenter-provider-aws/pkg/fake"
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 	"github.com/aws/karpenter-provider-aws/pkg/test"
@@ -232,6 +233,31 @@ var _ = Describe("NodeClass Validation Status Controller", func() {
 
 			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsTrue()).To(BeTrue())
 			Expect(nodeClass.StatusConditions().Get(status.ConditionReady).IsTrue()).To(BeTrue())
+		})
+	})
+	Context("UserData size", func() {
+		It("should surface an oversized user data rejection as UserDataSizeLimitExceeded", func() {
+			awsEnv.EC2API.CreateLaunchTemplateBehavior.Error.Set(&smithy.GenericAPIError{
+				Code:    awserrors.InvalidUserDataMalformedCode,
+				Message: "User data is limited to 16384 bytes",
+			})
+			ExpectApplied(ctx, env.Client, nodeClass)
+			ExpectObjectReconciled(ctx, env.Client, controller, nodeClass)
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).IsFalse()).To(BeTrue())
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).To(Equal(nodeclass.ConditionReasonUserDataTooLarge))
+		})
+		It("should not surface a non-size InvalidUserData.Malformed rejection as UserDataSizeLimitExceeded", func() {
+			// Same error code, but a format (base64) message. Mislabeling this would tell the user to shrink
+			// user data that isn't too big, so it must fall through to the unexpected-error path.
+			awsEnv.EC2API.CreateLaunchTemplateBehavior.Error.Set(&smithy.GenericAPIError{
+				Code:    awserrors.InvalidUserDataMalformedCode,
+				Message: "Invalid BASE64 encoding of user data.",
+			})
+			ExpectApplied(ctx, env.Client, nodeClass)
+			Expect(ExpectObjectReconcileFailed(ctx, env.Client, controller, nodeClass)).To(HaveOccurred())
+			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
+			Expect(nodeClass.StatusConditions().Get(v1.ConditionTypeValidationSucceeded).Reason).ToNot(Equal(nodeclass.ConditionReasonUserDataTooLarge))
 		})
 	})
 	Context("Kubelet Expression Validation", func() {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -32,6 +32,7 @@ const (
 	ServiceLinkedRoleCreationNotPermittedErrorCode = "AuthFailure.ServiceLinkedRoleCreationNotPermitted"
 	InsufficientFreeAddressesInSubnetErrorCode     = "InsufficientFreeAddressesInSubnet"
 	MaxFleetCountExceededErrorCode                 = "MaxFleetCountExceeded"
+	InvalidUserDataMalformedCode                   = "InvalidUserData.Malformed"
 )
 
 var (
@@ -218,6 +219,16 @@ func IsInstanceProfileNotFound(err error) bool {
 	return false
 }
 
+func IsUserDataTooLarge(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apiErr, ok := lo.ErrorsAs[smithy.APIError](err); ok {
+		return apiErr.ErrorCode() == InvalidUserDataMalformedCode && strings.Contains(apiErr.ErrorMessage(), "User data is limited to")
+	}
+	return false
+}
+
 // ToReasonMessage converts an error message from AWS into a well-known condition reason
 // and well-known condition message that can be used for Launch failure classification
 // nolint:gocyclo
@@ -245,6 +256,9 @@ func ToReasonMessage(err error) (string, string) {
 	}
 	if strings.Contains(err.Error(), "InvalidLaunchTemplateId.NotFound") {
 		return "LaunchTemplateNotFound", "Launch template used for instance launch wasn't found"
+	}
+	if IsUserDataTooLarge(err) || strings.Contains(err.Error(), "User data is limited to") {
+		return "UserDataSizeLimitExceeded", "Rendered user data exceeds the EC2 user data size limit"
 	}
 	if strings.Contains(err.Error(), "InvalidAMIID.Malformed") {
 		return "InvalidAMIID", "AMI used for instance launch is invalid"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -257,7 +257,7 @@ func ToReasonMessage(err error) (string, string) {
 	if strings.Contains(err.Error(), "InvalidLaunchTemplateId.NotFound") {
 		return "LaunchTemplateNotFound", "Launch template used for instance launch wasn't found"
 	}
-	if IsUserDataTooLarge(err) || strings.Contains(err.Error(), "User data is limited to") {
+	if strings.Contains(err.Error(), "User data is limited to") {
 		return "UserDataSizeLimitExceeded", "Rendered user data exceeds the EC2 user data size limit"
 	}
 	if strings.Contains(err.Error(), "InvalidAMIID.Malformed") {

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -16,6 +16,7 @@ package launchtemplate
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"net"
@@ -278,6 +279,14 @@ func (p *DefaultProvider) createLaunchTemplate(ctx context.Context, options *ami
 	if err != nil {
 		return ec2types.LaunchTemplate{}, err
 	}
+	// EC2 enforces its limit against the decoded bytes, so measure those rather than the base64 string.
+	if raw, err := base64.StdEncoding.DecodeString(userData); err == nil {
+		UserDataBytes.Set(float64(len(raw)), map[string]string{nodeClassLabel: options.NodeClassName})
+		if len(raw) >= userDataWarnBytes {
+			log.FromContext(ctx).Info("rendered user data is approaching the EC2 user data size limit",
+				"userdata-bytes", len(raw), "warn-threshold", userDataWarnBytes, "limit", userDataMaxBytes)
+		}
+	}
 	createLaunchTemplateInput := NewCreateLaunchTemplateInputBuilder(options, p.ClusterIPFamily, userData).WithLaunchModeProvider(p).Build(ctx)
 	output, err := p.ec2api.CreateLaunchTemplate(ctx, createLaunchTemplateInput)
 	if err != nil {
@@ -519,6 +528,7 @@ func (p *DefaultProvider) DeleteAll(ctx context.Context, nodeClass *v1.EC2NodeCl
 	if len(ltNames) > 0 {
 		log.FromContext(ctx).WithValues("launchTemplates", utils.PrettySlice(lo.FromSlicePtr(ltNames), 5)).V(1).Info("deleted launch templates")
 	}
+	UserDataBytes.Delete(map[string]string{nodeClassLabel: nodeClass.Name})
 	if deleteErr != nil {
 		return fmt.Errorf("deleting launch templates, %w", deleteErr)
 	}

--- a/pkg/providers/launchtemplate/metrics.go
+++ b/pkg/providers/launchtemplate/metrics.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	nodeClassSubsystem = "nodeclass"
+	nodeClassSubsystem = "ec2nodeclasses"
 	nodeClassLabel     = "nodeclass"
 	// userDataMaxBytes is the ec2:CreateLaunchTemplate user data limit. EC2 is the authority here — we
 	// never gate provisioning on this locally, we only warn as it's approached so growth (cert bundles,
@@ -33,10 +33,12 @@ const (
 )
 
 var (
-	// UserDataBytes is recorded when the user data is rendered, just before ec2:CreateLaunchTemplate — so
-	// an oversized rendering is reported even though EC2 rejects the create, which is when the size matters
-	// most. The launch template name is a hash that includes the user data, so any change to the rendered
-	// user data produces a new launch template and refreshes this gauge.
+	// UserDataBytes is recorded when the user data is rendered, just before ec2:CreateLaunchTemplate, so an
+	// oversized rendering is still reported even though EC2 rejects the create. Only the create path writes
+	// the gauge, which stays current because launch templates are deleted from EC2 when their cache entry
+	// expires (cache.DefaultTTL), so the next EnsureAll re-creates and re-measures. A NodeClass has no series
+	// until it reaches this path — notably when dry-run validation is disabled, nothing calls EnsureAll until
+	// a node actually launches.
 	UserDataBytes = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
 		prometheus.GaugeOpts{

--- a/pkg/providers/launchtemplate/metrics.go
+++ b/pkg/providers/launchtemplate/metrics.go
@@ -33,9 +33,10 @@ const (
 )
 
 var (
-	// UserDataBytes is recorded when a launch template is created, which is the only time the user data
-	// is rendered. The launch template name is a hash that includes the user data, so any change to the
-	// rendered user data produces a new launch template and refreshes this gauge.
+	// UserDataBytes is recorded when the user data is rendered, just before ec2:CreateLaunchTemplate — so
+	// an oversized rendering is reported even though EC2 rejects the create, which is when the size matters
+	// most. The launch template name is a hash that includes the user data, so any change to the rendered
+	// user data produces a new launch template and refreshes this gauge.
 	UserDataBytes = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
 		prometheus.GaugeOpts{

--- a/pkg/providers/launchtemplate/metrics.go
+++ b/pkg/providers/launchtemplate/metrics.go
@@ -1,0 +1,51 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launchtemplate
+
+import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/karpenter/pkg/metrics"
+)
+
+const (
+	nodeClassSubsystem = "nodeclass"
+	nodeClassLabel     = "nodeclass"
+	// userDataMaxBytes is the ec2:CreateLaunchTemplate user data limit. EC2 is the authority here — we
+	// never gate provisioning on this locally, we only warn as it's approached so growth (cert bundles,
+	// custom user data) is visible before the hard rejection.
+	userDataMaxBytes  = 16384
+	userDataWarnBytes = userDataMaxBytes * 9 / 10
+)
+
+var (
+	// UserDataBytes is recorded when a launch template is created, which is the only time the user data
+	// is rendered. The launch template name is a hash that includes the user data, so any change to the
+	// rendered user data produces a new launch template and refreshes this gauge.
+	UserDataBytes = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: nodeClassSubsystem,
+			Name:      "userdata_bytes",
+			Help:      "Size in bytes of the rendered user data (raw, pre-base64) for the EC2NodeClass",
+		},
+		[]string{
+			nodeClassLabel,
+		},
+	)
+)

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1157,7 +1157,7 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 
-			m, ok := FindMetricWithLabelValues("karpenter_nodeclass_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
+			m, ok := FindMetricWithLabelValues("karpenter_ec2nodeclasses_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
 			Expect(ok).To(BeTrue())
 			// The gauge measures raw pre-base64 bytes, so it must match the decoded user data EC2 was sent
 			// rather than the encoded string. A NodeClass renders one launch template per max-pods value,
@@ -1173,13 +1173,13 @@ var _ = Describe("LaunchTemplate Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			_, ok := FindMetricWithLabelValues("karpenter_nodeclass_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
+			_, ok := FindMetricWithLabelValues("karpenter_ec2nodeclasses_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
 			Expect(ok).To(BeTrue())
 
 			Expect(awsEnv.LaunchTemplateProvider.DeleteAll(ctx, nodeClass)).To(Succeed())
 			// The series is removed rather than zeroed, so a deleted NodeClass doesn't look like one with
 			// empty user data.
-			_, ok = FindMetricWithLabelValues("karpenter_nodeclass_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
+			_, ok = FindMetricWithLabelValues("karpenter_ec2nodeclasses_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
 			Expect(ok).To(BeFalse())
 		})
 		It("should specify --use-max-pods=false when using ENI-based pod density", func() {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1151,6 +1151,37 @@ var _ = Describe("LaunchTemplate Provider", func() {
 		})
 	})
 	Context("User Data", func() {
+		It("should record the rendered user data size, keyed by nodeclass", func() {
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			m, ok := FindMetricWithLabelValues("karpenter_nodeclass_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
+			Expect(ok).To(BeTrue())
+			// The gauge measures raw pre-base64 bytes, so it must match the decoded user data EC2 was sent
+			// rather than the encoded string. A NodeClass renders one launch template per max-pods value,
+			// so the gauge holds one of their sizes — assert membership rather than a specific template.
+			sizes := lo.Map(ExpectUserDataExistsFromCreatedLaunchTemplates(), func(ud string, _ int) float64 {
+				return float64(len(ud))
+			})
+			Expect(m.GetGauge().GetValue()).To(BeElementOf(sizes))
+			Expect(m.GetGauge().GetValue()).To(BeNumerically("<", 16384))
+		})
+		It("should delete the user data gauge when the nodeclass launch templates are deleted", func() {
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+			_, ok := FindMetricWithLabelValues("karpenter_nodeclass_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
+			Expect(ok).To(BeTrue())
+
+			Expect(awsEnv.LaunchTemplateProvider.DeleteAll(ctx, nodeClass)).To(Succeed())
+			// The series is removed rather than zeroed, so a deleted NodeClass doesn't look like one with
+			// empty user data.
+			_, ok = FindMetricWithLabelValues("karpenter_nodeclass_userdata_bytes", map[string]string{"nodeclass": nodeClass.Name})
+			Expect(ok).To(BeFalse())
+		})
 		It("should specify --use-max-pods=false when using ENI-based pod density", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1.AMISelectorTerm{{Alias: "al2@latest"}}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -344,12 +344,6 @@ Total cost of the nodepool from Karpenter's perspective. Units are determined by
 The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
 - Stability Level: ALPHA
 
-## Nodeclass Metrics
-
-### `karpenter_nodeclass_userdata_bytes`
-Size in bytes of the rendered user data (raw, pre-base64) for the EC2NodeClass
-- Stability Level: ALPHA
-
 ## Interruption Metrics
 
 ### `karpenter_interruption_received_messages_total`
@@ -367,6 +361,12 @@ Count of unique unhealthy instance statuses detected from EC2 DescribeInstanceSt
 ### `karpenter_interruption_deleted_messages_total`
 Count of messages deleted from the SQS queue.
 - Stability Level: STABLE
+
+## EC2NodeClasses Metrics
+
+### `karpenter_ec2nodeclasses_userdata_bytes`
+Size in bytes of the rendered user data (raw, pre-base64) for the EC2NodeClass
+- Stability Level: ALPHA
 
 ## Cluster Metrics
 

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -344,6 +344,12 @@ Total cost of the nodepool from Karpenter's perspective. Units are determined by
 The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.
 - Stability Level: ALPHA
 
+## Nodeclass Metrics
+
+### `karpenter_nodeclass_userdata_bytes`
+Size in bytes of the rendered user data (raw, pre-base64) for the EC2NodeClass
+- Stability Level: ALPHA
+
 ## Interruption Metrics
 
 ### `karpenter_interruption_received_messages_total`


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

add new error handling for ec2 user data size limit exceeded in nodeclass
- also adds logging for when close to limit

add new metric on ec2 user data size per nodeclass

**How was this change tested?**

deployed to test cluster and can see the metric

**AI Disclosure**

I used an LLM to parallel program with me. This included:

- First draft of code changes (edited by me)
- Helping me setup the in cluster testing


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.