### PR TITLE
docs: fix example-text mismatch in Min Values section

### DIFF
--- a/website/content/en/docs/concepts/nodepools.md
+++ b/website/content/en/docs/concepts/nodepools.md
@@ -300,7 +300,7 @@ There is currently a limit of 100 on the total number of requirements on both th
 Along with the combination of [key,operator,values] in the requirements, Karpenter also supports `minValues` in the NodePool requirements block, allowing the scheduler to be aware of user-specified flexibility minimums while scheduling pods to a cluster. Depending on the policy configured via the flag `--min-values-policy` or environment variable `MIN_VALUES_POLICY`, if Karpenter cannot meet this minimum flexibility for each key when scheduling a pod, it will either fail the scheduling loop for that NodePool, either falling back to another NodePool which meets the pod requirements or failing scheduling the pod altogether (when policy is set to `Strict`) or relax `minValues` until they can be met (when policy is set to `BestEffort`).
 
 For spot instances, you should specify `karpenter.sh/capacity-type: spot` in your requirements. For example, the below spec will use spot instance type for all provisioned instances and enforces `minValues` to various keys where it is defined
-i.e at least 2 unique instance categories from [c,m,r], 5 unique instance families [eg: "m5","m5d","r4","c5","c5d","c4" etc], 10 unique instance types [eg: "c5.2xlarge","c4.xlarge" etc] are required for scheduling the pods.
+i.e at least 2 unique instance categories from [c,m,r], at least 5 unique instance families (from any family that meets the other requirements), 10 unique instance types [eg: "c5.2xlarge","c4.xlarge" etc] are required for scheduling the pods.
 
 ```yaml
 spec:


### PR DESCRIPTION
## What this PR does

The Min Values section of the NodePools documentation had a mismatch between the descriptive text and the YAML example.

**Before:** The text described specific instance families like `["m5","m5d","r4","c5","c5d","c4" etc]`, but the example used `operator: Exists` without listing any values.

**After:** Updated the text to say "at least 5 unique instance families (from any family that meets the other requirements)", which correctly matches the `operator: Exists` in the example.

Fixes kubernetes-sigs/karpenter#2548