### PR TITLE
chore: override NodeClaim launch timeout to 45s

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -15,6 +15,8 @@ limitations under the License.
 package main
 
 import (
+	"time"
+
 	v1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider"
 	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider/registrationhooks"
@@ -24,10 +26,17 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/overlay"
 	corecontrollers "sigs.k8s.io/karpenter/pkg/controllers"
+	nodeclaimlifecycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	coreoperator "sigs.k8s.io/karpenter/pkg/operator"
 	karpoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 )
+
+func init() {
+	// Override the upstream NodeClaim launch timeout. If an instance doesn't launch
+	// within this window, the NodeClaim is deleted and launch is retried.
+	nodeclaimlifecycle.LaunchTimeout = 45 * time.Second
+}
 
 func main() {
 	ctx, op := operator.NewOperator(coreoperator.NewOperator())


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Sets the upstream nodeclaim lifecycle `LaunchTimeout` to 45 seconds on startup via an `init()` in the controller entrypoint. The upstream default is 5 minutes; this shortens the window before an unlaunched NodeClaim is deleted and retried.

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.