### PR TITLE
docs: fix invalid eksctl flag in Zonal Shift onboarding

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
@@ -204,7 +204,7 @@ You can optionally enable the Zonal Shift integration with Karpenter which provi
 To do this, the EKS cluster must first be enabled for Zonal Shift. This can be done through the AWS Console, AWS CLI, or `eksctl`. For step-by-step instructions, see [Enable EKS zonal shift](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift-enable.html).
 
 ```bash
-eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
 ```
 
 Once the cluster has been enabled for Zonal Shift, you can use Zonal Shift controls to shift traffic and scaling operations. For more details see the [guide on using Zonal Shift with EKS.](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift.html) 
@@ -238,7 +238,7 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash
-    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
     ```
 
 3. **Enable Zonal Shift in Karpenter** by upgrading the Helm release with the `settings.enableZonalShift` value:

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -204,7 +204,7 @@ You can optionally enable the Zonal Shift integration with Karpenter which provi
 To do this, the EKS cluster must first be enabled for Zonal Shift. This can be done through the AWS Console, AWS CLI, or `eksctl`. For step-by-step instructions, see [Enable EKS zonal shift](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift-enable.html).
 
 ```bash
-eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
 ```
 
 Once the cluster has been enabled for Zonal Shift, you can use Zonal Shift controls to shift traffic and scaling operations. For more details see the [guide on using Zonal Shift with EKS.](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift.html) 
@@ -238,7 +238,7 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash
-    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
     ```
 
 3. **Enable Zonal Shift in Karpenter** by upgrading the Helm release with the `settings.enableZonalShift` value:

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
@@ -204,7 +204,7 @@ You can optionally enable the Zonal Shift integration with Karpenter which provi
 To do this, the EKS cluster must first be enabled for Zonal Shift. This can be done through the AWS Console, AWS CLI, or `eksctl`. For step-by-step instructions, see [Enable EKS zonal shift](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift-enable.html).
 
 ```bash
-eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
 ```
 
 Once the cluster has been enabled for Zonal Shift, you can use Zonal Shift controls to shift traffic and scaling operations. For more details see the [guide on using Zonal Shift with EKS.](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift.html) 
@@ -238,7 +238,7 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash
-    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
     ```
 
 3. **Enable Zonal Shift in Karpenter** by upgrading the Helm release with the `settings.enableZonalShift` value:

--- a/website/content/en/v1.13/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.13/getting-started/getting-started-with-karpenter/_index.md
@@ -204,7 +204,7 @@ You can optionally enable the Zonal Shift integration with Karpenter which provi
 To do this, the EKS cluster must first be enabled for Zonal Shift. This can be done through the AWS Console, AWS CLI, or `eksctl`. For step-by-step instructions, see [Enable EKS zonal shift](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift-enable.html).
 
 ```bash
-eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
 ```
 
 Once the cluster has been enabled for Zonal Shift, you can use Zonal Shift controls to shift traffic and scaling operations. For more details see the [guide on using Zonal Shift with EKS.](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift.html) 
@@ -238,7 +238,7 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash
-    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
     ```
 
 3. **Enable Zonal Shift in Karpenter** by upgrading the Helm release with the `settings.enableZonalShift` value:

--- a/website/content/en/v1.14/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.14/getting-started/getting-started-with-karpenter/_index.md
@@ -204,7 +204,7 @@ You can optionally enable the Zonal Shift integration with Karpenter which provi
 To do this, the EKS cluster must first be enabled for Zonal Shift. This can be done through the AWS Console, AWS CLI, or `eksctl`. For step-by-step instructions, see [Enable EKS zonal shift](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift-enable.html).
 
 ```bash
-eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
 ```
 
 Once the cluster has been enabled for Zonal Shift, you can use Zonal Shift controls to shift traffic and scaling operations. For more details see the [guide on using Zonal Shift with EKS.](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift.html) 
@@ -238,7 +238,7 @@ If you are upgrading an existing Karpenter installation to v1.12.0+ and want to 
 2. **Enable Zonal Shift on the EKS cluster** if not already enabled:
 
     ```bash
-    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled
+    eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enable-zonal-shift=true
     ```
 
 3. **Enable Zonal Shift in Karpenter** by upgrading the Helm release with the `settings.enableZonalShift` value:


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
`eksctl utils update-zonal-shift-config` has no `--enabled` flag; running the documented command fails with "unknown flag: --enabled". Use `--enable-zonal-shift=true` instead

**How was this change tested?**
```
eksctl utils update-zonal-shift-config --cluster=${CLUSTER_NAME} --enabled

Error: unknown flag: --enabled

eksctl utils update-zonal-shift-config \
  --cluster=${CLUSTER_NAME} \
  --enable-zonal-shift=true
2026-08-10 14:03:42 [ℹ]  zonal shift is already enabled

```

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.