### PR TITLE
docs: restricted runtime labels do not trigger provisioning

### DIFF
--- a/website/content/en/docs/concepts/scheduling.md
+++ b/website/content/en/docs/concepts/scheduling.md
@@ -203,6 +203,10 @@ requirements:
     operator: Exists
 ```
 
+{{% alert title="Warning" color="warning" %}}
+Labels in the `karpenter.sh` domain that are **not** in the well-known table above — including `karpenter.sh/registered` and `karpenter.sh/initialized` — are restricted. Karpenter stamps them on nodes after they join, so kube-scheduler can match them on *existing* Karpenter nodes, but they do not trigger provisioning. You cannot make them provisionable by adding `Exists` on the NodePool (NodePool CEL rejects them). Pin workloads with `karpenter.sh/nodepool` (`Exists` or a specific pool name) instead. When a selector uses a restricted label, Karpenter emits a pod `FailedScheduling` event; controller logs for that path are at verbosity 1 by default.
+{{% /alert %}}
+
 {{% alert title="Note" color="primary" %}}
 There is currently a limit of 100 on the total number of requirements on both the NodePool and the NodeClaim. It's important to note that `spec.template.metadata.labels` are also propagated as requirements on the NodeClaim when it's created, meaning that you can't have more than 100 requirements and labels combined set on your NodePool.
 {{% /alert %}}

--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -63,7 +63,7 @@ Yes, NodePools can identify multiple teams based on labels. See the [NodePool AP
 
 ### If multiple NodePools are defined, which will my pod use?
 
-Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`.
+Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`. Do not select `karpenter.sh/registered` or `karpenter.sh/initialized`: those labels match existing Karpenter nodes but cannot trigger scale-up.
 
 ### How can I configure Karpenter to only provision pods for a particular namespace?
 

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -203,6 +203,10 @@ requirements:
     operator: Exists
 ```
 
+{{% alert title="Warning" color="warning" %}}
+Labels in the `karpenter.sh` domain that are **not** in the well-known table above — including `karpenter.sh/registered` and `karpenter.sh/initialized` — are restricted. Karpenter stamps them on nodes after they join, so kube-scheduler can match them on *existing* Karpenter nodes, but they do not trigger provisioning. You cannot make them provisionable by adding `Exists` on the NodePool (NodePool CEL rejects them). Pin workloads with `karpenter.sh/nodepool` (`Exists` or a specific pool name) instead. When a selector uses a restricted label, Karpenter emits a pod `FailedScheduling` event; controller logs for that path are at verbosity 1 by default.
+{{% /alert %}}
+
 {{% alert title="Note" color="primary" %}}
 There is currently a limit of 100 on the total number of requirements on both the NodePool and the NodeClaim. It's important to note that `spec.template.metadata.labels` are also propagated as requirements on the NodeClaim when it's created, meaning that you can't have more than 100 requirements and labels combined set on your NodePool.
 {{% /alert %}}

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -63,7 +63,7 @@ Yes, NodePools can identify multiple teams based on labels. See the [NodePool AP
 
 ### If multiple NodePools are defined, which will my pod use?
 
-Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`.
+Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`. Do not select `karpenter.sh/registered` or `karpenter.sh/initialized`: those labels match existing Karpenter nodes but cannot trigger scale-up.
 
 ### How can I configure Karpenter to only provision pods for a particular namespace?
 

--- a/website/content/en/v1.0/concepts/scheduling.md
+++ b/website/content/en/v1.0/concepts/scheduling.md
@@ -182,6 +182,10 @@ requirements:
     operator: Exists
 ```
 
+{{% alert title="Warning" color="warning" %}}
+Labels in the `karpenter.sh` domain that are **not** in the well-known table above — including `karpenter.sh/registered` and `karpenter.sh/initialized` — are restricted. Karpenter stamps them on nodes after they join, so kube-scheduler can match them on *existing* Karpenter nodes, but they do not trigger provisioning. You cannot make them provisionable by adding `Exists` on the NodePool (NodePool CEL rejects them). Pin workloads with `karpenter.sh/nodepool` (`Exists` or a specific pool name) instead. When a selector uses a restricted label, Karpenter emits a pod `FailedScheduling` event; controller logs for that path are at verbosity 1 by default.
+{{% /alert %}}
+
 {{% alert title="Note" color="primary" %}}
 There is currently a limit of 100 on the total number of requirements on both the NodePool and the NodeClaim. It's important to note that `spec.template.metadata.labels` are also propagated as requirements on the NodeClaim when it's created, meaning that you can't have more than 100 requirements and labels combined set on your NodePool.
 {{% /alert %}}

--- a/website/content/en/v1.0/faq.md
+++ b/website/content/en/v1.0/faq.md
@@ -63,7 +63,7 @@ Yes, NodePools can identify multiple teams based on labels. See the [NodePool AP
 
 ### If multiple NodePools are defined, which will my pod use?
 
-Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`.
+Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`. Do not select `karpenter.sh/registered` or `karpenter.sh/initialized`: those labels match existing Karpenter nodes but cannot trigger scale-up.
 
 ### How can I configure Karpenter to only provision pods for a particular namespace?
 

--- a/website/content/en/v1.12/concepts/scheduling.md
+++ b/website/content/en/v1.12/concepts/scheduling.md
@@ -203,6 +203,10 @@ requirements:
     operator: Exists
 ```
 
+{{% alert title="Warning" color="warning" %}}
+Labels in the `karpenter.sh` domain that are **not** in the well-known table above — including `karpenter.sh/registered` and `karpenter.sh/initialized` — are restricted. Karpenter stamps them on nodes after they join, so kube-scheduler can match them on *existing* Karpenter nodes, but they do not trigger provisioning. You cannot make them provisionable by adding `Exists` on the NodePool (NodePool CEL rejects them). Pin workloads with `karpenter.sh/nodepool` (`Exists` or a specific pool name) instead. When a selector uses a restricted label, Karpenter emits a pod `FailedScheduling` event; controller logs for that path are at verbosity 1 by default.
+{{% /alert %}}
+
 {{% alert title="Note" color="primary" %}}
 There is currently a limit of 100 on the total number of requirements on both the NodePool and the NodeClaim. It's important to note that `spec.template.metadata.labels` are also propagated as requirements on the NodeClaim when it's created, meaning that you can't have more than 100 requirements and labels combined set on your NodePool.
 {{% /alert %}}

--- a/website/content/en/v1.12/faq.md
+++ b/website/content/en/v1.12/faq.md
@@ -63,7 +63,7 @@ Yes, NodePools can identify multiple teams based on labels. See the [NodePool AP
 
 ### If multiple NodePools are defined, which will my pod use?
 
-Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`.
+Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`. Do not select `karpenter.sh/registered` or `karpenter.sh/initialized`: those labels match existing Karpenter nodes but cannot trigger scale-up.
 
 ### How can I configure Karpenter to only provision pods for a particular namespace?
 

--- a/website/content/en/v1.13/concepts/scheduling.md
+++ b/website/content/en/v1.13/concepts/scheduling.md
@@ -203,6 +203,10 @@ requirements:
     operator: Exists
 ```
 
+{{% alert title="Warning" color="warning" %}}
+Labels in the `karpenter.sh` domain that are **not** in the well-known table above — including `karpenter.sh/registered` and `karpenter.sh/initialized` — are restricted. Karpenter stamps them on nodes after they join, so kube-scheduler can match them on *existing* Karpenter nodes, but they do not trigger provisioning. You cannot make them provisionable by adding `Exists` on the NodePool (NodePool CEL rejects them). Pin workloads with `karpenter.sh/nodepool` (`Exists` or a specific pool name) instead. When a selector uses a restricted label, Karpenter emits a pod `FailedScheduling` event; controller logs for that path are at verbosity 1 by default.
+{{% /alert %}}
+
 {{% alert title="Note" color="primary" %}}
 There is currently a limit of 100 on the total number of requirements on both the NodePool and the NodeClaim. It's important to note that `spec.template.metadata.labels` are also propagated as requirements on the NodeClaim when it's created, meaning that you can't have more than 100 requirements and labels combined set on your NodePool.
 {{% /alert %}}

--- a/website/content/en/v1.13/faq.md
+++ b/website/content/en/v1.13/faq.md
@@ -63,7 +63,7 @@ Yes, NodePools can identify multiple teams based on labels. See the [NodePool AP
 
 ### If multiple NodePools are defined, which will my pod use?
 
-Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`.
+Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`. Do not select `karpenter.sh/registered` or `karpenter.sh/initialized`: those labels match existing Karpenter nodes but cannot trigger scale-up.
 
 ### How can I configure Karpenter to only provision pods for a particular namespace?
 

--- a/website/content/en/v1.14/concepts/scheduling.md
+++ b/website/content/en/v1.14/concepts/scheduling.md
@@ -203,6 +203,10 @@ requirements:
     operator: Exists
 ```
 
+{{% alert title="Warning" color="warning" %}}
+Labels in the `karpenter.sh` domain that are **not** in the well-known table above — including `karpenter.sh/registered` and `karpenter.sh/initialized` — are restricted. Karpenter stamps them on nodes after they join, so kube-scheduler can match them on *existing* Karpenter nodes, but they do not trigger provisioning. You cannot make them provisionable by adding `Exists` on the NodePool (NodePool CEL rejects them). Pin workloads with `karpenter.sh/nodepool` (`Exists` or a specific pool name) instead. When a selector uses a restricted label, Karpenter emits a pod `FailedScheduling` event; controller logs for that path are at verbosity 1 by default.
+{{% /alert %}}
+
 {{% alert title="Note" color="primary" %}}
 There is currently a limit of 100 on the total number of requirements on both the NodePool and the NodeClaim. It's important to note that `spec.template.metadata.labels` are also propagated as requirements on the NodeClaim when it's created, meaning that you can't have more than 100 requirements and labels combined set on your NodePool.
 {{% /alert %}}

--- a/website/content/en/v1.14/faq.md
+++ b/website/content/en/v1.14/faq.md
@@ -63,7 +63,7 @@ Yes, NodePools can identify multiple teams based on labels. See the [NodePool AP
 
 ### If multiple NodePools are defined, which will my pod use?
 
-Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`.
+Pending pods will be handled by any NodePools that matches the requirements of the pod. There is no ordering guarantee if multiple NodePools match pod requirements. We recommend that NodePools are set-up to be mutually exclusive. To select a specific NodePool, use the node selector `karpenter.sh/nodepool: my-nodepool`. Do not select `karpenter.sh/registered` or `karpenter.sh/initialized`: those labels match existing Karpenter nodes but cannot trigger scale-up.
 
 ### How can I configure Karpenter to only provision pods for a particular namespace?
 


### PR DESCRIPTION
Fixes https://github.com/aws/karpenter-provider-aws/issues/9553

**Description**

`karpenter.sh/registered` and `karpenter.sh/initialized` match existing Karpenter nodes via kube-scheduler but do not trigger provisioning. The User-Defined Labels section currently points people at `Exists` on the NodePool, which NodePool CEL rejects for restricted-domain keys.

This PR documents the restriction next to that pattern, and notes `karpenter.sh/nodepool` as the supported pin in the FAQ. No controller change.

Backported to `docs/`, `preview/`, and the published version trees (`v1.14`, `v1.13`, `v1.12`, `v1.0`) per the documentation-updates guide.

**How was this change tested?**

Rendered the affected sections locally and confirmed the warning sits after the `Exists` example, not after the well-known table.

**Does this change impact docs?**

Yes, this is docs-only.

**Does this change impact resources (CPU/Mem)?**

No
