### PR TITLE
feat: make auto repair policies dynamic

### DIFF
--- a/charts/karpenter/templates/clusterrole.yaml
+++ b/charts/karpenter/templates/clusterrole.yaml
@@ -32,6 +32,9 @@ rules:
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["ec2nodeclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
   # Write
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["ec2nodeclasses", "ec2nodeclasses/status"]

--- a/charts/karpenter/templates/configmap-repair-policies.yaml
+++ b/charts/karpenter/templates/configmap-repair-policies.yaml
@@ -1,0 +1,16 @@
+{{- with .Values.settings.nodeRepairConfigMapName }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "karpenter.labels" $ | nindent 4 }}
+  {{- with $.Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  policies.json: |-
+    {{- toPrettyJson $.Values.settings.nodeRepairPolicies | nindent 4 }}
+{{- end }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -145,6 +145,10 @@ spec:
             - name: MIN_VALUES_POLICY
               value: "{{ . }}"
           {{- end }}
+          {{- with .Values.settings.nodeRepairConfigMapName }}
+            - name: NODE_REPAIR_CONFIGMAP_NAME
+              value: "{{ . }}"
+          {{- end }}
           {{- with .Values.settings.clusterCABundle }}
             - name: CLUSTER_CA_BUNDLE
               value: "{{ tpl (toString .) $ }}"

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -190,6 +190,32 @@ settings:
   preferencePolicy: Respect
   # -- How the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met).
   minValuesPolicy: Strict
+  # -- Name of the ConfigMap in Karpenter's namespace that defines the node auto repair policies.
+  # If the ConfigMap is absent or invalid, the built-in default policies are used.
+  nodeRepairConfigMapName: karpenter-repair-policies
+  # -- Node auto repair policies. These defaults preserve the built-in policies used by Karpenter.
+  nodeRepairPolicies:
+    - conditionType: Ready
+      conditionStatus: "False"
+      tolerationDuration: 30m
+    - conditionType: Ready
+      conditionStatus: Unknown
+      tolerationDuration: 30m
+    - conditionType: AcceleratedHardwareReady
+      conditionStatus: "False"
+      tolerationDuration: 10m
+    - conditionType: StorageReady
+      conditionStatus: "False"
+      tolerationDuration: 30m
+    - conditionType: NetworkingReady
+      conditionStatus: "False"
+      tolerationDuration: 30m
+    - conditionType: KernelReady
+      conditionStatus: "False"
+      tolerationDuration: 30m
+    - conditionType: ContainerRuntimeReady
+      conditionStatus: "False"
+      tolerationDuration: 30m
   # -- Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
   clusterCABundle: ""
   # -- Cluster name.

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,7 +19,9 @@ import (
 	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider"
 	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider/registrationhooks"
 	"github.com/aws/karpenter-provider-aws/pkg/controllers"
+	"github.com/aws/karpenter-provider-aws/pkg/controllers/repairpolicy"
 	"github.com/aws/karpenter-provider-aws/pkg/operator"
+	"github.com/aws/karpenter-provider-aws/pkg/operator/options"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/overlay"
@@ -96,5 +98,10 @@ func main() {
 			op.CABundle,
 			op.CELEnvironment,
 		)...).
+		WithControllers(ctx, repairpolicy.NewController(
+			op.GetClient(),
+			awsCloudProvider,
+			options.FromContext(ctx).NodeRepairConfigMapName,
+		)).
 		Start(ctx)
 }

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -71,6 +72,7 @@ type CloudProvider struct {
 	placementGroupProvider      placementgroup.Provider
 	instanceTypeStore           *nodeoverlay.InstanceTypeStore
 	caBundle                    *string
+	repairPolicies              atomic.Pointer[[]cloudprovider.RepairPolicy]
 }
 
 func New(
@@ -85,7 +87,7 @@ func New(
 	store *nodeoverlay.InstanceTypeStore,
 	caBundle *string,
 ) *CloudProvider {
-	return &CloudProvider{
+	cp := &CloudProvider{
 		instanceTypeProvider:        instanceTypeProvider,
 		instanceProvider:            instanceProvider,
 		kubeClient:                  kubeClient,
@@ -97,6 +99,15 @@ func New(
 		instanceTypeStore:           store,
 		caBundle:                    caBundle,
 	}
+	cp.SetRepairPolicies(DefaultRepairPolicies())
+	return cp
+}
+
+// SetRepairPolicies atomically replaces the active repair policy list.
+// Safe to call concurrently with RepairPolicies().
+func (c *CloudProvider) SetRepairPolicies(policies []cloudprovider.RepairPolicy) {
+	cp := append([]cloudprovider.RepairPolicy(nil), policies...)
+	c.repairPolicies.Store(&cp)
 }
 
 // Create a NodeClaim given the constraints.
@@ -303,46 +314,10 @@ func (c *CloudProvider) GetSupportedNodeClasses() []status.Object {
 }
 
 func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
-	return []cloudprovider.RepairPolicy{
-		// Supported Kubelet Node Conditions
-		{
-			ConditionType:      corev1.NodeReady,
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      corev1.NodeReady,
-			ConditionStatus:    corev1.ConditionUnknown,
-			TolerationDuration: 30 * time.Minute,
-		},
-		// Support Node Monitoring Agent Conditions
-		//
-		{
-			ConditionType:      "AcceleratedHardwareReady",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 10 * time.Minute,
-		},
-		{
-			ConditionType:      "StorageReady",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      "NetworkingReady",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      "KernelReady",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      "ContainerRuntimeReady",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
+	if p := c.repairPolicies.Load(); p != nil {
+		return *p
 	}
+	return nil
 }
 
 func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*v1.EC2NodeClass, error) {

--- a/pkg/cloudprovider/repairpolicy.go
+++ b/pkg/cloudprovider/repairpolicy.go
@@ -1,0 +1,75 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+)
+
+// RepairPolicyConfigMapKey is the ConfigMap data key holding the policy JSON.
+const RepairPolicyConfigMapKey = "policies.json"
+
+type repairPolicyEntry struct {
+	ConditionType   string `json:"conditionType"`
+	ConditionStatus string `json:"conditionStatus"`
+	// TolerationDuration is a Go duration string (e.g. "30m").
+	TolerationDuration string `json:"tolerationDuration"`
+}
+
+// DefaultRepairPolicies is the built-in fallback used when the ConfigMap is
+// absent or unparseable.
+func DefaultRepairPolicies() []cloudprovider.RepairPolicy {
+	return []cloudprovider.RepairPolicy{
+		// Supported Kubelet Node Conditions
+		{ConditionType: corev1.NodeReady, ConditionStatus: corev1.ConditionFalse, TolerationDuration: 30 * time.Minute},
+		{ConditionType: corev1.NodeReady, ConditionStatus: corev1.ConditionUnknown, TolerationDuration: 30 * time.Minute},
+		// Supported Node Monitoring Agent Conditions
+		{ConditionType: "AcceleratedHardwareReady", ConditionStatus: corev1.ConditionFalse, TolerationDuration: 10 * time.Minute},
+		{ConditionType: "StorageReady", ConditionStatus: corev1.ConditionFalse, TolerationDuration: 30 * time.Minute},
+		{ConditionType: "NetworkingReady", ConditionStatus: corev1.ConditionFalse, TolerationDuration: 30 * time.Minute},
+		{ConditionType: "KernelReady", ConditionStatus: corev1.ConditionFalse, TolerationDuration: 30 * time.Minute},
+		{ConditionType: "ContainerRuntimeReady", ConditionStatus: corev1.ConditionFalse, TolerationDuration: 30 * time.Minute},
+	}
+}
+
+// ParseRepairPolicies parses a ConfigMap's policies.json key into RepairPolicy.
+func ParseRepairPolicies(cm *corev1.ConfigMap) ([]cloudprovider.RepairPolicy, error) {
+	raw, ok := cm.Data[RepairPolicyConfigMapKey]
+	if !ok {
+		return nil, fmt.Errorf("configmap missing key %q", RepairPolicyConfigMapKey)
+	}
+	var entries []repairPolicyEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, fmt.Errorf("parsing repair policies: %w", err)
+	}
+	policies := make([]cloudprovider.RepairPolicy, 0, len(entries))
+	for i, e := range entries {
+		d, err := time.ParseDuration(e.TolerationDuration)
+		if err != nil {
+			return nil, fmt.Errorf("policy[%d] tolerationDuration %q: %w", i, e.TolerationDuration, err)
+		}
+		policies = append(policies, cloudprovider.RepairPolicy{
+			ConditionType:      corev1.NodeConditionType(e.ConditionType),
+			ConditionStatus:    corev1.ConditionStatus(e.ConditionStatus),
+			TolerationDuration: d,
+		})
+	}
+	return policies, nil
+}

--- a/pkg/cloudprovider/repairpolicy_test.go
+++ b/pkg/cloudprovider/repairpolicy_test.go
@@ -1,0 +1,87 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider_test
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider"
+)
+
+func cm(data string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{Data: map[string]string{cloudprovider.RepairPolicyConfigMapKey: data}}
+}
+
+func TestParseRepairPolicies(t *testing.T) {
+	t.Run("parses a valid policy list", func(t *testing.T) {
+		policies, err := cloudprovider.ParseRepairPolicies(cm(`[
+			{"conditionType":"Ready","conditionStatus":"False","tolerationDuration":"30m"},
+			{"conditionType":"NetworkingReady","conditionStatus":"False","tolerationDuration":"5m"}
+		]`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(policies) != 2 {
+			t.Fatalf("expected 2 policies, got %d", len(policies))
+		}
+		if policies[0].ConditionType != corev1.NodeReady ||
+			policies[0].ConditionStatus != corev1.ConditionFalse ||
+			policies[0].TolerationDuration != 30*time.Minute {
+			t.Fatalf("policy[0] mismatch: %+v", policies[0])
+		}
+		if policies[1].TolerationDuration != 5*time.Minute {
+			t.Fatalf("policy[1] duration mismatch: %+v", policies[1])
+		}
+	})
+
+	t.Run("errors when the data key is missing", func(t *testing.T) {
+		if _, err := cloudprovider.ParseRepairPolicies(&corev1.ConfigMap{}); err == nil {
+			t.Fatal("expected error for missing key")
+		}
+	})
+
+	t.Run("errors on malformed json", func(t *testing.T) {
+		if _, err := cloudprovider.ParseRepairPolicies(cm(`not json`)); err == nil {
+			t.Fatal("expected error for malformed json")
+		}
+	})
+
+	t.Run("errors on unparseable duration", func(t *testing.T) {
+		if _, err := cloudprovider.ParseRepairPolicies(cm(`[{"conditionType":"Ready","conditionStatus":"False","tolerationDuration":"soon"}]`)); err == nil {
+			t.Fatal("expected error for bad duration")
+		}
+	})
+}
+
+func TestSetRepairPoliciesRoundTrip(t *testing.T) {
+	cp := &cloudprovider.CloudProvider{}
+	if got := cp.RepairPolicies(); got != nil {
+		t.Fatalf("expected nil before seeding, got %+v", got)
+	}
+	want := cloudprovider.DefaultRepairPolicies()
+	cp.SetRepairPolicies(want)
+	got := cp.RepairPolicies()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d policies, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("policy[%d] mismatch: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/controllers/repairpolicy/controller.go
+++ b/pkg/controllers/repairpolicy/controller.go
@@ -1,0 +1,78 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repairpolicy
+
+import (
+	"context"
+	"os"
+
+	"github.com/awslabs/operatorpkg/reasonable"
+	corev1 "k8s.io/api/core/v1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+
+	"github.com/aws/karpenter-provider-aws/pkg/cloudprovider"
+)
+
+// Controller watches the node repair policy ConfigMap and pushes parsed policies
+// into the CloudProvider so RepairPolicies() reflects changes without a restart.
+type Controller struct {
+	kubeClient    client.Client
+	cloudProvider *cloudprovider.CloudProvider
+	configMapName string
+}
+
+func NewController(kubeClient client.Client, cp *cloudprovider.CloudProvider, configMapName string) *Controller {
+	return &Controller{
+		kubeClient:    kubeClient,
+		cloudProvider: cp,
+		configMapName: configMapName,
+	}
+}
+
+func (c *Controller) Name() string { return "repairpolicy" }
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		For(&corev1.ConfigMap{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+			return o.GetNamespace() == os.Getenv("SYSTEM_NAMESPACE") &&
+				o.GetName() == c.configMapName
+		}))).
+		WithOptions(controller.Options{
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: 1,
+		}).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}
+
+func (c *Controller) Reconcile(ctx context.Context, cm *corev1.ConfigMap) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, c.Name())
+	policies, err := cloudprovider.ParseRepairPolicies(cm)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "invalid repair policy configmap, retaining previous policies")
+		return reconcile.Result{}, nil
+	}
+	c.cloudProvider.SetRepairPolicies(policies)
+	log.FromContext(ctx).Info("reloaded repair policies", "count", len(policies))
+	return reconcile.Result{}, nil
+}

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	ReservedENIs                 int
 	DisableDryRun                bool
 	EnableZonalShift             bool
+	NodeRepairConfigMapName      string
 	AMIRefreshInterval           time.Duration
 	SubnetRefreshInterval        time.Duration
 	SecurityGroupRefreshInterval time.Duration
@@ -69,6 +70,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.IntVar(&o.ReservedENIs, "reserved-enis", env.WithDefaultInt("RESERVED_ENIS", 0), "Reserved ENIs are not included in the calculations for max-pods or kube-reserved. This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.")
 	fs.BoolVarWithEnv(&o.DisableDryRun, "disable-dry-run", "DISABLE_DRY_RUN", false, "If true, then disable dry run validation for EC2NodeClasses.")
 	fs.BoolVarWithEnv(&o.EnableZonalShift, "enable-zonal-shift", "ENABLE_ZONAL_SHIFT", false, "If true, then enable zonal shifting feature.")
+	fs.StringVar(&o.NodeRepairConfigMapName, "node-repair-configmap-name", env.WithDefaultString("NODE_REPAIR_CONFIGMAP_NAME", "karpenter-repair-policies"), "Name of the ConfigMap in Karpenter's namespace that defines the node auto repair policies. If absent or invalid, the built-in default policies are used.")
 	fs.DurationVar(&o.AMIRefreshInterval, "ami-refresh-interval", env.WithDefaultDuration("AMI_REFRESH_INTERVAL", time.Minute), "How often Karpenter refreshes AMI data from EC2. Increasing this value will reduce the number of DescribeImages API calls at the cost of increased staleness in AMI discovery and drift detection. Must be at least 1m.")
 	fs.DurationVar(&o.SubnetRefreshInterval, "subnet-refresh-interval", env.WithDefaultDuration("SUBNET_REFRESH_INTERVAL", time.Minute), "How often Karpenter refreshes subnet data from EC2. Increasing this value will reduce the number of DescribeSubnets API calls at the cost of increased staleness in subnet discovery. Must be at least 1m.")
 	fs.DurationVar(&o.SecurityGroupRefreshInterval, "security-group-refresh-interval", env.WithDefaultDuration("SECURITY_GROUP_REFRESH_INTERVAL", time.Minute), "How often Karpenter refreshes security group data from EC2. Increasing this value will reduce the number of DescribeSecurityGroups API calls at the cost of increased staleness in security group discovery. Must be at least 1m.")


### PR DESCRIPTION
**Description**

Added a new controller to propagate auto repair policies from a supplied configmap as part of the chart. Policies can now be dynamically updated without restarting karpenter as they appear on nodes.

With this you can now update this config map to match any custom node conditions and adjust the toleration duration for them individually.

**How was this change tested?**

Unit tests have been added and this patch has been running in production at Netflix for a few months now.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.