### PR TITLE
fix: migrate mergo imports to dario.cat/mergo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws/karpenter-provider-aws
 go 1.26.5
 
 require (
+	dario.cat/mergo v1.0.2
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -29,7 +30,6 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/cel-go v0.29.2
 	github.com/google/uuid v1.6.0
-	github.com/imdario/mergo v0.3.16
 	github.com/jonathan-innis/aws-sdk-go-prometheus v0.1.1
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.32.0
@@ -98,6 +98,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00lCDlaYPg=

--- a/pkg/apis/v1/ec2nodeclass_hash_test.go
+++ b/pkg/apis/v1/ec2nodeclass_hash_test.go
@@ -15,7 +15,7 @@ limitations under the License.
 package v1_test
 
 import (
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1/ec2nodeclass_validation_cel_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -37,8 +37,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"dario.cat/mergo"
 	opstatus "github.com/awslabs/operatorpkg/status"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-provider-aws/pkg/apis"

--- a/pkg/controllers/capacityreservation/expiration/suite_test.go
+++ b/pkg/controllers/capacityreservation/expiration/suite_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/awslabs/operatorpkg/option"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 	"k8s.io/client-go/tools/record"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"

--- a/pkg/controllers/nodeclass/hash/suite_test.go
+++ b/pkg/controllers/nodeclass/hash/suite_test.go
@@ -22,8 +22,8 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 
+	"dario.cat/mergo"
 	"github.com/awslabs/operatorpkg/object"
-	"github.com/imdario/mergo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"

--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/awslabs/operatorpkg/option"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 
+	"dario.cat/mergo"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/arczonalshift"
 	arczonalshifttypes "github.com/aws/aws-sdk-go-v2/service/arczonalshift/types"
@@ -34,7 +35,6 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/awslabs/operatorpkg/object"
 	"github.com/awslabs/operatorpkg/status"
-	"github.com/imdario/mergo"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -17,7 +17,7 @@ package test
 import (
 	"fmt"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	corev1 "k8s.io/api/core/v1"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-provider-aws/pkg/operator/options"

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -17,9 +17,9 @@ package test
 import (
 	"fmt"
 
+	"dario.cat/mergo"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/imdario/mergo"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/samber/lo"


### PR DESCRIPTION
Fixes #9294

**Description**

Mergo's canonical module path is now `dario.cat/mergo`. This repo still imported `github.com/imdario/mergo`, which breaks `go mod tidy` for consumers that pull this module (module path mismatch at v1.x).

Update all direct imports to `dario.cat/mergo` and require `dario.cat/mergo v1.0.2`. `github.com/imdario/mergo` remains only as an indirect dependency via `sigs.k8s.io/karpenter`.

**How was this change tested?**

- `go mod tidy` succeeds
- `go build ./pkg/providers/amifamily/... ./pkg/providers/instance/ ./pkg/test/`
- `go test -c` for `./pkg/apis/v1/` and `./pkg/providers/amifamily/bootstrap/`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Made with [Cursor](https://cursor.com)