### PR TITLE
chore: let a Resolver exclude an instance type without failing List

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -181,12 +181,18 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass NodeClass) ([]*clo
 		if err != nil {
 			return nil, err
 		}
-		// Return resolution failure (e.g. a kubelet CEL expression that can't be evaluated for this instance type)
+		// Return resolution failure (e.g. a kubelet CEL expression that can't be evaluated for this instance type),
+		// but skip the instance types the resolver excluded - those are a deliberate choice not to offer an
+		// instance type, not a failure to resolve one.
 		instanceTypes = make([]*cloudprovider.InstanceType, 0, len(p.instanceTypesInfo))
 		for name := range p.instanceTypesInfo {
 			it, err := p.get(ctx, nodeClass, name, parsedKubelet)
 			if err != nil {
 				return nil, err
+			}
+			// A nil instance type with no error is the Resolver declining to offer this one; skip it.
+			if it == nil {
+				continue
 			}
 			instanceTypes = append(instanceTypes, it)
 		}
@@ -235,6 +241,12 @@ func (p *DefaultProvider) Get(ctx context.Context, nodeClass NodeClass, name ec2
 		if err != nil {
 			return nil, err
 		}
+		// The Resolver declined to offer this instance type. Get looks up one named instance type and its
+		// callers dereference the result, so "not offered" is reported as a failed lookup rather than passed
+		// back as a nil instance type.
+		if instanceType == nil {
+			return nil, fmt.Errorf("failed to generate instance type %s", name)
+		}
 	}
 	return p.offeringProvider.InjectOfferings(ctx, []*cloudprovider.InstanceType{instanceType}, p.instanceTypesInfo, nodeClass, p.allZones)[0], nil
 }
@@ -264,8 +276,11 @@ func (p *DefaultProvider) get(ctx context.Context, nodeClass NodeClass, name ec2
 	if err != nil {
 		return nil, fmt.Errorf("resolving instance type %s, %w", name, err)
 	}
+	// A nil instance type with no error is the Resolver declining to offer this instance type at all. Pass it
+	// through rather than erroring: List skips it, and Get turns it into a lookup failure. Returning early is
+	// also required because everything below dereferences it.
 	if it == nil {
-		return nil, fmt.Errorf("failed to generate instance type %s", name)
+		return nil, nil
 	}
 	if cached, ok := p.discoveredCapacityCache.Get(discoveredCapacityCacheKey(it.Name, nodeClass)); ok {
 		it.Capacity[corev1.ResourceMemory] = cached.(resource.Quantity)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3608,6 +3608,43 @@ var _ = Describe("InstanceTypeProvider", func() {
 			Expect(instanceTypes).ToNot(BeEmpty())
 		})
 	})
+	Context("Resolver Exclusions", func() {
+		// A resolver returning a nil instance type with no error is declining to offer that instance type at all.
+		// Unlike a resolution failure, that must not fail the whole List - otherwise a resolver that excludes any
+		// instance type takes the entire catalog down with it.
+		It("should skip an excluded instance type and return the rest from List", func() {
+			provider := newProviderWithResolver(&excludingResolver{
+				delegate:  awsEnv.InstanceTypesResolver,
+				excludeOn: "m5.large",
+			})
+			Expect(provider.UpdateInstanceTypes(ctx)).To(Succeed())
+			Expect(provider.UpdateInstanceTypeOfferings(ctx)).To(Succeed())
+
+			instanceTypes, err := provider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instanceTypes).ToNot(BeEmpty())
+			Expect(lo.SomeBy(instanceTypes, func(it *corecloudprovider.InstanceType) bool {
+				return it.Name == "m5.large"
+			})).To(BeFalse(), "an excluded instance type must not be listed")
+			Expect(lo.SomeBy(instanceTypes, func(it *corecloudprovider.InstanceType) bool {
+				return it.Name == "m5.xlarge"
+			})).To(BeTrue(), "excluding one instance type must not drop the others")
+		})
+		It("should report a failed lookup from Get for an excluded instance type", func() {
+			provider := newProviderWithResolver(&excludingResolver{
+				delegate:  awsEnv.InstanceTypesResolver,
+				excludeOn: "m5.large",
+			})
+			Expect(provider.UpdateInstanceTypes(ctx)).To(Succeed())
+			Expect(provider.UpdateInstanceTypeOfferings(ctx)).To(Succeed())
+
+			// Get reports the exclusion as an error rather than returning a nil instance type, since it injects
+			// offerings into the result and its callers dereference it.
+			instanceType, err := provider.Get(ctx, nodeClass, "m5.large")
+			Expect(err).To(MatchError(ContainSubstring("failed to generate instance type m5.large")))
+			Expect(instanceType).To(BeNil())
+		})
+	})
 	Context("Resolution Failures", func() {
 		// A resolution failure for a single instance type will fail the whole List call.
 		var newProviderWithFailingResolver func(resolver instancetype.Resolver) *instancetype.DefaultProvider
@@ -3962,6 +3999,45 @@ func (r *fakeOfferingResolver) ResolveOfferings(
 		})
 	}
 	return offerings
+}
+
+// newProviderWithResolver builds an instance type provider backed by the given Resolver, sharing the test
+// environment's caches and dependencies.
+func newProviderWithResolver(resolver instancetype.Resolver) *instancetype.DefaultProvider {
+	return instancetype.NewDefaultProvider(
+		awsEnv.InstanceTypeCache,
+		awsEnv.OfferingCache,
+		awsEnv.DiscoveredCapacityCache,
+		awsEnv.EC2API,
+		awsEnv.SubnetProvider,
+		awsEnv.PricingProvider,
+		awsEnv.CapacityReservationProvider,
+		awsEnv.PlacementGroupProvider,
+		awsEnv.UnavailableOfferingsCache,
+		resolver,
+		awsEnv.ZonalShiftProvider,
+		env.Client,
+		awsEnv.CELEnvironment,
+	)
+}
+
+// excludingResolver is a test Resolver that declines to offer a single named instance type, returning a nil
+// instance type and no error the way a resolver that filters the catalog (e.g. against an allowlist) does.
+// Every other instance type is delegated to the real resolver.
+type excludingResolver struct {
+	delegate  instancetype.Resolver
+	excludeOn ec2types.InstanceType
+}
+
+func (r *excludingResolver) CacheKey(nodeClass instancetype.NodeClass) string {
+	return r.delegate.CacheKey(nodeClass)
+}
+
+func (r *excludingResolver) Resolve(ctx context.Context, info ec2types.InstanceTypeInfo, zones []string, nodeClass instancetype.NodeClass, parsedKubelet *v1.ParsedKubeletConfig) (*corecloudprovider.InstanceType, error) {
+	if info.InstanceType == r.excludeOn {
+		return nil, nil
+	}
+	return r.delegate.Resolve(ctx, info, zones, nodeClass, parsedKubelet)
 }
 
 // failingResolver is a test Resolver that fails to resolve a single named instance type, standing in for a

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -62,6 +62,11 @@ type Resolver interface {
 	// CacheKey tells the InstanceType cache if something changes about the InstanceTypes or Offerings based on the NodeClass.
 	CacheKey(NodeClass) string
 	// Resolve generates an InstanceType based on raw InstanceTypeInfo and NodeClass setting data.
+	//
+	// An error means resolution failed and is fatal to the whole listing - e.g. a kubelet CEL expression that
+	// can't be evaluated - since it usually means the NodeClass is misconfigured rather than that one instance
+	// type is unusable. To decline to offer an instance type without failing the listing, return a nil
+	// InstanceType and a nil error; List skips it and Get reports a failed lookup.
 	Resolve(ctx context.Context, info ec2types.InstanceTypeInfo, zones []string, nodeClass NodeClass, parsedKubelet *v1.ParsedKubeletConfig) (*cloudprovider.InstanceType, error)
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Allow for Resolvers to skip instance types by returning nil, which was changed here - https://github.com/aws/karpenter-provider-aws/pull/9326/changes#diff-a556a909d093425283d434d60a9abae3093f4653a786ad135d22a030393e1cc8

**How was this change tested?**
Added unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.