### PR TITLE
fix: skip MessageLatency for no-op interruption messages

### DIFF
--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -116,7 +116,12 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 			errs[i] = fmt.Errorf("handling message, %w", e)
 			return
 		}
-		MessageLatency.Observe(time.Since(msg.StartTime()).Seconds(), nil)
+		// No-op messages (empty body or unrecognized source/detail-type/version) don't
+		// carry a meaningful StartTime, so recording queue latency for them produces
+		// garbage values that skew the histogram.
+		if msg.Kind() != messages.NoOpKind {
+			MessageLatency.Observe(time.Since(msg.StartTime()).Seconds(), nil)
+		}
 		errs[i] = c.deleteMessage(ctx, sqsMessages[i])
 	})
 	if err = multierr.Combine(errs...); err != nil {

--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -116,10 +116,12 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 			errs[i] = fmt.Errorf("handling message, %w", e)
 			return
 		}
-		// No-op messages (empty body or unrecognized source/detail-type/version) don't
-		// carry a meaningful StartTime, so recording queue latency for them produces
-		// garbage values that skew the histogram.
-		if msg.Kind() != messages.NoOpKind {
+		// Skip messages that can't yield a meaningful queue latency:
+		//   - NoOpKind (empty body or unrecognized source/detail-type/version)
+		//   - a zero StartTime (a well-formed body missing the EventBridge `time` field)
+		// Observing time.Since(zeroTime) saturates at maxDuration and permanently
+		// skews the histogram.
+		if msg.Kind() != messages.NoOpKind && !msg.StartTime().IsZero() {
 			MessageLatency.Observe(time.Since(msg.StartTime()).Seconds(), nil)
 		}
 		errs[i] = c.deleteMessage(ctx, sqsMessages[i])

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -267,6 +267,28 @@ var _ = Describe("InterruptionHandling", func() {
 			Expect(sqsapi.ReceiveMessageBehavior.SuccessfulCalls()).To(Equal(1))
 			Expect(sqsapi.DeleteMessageBehavior.SuccessfulCalls()).To(Equal(1))
 		})
+		It("should not observe MessageLatency for no-op messages", func() {
+			// Regression test for https://github.com/aws/karpenter-provider-aws/issues/9523.
+			// EventParser.Parse returns a bare noop.Message{} with a zero-valued
+			// StartTime for empty or unrecognized SQS bodies. Observing latency
+			// against that zero time produces math.MaxInt64-nanosecond values
+			// (~9.22e9 seconds) that permanently skew histogram averages.
+			interruption.MessageLatency.Reset()
+
+			ExpectMessagesCreated(&sqstypes.Message{
+				Body:      aws.String(""),
+				MessageId: aws.String(string(uuid.NewUUID())),
+			})
+			ExpectSingletonReconciled(ctx, controller)
+			Expect(sqsapi.DeleteMessageBehavior.SuccessfulCalls()).To(Equal(1))
+			ExpectMetricHistogramSampleCountValue("karpenter_interruption_message_queue_duration_seconds", 0, nil)
+
+			// A well-formed interruption message should still record latency.
+			ExpectMessagesCreated(spotInterruptionMessage(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))))
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+			ExpectSingletonReconciled(ctx, controller)
+			ExpectMetricHistogramSampleCountValue("karpenter_interruption_message_queue_duration_seconds", 1, nil)
+		})
 		It("should delete a state change message when the state isn't in accepted states", func() {
 			ExpectMessagesCreated(stateChangeMessage(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID)), "creating"))
 			ExpectApplied(ctx, env.Client, nodeClaim, node)

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -289,6 +289,33 @@ var _ = Describe("InterruptionHandling", func() {
 			ExpectSingletonReconciled(ctx, controller)
 			ExpectMetricHistogramSampleCountValue("karpenter_interruption_message_queue_duration_seconds", 1, nil)
 		})
+		It("should not observe MessageLatency when a well-formed message is missing the EventBridge time field", func() {
+			// A body that matches a known parser's source/detail-type/version but
+			// omits `time` unmarshals with StartTime==zero. Kind() is a valid
+			// message kind, so guarding only on Kind would still let time.Since
+			// saturate against the zero value and corrupt the histogram.
+			interruption.MessageLatency.Reset()
+			instanceID := lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))
+			body := fmt.Sprintf(`{
+				"version":     "0",
+				"account":     %q,
+				"detail-type": "EC2 Spot Instance Interruption Warning",
+				"id":          %q,
+				"region":      %q,
+				"resources":   ["arn:aws:ec2:%s:instance/%s"],
+				"source":      "aws.ec2",
+				"detail":      {"instance-id": %q, "instance-action": "terminate"}
+			}`, defaultAccountID, string(uuid.NewUUID()), fake.DefaultRegion, fake.DefaultRegion, instanceID, instanceID)
+
+			ExpectMessagesCreated(&sqstypes.Message{
+				Body:      aws.String(body),
+				MessageId: aws.String(string(uuid.NewUUID())),
+			})
+			ExpectApplied(ctx, env.Client, nodeClaim, node)
+			ExpectSingletonReconciled(ctx, controller)
+			Expect(sqsapi.DeleteMessageBehavior.SuccessfulCalls()).To(Equal(1))
+			ExpectMetricHistogramSampleCountValue("karpenter_interruption_message_queue_duration_seconds", 0, nil)
+		})
 		It("should delete a state change message when the state isn't in accepted states", func() {
 			ExpectMessagesCreated(stateChangeMessage(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID)), "creating"))
 			ExpectApplied(ctx, env.Client, nodeClaim, node)

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -281,7 +281,8 @@ var _ = Describe("InterruptionHandling", func() {
 			})
 			ExpectSingletonReconciled(ctx, controller)
 			Expect(sqsapi.DeleteMessageBehavior.SuccessfulCalls()).To(Equal(1))
-			ExpectMetricHistogramSampleCountValue("karpenter_interruption_message_queue_duration_seconds", 0, nil)
+			_, ok := FindMetricWithLabelValues("karpenter_interruption_message_queue_duration_seconds", nil)
+			Expect(ok).To(BeFalse(), "no latency should be recorded for a no-op message")
 
 			// A well-formed interruption message should still record latency.
 			ExpectMessagesCreated(spotInterruptionMessage(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID))))
@@ -321,7 +322,8 @@ var _ = Describe("InterruptionHandling", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim, node)
 			ExpectSingletonReconciled(ctx, controller)
 			Expect(sqsapi.DeleteMessageBehavior.SuccessfulCalls()).To(Equal(1))
-			ExpectMetricHistogramSampleCountValue("karpenter_interruption_message_queue_duration_seconds", 0, nil)
+			_, ok := FindMetricWithLabelValues("karpenter_interruption_message_queue_duration_seconds", nil)
+			Expect(ok).To(BeFalse(), "no latency should be recorded for a message with no usable StartTime")
 		})
 		It("should delete a state change message when the state isn't in accepted states", func() {
 			ExpectMessagesCreated(stateChangeMessage(lo.Must(utils.ParseInstanceID(nodeClaim.Status.ProviderID)), "creating"))

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -288,6 +288,13 @@ var _ = Describe("InterruptionHandling", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim, node)
 			ExpectSingletonReconciled(ctx, controller)
 			ExpectMetricHistogramSampleCountValue("karpenter_interruption_message_queue_duration_seconds", 1, nil)
+			// Pin the actual observed value: the pre-fix bug would have recorded
+			// ~9.22e9 seconds (math.MaxInt64 nanoseconds), so anything on the order
+			// of test wall time (< 1h) is a real observation.
+			metric, ok := FindMetricWithLabelValues("karpenter_interruption_message_queue_duration_seconds", nil)
+			Expect(ok).To(BeTrue())
+			Expect(metric.GetHistogram().GetSampleSum()).To(BeNumerically(">", 0))
+			Expect(metric.GetHistogram().GetSampleSum()).To(BeNumerically("<", 3600))
 		})
 		It("should not observe MessageLatency when a well-formed message is missing the EventBridge time field", func() {
 			// A body that matches a known parser's source/detail-type/version but


### PR DESCRIPTION
Fixes #9523

**Description**

Regression from #9064. When #9064 refactored `handleMessage` to share logic between the SQS `Controller` and the new `InstanceStatusController`, the `MessageLatency.Observe(...)` call was moved from inside `handleMessage` (where it lived below the `NoOpKind` early-return in v1.11.3) to the caller in `Controller.Reconcile`. The move dropped the `NoOpKind` guard.

`EventParser.Parse` returns a bare `noop.Message{}` with a zero-valued `StartTime` for empty message bodies and for events whose `source`/`detail-type`/`version` don't match any registered parser. `time.Since(time.Time{}).Seconds()` overflows to `math.MaxInt64` nanoseconds — the ~`9223372036.854775807` seconds shape the reporter sees, and multiples thereof in `_sum` after several such messages.

This restores the pre-1.14.0 semantics: skip the `MessageLatency` observation for `NoOpKind`. `ReceivedMessages` still increments so no-op traffic remains observable via that counter.

**How was this change tested?**

- New Ginkgo spec `should not observe MessageLatency for no-op messages` (in `pkg/controllers/interruption/suite_test.go`):
  - Feeds an empty-body SQS message; asserts `karpenter_interruption_message_queue_duration_seconds` sample count stays at 0 after reconcile.
  - Follows with a valid spot-interruption message; asserts sample count is 1.
- `go build ./pkg/controllers/interruption/...` and `go vet ./pkg/controllers/interruption/...` clean.
- The envtest suite couldn't run locally on this machine (a `listen tcp 127.0.0.1:0: bind: operation not permitted` from the corp network policy blocks envtest's control-plane bring-up); relying on CI for the full suite run.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.