### PR TITLE
docs: document install-side view ClusterRole for NodePools

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -36,6 +36,30 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.14.1 \
   --annotations version=1.14.1
 ```
 
+## User RBAC
+
+The chart creates `karpenter-admin` (see `templates/aggregate-clusterrole.yaml`) so the default `admin` ClusterRole can manage NodePools, NodeClaims, and EC2NodeClasses. It does **not** aggregate those resources into `view` or `edit`. Kubernetes RBAC aggregation flows `edit` → `admin`, not the reverse, so view and edit users cannot read Karpenter CRDs.
+
+That matches the default `view` ClusterRole, which also omits Nodes. Those objects are cluster-scoped capacity resources. If your operators need read access, install this ClusterRole on the cluster. It is not a chart value.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["ec2nodeclasses", "ec2nodeclasses/status"]
+    verbs: ["get", "list", "watch"]
+```
+
+Do not add write verbs. Aggregating create, delete, or patch into `edit` would let any cluster-wide `edit` binding delete NodePools.
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -29,7 +29,30 @@ Karpenter has multiple mechanisms for configuring the [operating system]({{< ref
 Karpenter is flexible to multi-architecture configurations using [well known labels]({{< ref "./concepts/scheduling/#supported-labels">}}).
 
 ### What RBAC access is required?
-All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/role.yaml) files for details.
+All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole.yaml), [aggregate-clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/aggregate-clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/role.yaml) files for details.
+
+### Why can't view or edit users see NodePools?
+The Helm chart ships `karpenter-admin`, which aggregates NodePools, NodeClaims, and EC2NodeClasses only to the default `admin` ClusterRole. Kubernetes RBAC aggregation flows `edit` → `admin`, not the reverse, so users bound to `view` or `edit` cannot get, list, or watch those objects.
+
+That is intentional. Those objects are cluster-scoped capacity resources, closer to Nodes (which `view` also omits) than to namespaced workload objects. If your operators need read access, install the following ClusterRole on the cluster. It is not a chart value.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["ec2nodeclasses", "ec2nodeclasses/status"]
+    verbs: ["get", "list", "watch"]
+```
+
+Do not add write verbs. Aggregating create, delete, or patch into `edit` would let any cluster-wide `edit` binding delete NodePools.
 
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -29,7 +29,30 @@ Karpenter has multiple mechanisms for configuring the [operating system]({{< ref
 Karpenter is flexible to multi-architecture configurations using [well known labels]({{< ref "./concepts/scheduling/#supported-labels">}}).
 
 ### What RBAC access is required?
-All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/role.yaml) files for details.
+All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/clusterrole.yaml), [aggregate-clusterrole.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/aggregate-clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob{{< githubRelRef >}}charts/karpenter/templates/role.yaml) files for details.
+
+### Why can't view or edit users see NodePools?
+The Helm chart ships `karpenter-admin`, which aggregates NodePools, NodeClaims, and EC2NodeClasses only to the default `admin` ClusterRole. Kubernetes RBAC aggregation flows `edit` → `admin`, not the reverse, so users bound to `view` or `edit` cannot get, list, or watch those objects.
+
+That is intentional. Those objects are cluster-scoped capacity resources, closer to Nodes (which `view` also omits) than to namespaced workload objects. If your operators need read access, install the following ClusterRole on the cluster. It is not a chart value.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["ec2nodeclasses", "ec2nodeclasses/status"]
+    verbs: ["get", "list", "watch"]
+```
+
+Do not add write verbs. Aggregating create, delete, or patch into `edit` would let any cluster-wide `edit` binding delete NodePools.
 
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.

--- a/website/content/en/v1.0/faq.md
+++ b/website/content/en/v1.0/faq.md
@@ -29,7 +29,30 @@ Karpenter has multiple mechanisms for configuring the [operating system]({{< ref
 Karpenter is flexible to multi-architecture configurations using [well known labels]({{< ref "./concepts/scheduling/#supported-labels">}}).
 
 ### What RBAC access is required?
-All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/role.yaml) files for details.
+All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/clusterrole.yaml), [aggregate-clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/aggregate-clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.0.11/charts/karpenter/templates/role.yaml) files for details.
+
+### Why can't view or edit users see NodePools?
+The Helm chart ships `karpenter-admin`, which aggregates NodePools, NodeClaims, and EC2NodeClasses only to the default `admin` ClusterRole. Kubernetes RBAC aggregation flows `edit` → `admin`, not the reverse, so users bound to `view` or `edit` cannot get, list, or watch those objects.
+
+That is intentional. Those objects are cluster-scoped capacity resources, closer to Nodes (which `view` also omits) than to namespaced workload objects. If your operators need read access, install the following ClusterRole on the cluster. It is not a chart value.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["ec2nodeclasses", "ec2nodeclasses/status"]
+    verbs: ["get", "list", "watch"]
+```
+
+Do not add write verbs. Aggregating create, delete, or patch into `edit` would let any cluster-wide `edit` binding delete NodePools.
 
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.

--- a/website/content/en/v1.12/faq.md
+++ b/website/content/en/v1.12/faq.md
@@ -29,7 +29,30 @@ Karpenter has multiple mechanisms for configuring the [operating system]({{< ref
 Karpenter is flexible to multi-architecture configurations using [well known labels]({{< ref "./concepts/scheduling/#supported-labels">}}).
 
 ### What RBAC access is required?
-All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/role.yaml) files for details.
+All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/clusterrole.yaml), [aggregate-clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/aggregate-clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.12.1/charts/karpenter/templates/role.yaml) files for details.
+
+### Why can't view or edit users see NodePools?
+The Helm chart ships `karpenter-admin`, which aggregates NodePools, NodeClaims, and EC2NodeClasses only to the default `admin` ClusterRole. Kubernetes RBAC aggregation flows `edit` → `admin`, not the reverse, so users bound to `view` or `edit` cannot get, list, or watch those objects.
+
+That is intentional. Those objects are cluster-scoped capacity resources, closer to Nodes (which `view` also omits) than to namespaced workload objects. If your operators need read access, install the following ClusterRole on the cluster. It is not a chart value.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["ec2nodeclasses", "ec2nodeclasses/status"]
+    verbs: ["get", "list", "watch"]
+```
+
+Do not add write verbs. Aggregating create, delete, or patch into `edit` would let any cluster-wide `edit` binding delete NodePools.
 
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.

--- a/website/content/en/v1.13/faq.md
+++ b/website/content/en/v1.13/faq.md
@@ -29,7 +29,30 @@ Karpenter has multiple mechanisms for configuring the [operating system]({{< ref
 Karpenter is flexible to multi-architecture configurations using [well known labels]({{< ref "./concepts/scheduling/#supported-labels">}}).
 
 ### What RBAC access is required?
-All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/role.yaml) files for details.
+All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/clusterrole.yaml), [aggregate-clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/aggregate-clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.13.0/charts/karpenter/templates/role.yaml) files for details.
+
+### Why can't view or edit users see NodePools?
+The Helm chart ships `karpenter-admin`, which aggregates NodePools, NodeClaims, and EC2NodeClasses only to the default `admin` ClusterRole. Kubernetes RBAC aggregation flows `edit` → `admin`, not the reverse, so users bound to `view` or `edit` cannot get, list, or watch those objects.
+
+That is intentional. Those objects are cluster-scoped capacity resources, closer to Nodes (which `view` also omits) than to namespaced workload objects. If your operators need read access, install the following ClusterRole on the cluster. It is not a chart value.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["ec2nodeclasses", "ec2nodeclasses/status"]
+    verbs: ["get", "list", "watch"]
+```
+
+Do not add write verbs. Aggregating create, delete, or patch into `edit` would let any cluster-wide `edit` binding delete NodePools.
 
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.

--- a/website/content/en/v1.14/faq.md
+++ b/website/content/en/v1.14/faq.md
@@ -29,7 +29,30 @@ Karpenter has multiple mechanisms for configuring the [operating system]({{< ref
 Karpenter is flexible to multi-architecture configurations using [well known labels]({{< ref "./concepts/scheduling/#supported-labels">}}).
 
 ### What RBAC access is required?
-All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/role.yaml) files for details.
+All the required RBAC rules can be found in the Helm chart template. See [clusterrole-core.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole-core.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/clusterrole.yaml), [aggregate-clusterrole.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/aggregate-clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/v1.14.1/charts/karpenter/templates/role.yaml) files for details.
+
+### Why can't view or edit users see NodePools?
+The Helm chart ships `karpenter-admin`, which aggregates NodePools, NodeClaims, and EC2NodeClasses only to the default `admin` ClusterRole. Kubernetes RBAC aggregation flows `edit` → `admin`, not the reverse, so users bound to `view` or `edit` cannot get, list, or watch those objects.
+
+That is intentional. Those objects are cluster-scoped capacity resources, closer to Nodes (which `view` also omits) than to namespaced workload objects. If your operators need read access, install the following ClusterRole on the cluster. It is not a chart value.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["ec2nodeclasses", "ec2nodeclasses/status"]
+    verbs: ["get", "list", "watch"]
+```
+
+Do not add write verbs. Aggregating create, delete, or patch into `edit` would let any cluster-wide `edit` binding delete NodePools.
 
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.


### PR DESCRIPTION
Fixes #9551

**Description**

The chart ships `karpenter-admin` (`aggregate-to-admin` only). Users bound to the default `view` or `edit` ClusterRole cannot get/list/watch NodePools, NodeClaims, or EC2NodeClasses.

https://github.com/aws/karpenter/pull/2901 asked to put those rules on `view` by default and was closed: do it on the installation side. This PR documents that install-side ClusterRole. It does not add a chart value.

Also lists `aggregate-clusterrole.yaml` in the existing controller-RBAC FAQ answer.

Backported to `docs/`, `preview/`, and the published version trees (`v1.14`, `v1.13`, `v1.12`, `v1.0`) per the documentation-updates guide.

**How was this change tested?**

Rendered the FAQ locally and confirmed the YAML snippet matches the resource set on `karpenter-admin` (get/list/watch only).

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
