### PR TITLE
test: bump IODCR interruption notice period

### DIFF
--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Interruption", func() {
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).To(Succeed())
 			g.Expect(!node.DeletionTimestamp.IsZero()).To(BeTrue())
-		}).WithTimeout(time.Minute).Should(Succeed())
+		}).WithTimeout(2 * time.Minute).Should(Succeed())
 		env.EventuallyExpectNotFound(node)
 		env.EventuallyExpectHealthyPodCount(selector, 1)
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
`should terminate the interruptible reserved capacity instance and spin-up a new node on reserved capacity interruption warning` is becoming more and more flaky

e.g https://github.com/aws/karpenter-provider-aws/actions/runs/32902850782/job/97981346898
```
  STEP: Interrupting the reserved instance - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/interruption/suite_test.go:162 @ 08/25/26 22:22:49.454
  STEP: Waiting to receive the interruption and terminate the node - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/interruption/suite_test.go:166 @ 08/25/26 22:22:50.75
[CREATED/UPDATED 2026-08-25T22:22:52Z] NODE ip-192-168-52-67.us-east-2.compute.internal ready=True schedulable=true initialized= pods=5 taints=[{node.kubernetes.io/not-ready  NoExecute 2026-08-25 22:22:37 +0000 UTC}]
[CREATED/UPDATED 2026-08-25T22:22:52Z] NODE ip-192-168-52-67.us-east-2.compute.internal ready=True schedulable=true initialized=true pods=5 taints=[]
[CREATED/UPDATED 2026-08-25T22:22:52Z] NODECLAIM flyhot-8-etn2rmr3lh-8ddcj ready=true launched=true registered=true initialized=true
  [FAILED] Timed out after 60.000s.
  The function passed to Eventually failed at /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/interruption/suite_test.go:169 with:
  Expected
      <bool>: false
  to be true
  In [It] at: /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/interruption/suite_test.go:170 @ 08/25/26 22:23:50.751
```

The reason for this is delays between when we modify the IODCR to remove the capacity and when the instance interruption event is received. This is out of Karpenters control.

`2026-08-25T22:22:04.585Z` - Discovered CRs
```
{"level":"DEBUG","time":"2026-08-25T22:22:04.585Z","logger":"controller","caller":"nodeclass/capacityreservation.go:67","message":"discovered capacity reservations","commit":"85eb1cf","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"mothlove-7-jfdnkksrbo"},"namespace":"","name":"mothlove-7-jfdnkksrbo","reconcileID":"5b177aa7-92c5-4c1f-a3fe-84917076d884","ids":["cr-0235c2b5c051442ff","cr-00a1e369335ac65d1"]}
```

`2026-08-25T22:22:17.879Z` - Launched NodeClaim `flyhot-8-etn2rmr3lh-8ddcj` / `i-0bf9d7011c9c530c1`
```
{"level":"INFO","time":"2026-08-25T22:22:17.879Z","logger":"controller","caller":"lifecycle/launch.go:124","message":"launched nodeclaim","commit":"85eb1cf","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"flyhot-8-etn2rmr3lh-8ddcj"},"namespace":"","name":"flyhot-8-etn2rmr3lh-8ddcj","reconcileID":"9d56f6f8-5c98-4f96-b672-f357a3fb4f84","provider-id":"aws:///us-east-2a/i-0bf9d7011c9c530c1","instance-type":"m5.large","zone":"us-east-2a","capacity-type":"reserved","allocatable":{"cpu":"1930m","ephemeral-storage":"17Gi","memory":"6903Mi","pods":"29","vpc.amazonaws.com/pod-eni":"9"}}
```

`22:22:49.454` - updating IODCR to 0 capacity (to trigger interruption)
```
STEP: Interrupting the reserved instance - /home/runner/work/karpenter-provider-aws/karpenter-provider-aws/test/suites/interruption/suite_test.go:162 @ 08/25/26 22:22:49.454
```

`2026-08-25T22:23:51.787Z` - interruption controller received `capacity_reservation_interrupted`
```
{"level":"INFO","time":"2026-08-25T22:23:51.787Z","logger":"controller","caller":"interruption/utils.go:160","message":"initiating delete from interruption message","commit":"85eb1cf","controller":"interruption","namespace":"","name":"","reconcileID":"c1f4dadf-b789-4782-9c74-09362661e31a","queue":"interruption-761517138","messageKind":"capacity_reservation_interrupted","NodeClaim":{"name":"flyhot-8-etn2rmr3lh-8ddcj"},"action":"CordonAndDrain","Node":{"name":"ip-192-168-52-67.us-east-2.compute.internal"}}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.