### PR TITLE
test: drop stale testing for unmanaged and managed instance profile

### DIFF
--- a/test/suites/integration/validation_test.go
+++ b/test/suites/integration/validation_test.go
@@ -102,30 +102,6 @@ var _ = Describe("Validation", func() {
 			nodeClass.Spec.InstanceProfile = nil
 			Expect(env.Client.Create(env.Context, nodeClass)).ToNot(Succeed())
 		})
-		It("should fail to switch between an unmanaged and managed instance profile", func() {
-			nodeClass.Spec.Role = ""
-			nodeClass.Spec.InstanceProfile = lo.ToPtr("test-instance-profile")
-			Expect(env.Client.Create(env.Context, nodeClass)).To(Succeed())
-
-			nodeClass.Spec.Role = "test-role"
-			nodeClass.Spec.InstanceProfile = nil
-			Expect(env.Client.Update(env.Context, nodeClass)).ToNot(Succeed())
-		})
-		It("should fail to switch between a managed and unmanaged instance profile", func() {
-			// Skipping this test for private cluster because there is no VPC private endpoint for the IAM API. As a result,
-			// you cannot use the default spec.role field in your EC2NodeClass. Instead, you need to provision and manage an
-			// instance profile manually and then specify Karpenter to use this instance profile through the spec.instanceProfile field.
-			if env.PrivateCluster {
-				Skip("skipping Unmanaged instance profile test for private cluster")
-			}
-			nodeClass.Spec.Role = "test-role"
-			nodeClass.Spec.InstanceProfile = nil
-			Expect(env.Client.Create(env.Context, nodeClass)).To(Succeed())
-
-			nodeClass.Spec.Role = ""
-			nodeClass.Spec.InstanceProfile = lo.ToPtr("test-instance-profile")
-			Expect(env.Client.Update(env.Context, nodeClass)).ToNot(Succeed())
-		})
 		// spec.kubelet is an open map the API server can't validate, so an invalid kubelet
 		// configuration is accepted on apply and surfaced by the nodeclass controller as
 		// ValidationSucceeded=False rather than being rejected at admission time.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Drops `should fail to switch between an unmanaged and managed instance profile` and `should fail to switch between a managed and unmanaged instance profile` - they are direct opposites of
https://github.com/aws/karpenter-provider-aws/blob/4c2ffe32ea2228d6aaa759b014ff785b3f77bb00/pkg/apis/v1/ec2nodeclass_validation_cel_test.go#L1335-L1352


These tests should be failing since https://github.com/aws/karpenter-provider-aws/pull/8249. The reason they are not failing is because we are seeing 409s when the testing infra patches the NodeClasses

For, https://github.com/aws/karpenter-provider-aws/actions/runs/33117994036/job/98677524889, and in audit logs we can see:
```
userAgent                              testing-unspecified
responseStatus.code                    409
responseStatus.details.kind            ec2nodeclasses
responseStatus.details.name            hissspring-249-p23ciacw3j
responseStatus.message                 Operation cannot be fulfilled on ec2nodeclasses.karpenter.k8s.aws "hissspring-249-p23ciacw3j": the object has been modified; please apply your changes to the latest version and try again
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.