### PR TITLE
fix: scope interruption handling to managed NodeClaims

### DIFF
--- a/pkg/controllers/interruption/utils.go
+++ b/pkg/controllers/interruption/utils.go
@@ -74,14 +74,14 @@ func (h *InterruptionHandler) handleMessage(ctx context.Context, msg messages.Me
 			err = multierr.Append(err, e)
 			continue
 		}
-		if len(nodeClaimList.Items) == 0 {
-			continue
-		}
-		found = true
-		if dryRun {
-			continue
-		}
 		for _, nodeClaim := range nodeClaimList.Items {
+			if !nodeclaimutils.IsManaged(&nodeClaim, h.cloudProvider) {
+				continue
+			}
+			found = true
+			if dryRun {
+				continue
+			}
 			nodeList := &corev1.NodeList{}
 			if e := h.kubeClient.List(ctx, nodeList, client.MatchingFields{"spec.instanceID": instanceID}); e != nil {
 				err = multierr.Append(err, e)


### PR DESCRIPTION
**Description**

In clusters running both self-managed Karpenter and EKS Auto Mode, both controllers use the same `NodeClaim` CRD.

Karpenter's interruption handler finds NodeClaims by EC2 instance ID, but does not verify which controller owns them. This means it could delete an Auto Mode NodeClaim when processing an interruption or unhealthy-instance event.

This change ignores NodeClaims that are not managed by the self-managed AWS provider. The check protects both the SQS interruption path and the EC2 instance-status path.

**Does this change impact docs?**
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.