### PR TITLE
fix: evict stale instance cache entries in List() (#9242)

### DIFF
--- a/kwok/operator/operator.go
+++ b/kwok/operator/operator.go
@@ -223,13 +223,10 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		placementGroupProvider,
 		zsProvider,
 		// Instance cache entries never expire. The cache is actively refreshed by the garbage
-		// collection controller's List() every 2 minutes, and entries are explicitly removed
-		// when Get() returns NotFound from EC2. NoExpiration ensures cached instances in zonally
-		// shifted AZs remain available for the zonal shift guards in Get(), Delete(), and
-		// CreateTags(), even if List() cannot return instances from the impaired AZ.
-		// TODO: Add a cache garbage collector that reconciles entries against EC2 and the API
-		// server, evicting entries for instances that no longer exist in either. Note: removing
-		// NodeClaim finalizers to bypass Karpenter's lifecycle management is not supported.
+		// collection controller's List() every 2 minutes, and stale entries are evicted by
+		// List() for instances no longer returned by EC2. NoExpiration ensures cached instances
+		// in zonally shifted AZs remain available for the zonal shift guards in Get(), Delete(),
+		// and CreateTags(), even if List() cannot return instances from the impaired AZ.
 		cache.New(cache.NoExpiration, cache.NoExpiration),
 	)
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -239,13 +239,10 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		placementGroupProvider,
 		zsProvider,
 		// Instance cache entries never expire. The cache is actively refreshed by the garbage
-		// collection controller's List() every 2 minutes, and entries are explicitly removed
-		// when Get() returns NotFound from EC2. NoExpiration ensures cached instances in zonally
-		// shifted AZs remain available for the zonal shift guards in Get(), Delete(), and
-		// CreateTags(), even if List() cannot return instances from the impaired AZ.
-		// TODO: Add a cache garbage collector that reconciles entries against EC2 and the API
-		// server, evicting entries for instances that no longer exist in either. Note: removing
-		// NodeClaim finalizers to bypass Karpenter's lifecycle management is not supported.
+		// collection controller's List() every 2 minutes, and stale entries are evicted by
+		// List() for instances no longer returned by EC2. NoExpiration ensures cached instances
+		// in zonally shifted AZs remain available for the zonal shift guards in Get(), Delete(),
+		// and CreateTags(), even if List() cannot return instances from the impaired AZ.
 		cache.New(cache.NoExpiration, cache.NoExpiration),
 	)
 	instanceStatusProvider := instancestatus.NewDefaultProvider(ec2api, operator.Clock)

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -212,8 +212,8 @@ func (p *DefaultProvider) Get(ctx context.Context, id string, opts ...Options) (
 	if len(instances) != 1 {
 		return nil, fmt.Errorf("expected a single instance, %w", err)
 	}
-	p.instanceCache.SetDefault(id, instances[0])
-	return instances[0], nil
+	p.instanceCache.SetDefault(id, instances[id])
+	return instances[id], nil
 }
 
 func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
@@ -247,10 +247,21 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 		out.Reservations = append(out.Reservations, page.Reservations...)
 	}
 	instances, err := instancesFromOutput(ctx, out)
-	for _, it := range instances {
-		p.instanceCache.SetDefault(it.ID, it)
+	for id, it := range instances {
+		p.instanceCache.SetDefault(id, it)
 	}
-	return instances, cloudprovider.IgnoreNodeClaimNotFoundError(err)
+	// Evict cached entries for instances no longer returned by EC2, unless they are in a
+	// zonally-shifted AZ where DescribeInstances may not return them.
+	for id, item := range p.instanceCache.Items() {
+		if _, live := instances[id]; live {
+			continue
+		}
+		if inst, ok := item.Object.(*Instance); ok && inst.ZoneID != "" && p.zonalshiftProvider.IsZonalShifted(ctx, inst.ZoneID) {
+			continue
+		}
+		p.instanceCache.Delete(id)
+	}
+	return lo.Values(instances), cloudprovider.IgnoreNodeClaimNotFoundError(err)
 }
 
 func (p *DefaultProvider) Delete(ctx context.Context, id string) error {
@@ -769,7 +780,7 @@ func getCapacityReservationInterruptible(instanceTypes []*cloudprovider.Instance
 	return false
 }
 
-func instancesFromOutput(ctx context.Context, out *ec2.DescribeInstancesOutput) ([]*Instance, error) {
+func instancesFromOutput(ctx context.Context, out *ec2.DescribeInstancesOutput) (map[string]*Instance, error) {
 	if len(out.Reservations) == 0 {
 		return nil, cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("instance not found"))
 	}
@@ -779,11 +790,10 @@ func instancesFromOutput(ctx context.Context, out *ec2.DescribeInstancesOutput) 
 	if len(instances) == 0 {
 		return nil, cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("instance not found"))
 	}
-	// Get a consistent ordering for instances
-	sort.Slice(instances, func(i, j int) bool {
-		return aws.ToString(instances[i].InstanceId) < aws.ToString(instances[j].InstanceId)
-	})
-	return lo.Map(instances, func(i ec2types.Instance, _ int) *Instance { return NewInstance(ctx, i) }), nil
+	return lo.SliceToMap(instances, func(i ec2types.Instance) (string, *Instance) {
+		inst := NewInstance(ctx, i)
+		return inst.ID, inst
+	}), nil
 }
 
 func combineFleetErrors(fleetErrs []ec2types.CreateFleetError) (errs error) {

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -1079,4 +1079,84 @@ var _ = Describe("InstanceProvider", func() {
 			})
 		})
 	})
+	Context("Cache Eviction", func() {
+		It("should evict cached instances that are no longer returned by List", func() {
+			// Store an instance in EC2 with the required tags for List() to find it
+			ec2Instance := test.EC2Instance(ec2types.Instance{
+				Placement: &ec2types.Placement{
+					AvailabilityZone:   aws.String("test-zone-1a"),
+					AvailabilityZoneId: aws.String("tstz1-1a"),
+				},
+				Tags: []ec2types.Tag{
+					{Key: aws.String(v1.NodePoolTagKey), Value: aws.String("default")},
+					{Key: aws.String(v1.LabelNodeClass), Value: aws.String("default")},
+					{Key: aws.String(v1.EKSClusterNameTagKey), Value: aws.String(options.FromContext(ctx).ClusterName)},
+				},
+			})
+			id := aws.ToString(ec2Instance.InstanceId)
+			awsEnv.EC2API.Instances.Store(id, ec2Instance)
+
+			// Populate the cache via Get
+			inst, err := awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inst.ID).To(Equal(id))
+
+			// Remove the instance from EC2 (simulates spot reclaim)
+			awsEnv.EC2API.Instances.Delete(id)
+
+			// Call List — this should evict the stale cache entry
+			_, err = awsEnv.InstanceProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Now Get without SkipCache should go to EC2 and return NotFound
+			_, err = awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).To(HaveOccurred())
+			Expect(corecloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
+		})
+		It("should not evict cached instances in a zonally shifted AZ when not returned by List", func() {
+			// Store an instance in the shifted zone and populate the cache
+			ec2Instance := test.EC2Instance(ec2types.Instance{
+				Placement: &ec2types.Placement{
+					AvailabilityZone:   aws.String("test-zone-1a"),
+					AvailabilityZoneId: aws.String("tstz1-1a"),
+				},
+				Tags: []ec2types.Tag{
+					{Key: aws.String(v1.NodePoolTagKey), Value: aws.String("default")},
+					{Key: aws.String(v1.LabelNodeClass), Value: aws.String("default")},
+					{Key: aws.String(v1.EKSClusterNameTagKey), Value: aws.String(options.FromContext(ctx).ClusterName)},
+				},
+			})
+			id := aws.ToString(ec2Instance.InstanceId)
+			awsEnv.EC2API.Instances.Store(id, ec2Instance)
+
+			// Populate the cache via Get
+			inst, err := awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inst.ID).To(Equal(id))
+
+			// Remove the instance from EC2
+			awsEnv.EC2API.Instances.Delete(id)
+
+			// Activate a zonal shift for tstz1-1a
+			awsEnv.ARCZonalShiftAPI.GetManagedResourceBehavior.Output.Set(&arczonalshift.GetManagedResourceOutput{
+				ZonalShifts: []arczonalshifttypes.ZonalShiftInResource{
+					{
+						AwayFrom:      aws.String("tstz1-1a"),
+						ExpiryTime:    aws.Time(time.Now().Add(time.Hour)),
+						AppliedStatus: arczonalshifttypes.AppliedStatusApplied,
+					},
+				},
+			})
+			Expect(awsEnv.ZonalShiftProvider.UpdateZonalShifts(ctx)).To(Succeed())
+
+			// List should NOT evict because the zone is shifted
+			_, err = awsEnv.InstanceProvider.List(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get without SkipCache should still return the cached instance
+			inst, err = awsEnv.InstanceProvider.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inst.ID).To(Equal(id))
+		})
+	})
 })


### PR DESCRIPTION
(cherry picked from commit 0b0cd60960be2517010290009bb1fda7fb62c9c9)

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- cherrypick of https://github.com/aws/karpenter-provider-aws/pull/9242

**How was this change tested?**
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.