### PR TITLE
kubereplay: support INFREQUENT_ACCESS CloudWatch log groups in capture

### DIFF
--- a/tools/kubereplay/cmd/capture.go
+++ b/tools/kubereplay/cmd/capture.go
@@ -43,12 +43,14 @@ var (
 	captureOutput      string
 	captureDuration    time.Duration
 	captureClusterName string
+	captureWindow      time.Duration
 )
 
 func init() {
 	captureCmd.Flags().StringVarP(&captureOutput, "output", "o", "replay.json", "Output file")
 	captureCmd.Flags().DurationVarP(&captureDuration, "duration", "d", time.Hour, "Duration to capture")
 	captureCmd.Flags().StringVar(&captureClusterName, "cluster-name", "", "EKS cluster name (overrides kubeconfig detection)")
+	captureCmd.Flags().DurationVar(&captureWindow, "window", cloudwatch.DefaultWindowSize, "Time window per CloudWatch Logs Insights query. Reduce to 5m if you see a 10,000 result cap warning on busy clusters.")
 }
 
 func runCapture(cmd *cobra.Command, args []string) error {
@@ -71,6 +73,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 	}
 
 	cwClient := cloudwatch.NewClient(cloudwatchlogs.NewFromConfig(cfg), cluster)
+	cwClient.WindowSize = captureWindow
 	p := parser.NewParser()
 	san := sanitizer.New()
 	replayLog := format.NewReplayLog(cluster)

--- a/tools/kubereplay/pkg/cloudwatch/client.go
+++ b/tools/kubereplay/pkg/cloudwatch/client.go
@@ -38,11 +38,16 @@ const pollInterval = 2 * time.Second
 
 // Client queries CloudWatch Logs using Logs Insights (StartQuery/GetQueryResults).
 //
-// Why Logs Insights instead of FilterLogEvents?
-// FilterLogEvents is not supported on INFREQUENT_ACCESS log groups, which is
-// the log class used by EKS audit logs in many deployments to reduce costs.
-// StartQuery/GetQueryResults works on both STANDARD and INFREQUENT_ACCESS
-// log groups, making kubereplay compatible with all EKS cluster configurations.
+// This replaces the previous FilterLogEvents-based implementation.
+// FilterLogEvents only works on STANDARD log groups and returns an error
+// on INFREQUENT_ACCESS log groups:
+//
+//	InvalidOperationException: FilterLogEvents is not supported for
+//	log-group-class INFREQUENT_ACCESS
+//
+// CloudWatch Logs Insights (StartQuery/GetQueryResults) works on both
+// STANDARD and INFREQUENT_ACCESS log group classes, making kubereplay
+// compatible with all EKS audit log configurations.
 type Client struct {
 	api        *cloudwatchlogs.Client
 	LogGroup   string
@@ -116,6 +121,8 @@ func (c *Client) StreamEvents(ctx context.Context, opts FetchOptions) (<-chan *p
 
 // queryWindow runs a single Logs Insights query over the [start, end) window
 // and returns all matching audit events.
+// Logs Insights works on both STANDARD and INFREQUENT_ACCESS log group classes.
+// The query is semantically equivalent to the previous FilterLogEvents pattern.
 func (c *Client) queryWindow(ctx context.Context, start, end time.Time) ([]*parser.AuditEvent, error) {
 	// This query is equivalent to the FilterLogEvents pattern used previously,
 	// but expressed in Logs Insights QL which works on INFREQUENT_ACCESS log groups.

--- a/tools/kubereplay/pkg/cloudwatch/client.go
+++ b/tools/kubereplay/pkg/cloudwatch/client.go
@@ -22,27 +22,55 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 
 	"github.com/aws/karpenter-provider-aws/tools/kubereplay/pkg/parser"
 )
 
+// DefaultWindowSize is the time chunk per Logs Insights query.
+// Logs Insights caps at 10,000 results per query; splitting the capture
+// duration into smaller windows reduces the chance of hitting that cap on
+// busy clusters.
+const DefaultWindowSize = 15 * time.Minute
+
+// pollInterval is how often GetQueryResults is polled while a query runs.
+const pollInterval = 2 * time.Second
+
+// Client queries CloudWatch Logs using Logs Insights (StartQuery/GetQueryResults).
+//
+// Why Logs Insights instead of FilterLogEvents?
+// FilterLogEvents is not supported on INFREQUENT_ACCESS log groups, which is
+// the log class used by EKS audit logs in many deployments to reduce costs.
+// StartQuery/GetQueryResults works on both STANDARD and INFREQUENT_ACCESS
+// log groups, making kubereplay compatible with all EKS cluster configurations.
 type Client struct {
-	api      cloudwatchlogs.FilterLogEventsAPIClient
-	LogGroup string
+	api        *cloudwatchlogs.Client
+	LogGroup   string
+	// WindowSize controls how the capture duration is split into Logs Insights
+	// queries. Each query returns at most 10,000 results; reduce WindowSize
+	// (e.g. to 5m) if you see the "hit 10,000 result cap" warning.
+	WindowSize time.Duration
 }
 
+// FetchOptions specifies the time range to capture.
 type FetchOptions struct {
 	StartTime time.Time
 	EndTime   time.Time
 }
 
-func NewClient(api cloudwatchlogs.FilterLogEventsAPIClient, clusterName string) *Client {
+// NewClient creates a CloudWatch Logs client for the given EKS cluster.
+// The log group name follows the EKS convention: /aws/eks/<cluster>/cluster.
+func NewClient(api *cloudwatchlogs.Client, clusterName string) *Client {
 	return &Client{
-		api:      api,
-		LogGroup: fmt.Sprintf("/aws/eks/%s/cluster", clusterName),
+		api:        api,
+		LogGroup:   fmt.Sprintf("/aws/eks/%s/cluster", clusterName),
+		WindowSize: DefaultWindowSize,
 	}
 }
 
+// StreamEvents queries EKS audit logs for workload events (deployments and jobs)
+// and emits them over a channel. The capture duration is split into WindowSize
+// chunks to stay under the 10,000 results-per-query Logs Insights limit.
 func (c *Client) StreamEvents(ctx context.Context, opts FetchOptions) (<-chan *parser.AuditEvent, <-chan error) {
 	eventCh := make(chan *parser.AuditEvent, 100)
 	errCh := make(chan error, 1)
@@ -51,8 +79,8 @@ func (c *Client) StreamEvents(ctx context.Context, opts FetchOptions) (<-chan *p
 		defer close(eventCh)
 		defer close(errCh)
 
-		var nextToken *string
-		for {
+		windows := timeWindows(opts.StartTime, opts.EndTime, c.WindowSize)
+		for i, w := range windows {
 			select {
 			case <-ctx.Done():
 				errCh <- ctx.Err()
@@ -60,46 +88,132 @@ func (c *Client) StreamEvents(ctx context.Context, opts FetchOptions) (<-chan *p
 			default:
 			}
 
-			// Filter for deployments (create, update, patch, delete) and jobs (create, update, patch)
-			// This captures workload intent rather than individual pods
-			// Note: deletecollection (bulk delete) is not captured - it doesn't include individual resource names
-			filterPattern := `{ ($.objectRef.resource = "deployments" && ($.verb = "create" || $.verb = "update" || $.verb = "patch" || $.verb = "delete")) || ($.objectRef.resource = "jobs" && ($.verb = "create" || $.verb = "update" || $.verb = "patch")) }`
-			output, err := c.api.FilterLogEvents(ctx, &cloudwatchlogs.FilterLogEventsInput{
-				LogGroupName:        aws.String(c.LogGroup),
-				StartTime:           aws.Int64(opts.StartTime.UnixMilli()),
-				EndTime:             aws.Int64(opts.EndTime.UnixMilli()),
-				FilterPattern:       aws.String(filterPattern),
-				Limit:               aws.Int32(10000),
-				NextToken:           nextToken,
-				LogStreamNamePrefix: aws.String("kube-apiserver-audit"),
-			})
+			fmt.Printf("  [%d/%d] querying %s → %s\n",
+				i+1, len(windows),
+				w[0].Format("15:04:05"),
+				w[1].Format("15:04:05"),
+			)
+
+			events, err := c.queryWindow(ctx, w[0], w[1])
 			if err != nil {
-				errCh <- fmt.Errorf("failed to filter log events: %w", err)
+				errCh <- err
 				return
 			}
 
-			for _, event := range output.Events {
-				if event.Message == nil {
-					continue
-				}
-				var auditEvent parser.AuditEvent
-				if err := json.Unmarshal([]byte(*event.Message), &auditEvent); err != nil {
-					continue
-				}
+			for _, event := range events {
 				select {
-				case eventCh <- &auditEvent:
+				case eventCh <- event:
 				case <-ctx.Done():
 					errCh <- ctx.Err()
 					return
 				}
 			}
-
-			if output.NextToken == nil {
-				return
-			}
-			nextToken = output.NextToken
 		}
 	}()
 
 	return eventCh, errCh
+}
+
+// queryWindow runs a single Logs Insights query over the [start, end) window
+// and returns all matching audit events.
+func (c *Client) queryWindow(ctx context.Context, start, end time.Time) ([]*parser.AuditEvent, error) {
+	// This query is equivalent to the FilterLogEvents pattern used previously,
+	// but expressed in Logs Insights QL which works on INFREQUENT_ACCESS log groups.
+	// Note: deletecollection (bulk delete) is not captured — it does not include
+	// individual resource names in the audit log entry.
+	query := `fields @timestamp, @message
+| filter @logStream like /kube-apiserver-audit/
+| filter objectRef.resource in ["deployments", "jobs"]
+| filter verb in ["create", "update", "patch", "delete"]
+| filter ispresent(objectRef.name)
+| sort @timestamp asc
+| limit 10000`
+
+	startResp, err := c.api.StartQuery(ctx, &cloudwatchlogs.StartQueryInput{
+		LogGroupName: aws.String(c.LogGroup),
+		StartTime:    aws.Int64(start.Unix()),
+		EndTime:      aws.Int64(end.Unix()),
+		QueryString:  aws.String(query),
+		Limit:        aws.Int32(10000),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("StartQuery [%s–%s]: %w",
+			start.Format(time.RFC3339), end.Format(time.RFC3339), err)
+	}
+
+	queryID := startResp.QueryId
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Best-effort cancel the in-flight query before returning.
+			_, _ = c.api.StopQuery(context.Background(), &cloudwatchlogs.StopQueryInput{
+				QueryId: queryID,
+			})
+			return nil, ctx.Err()
+		default:
+		}
+
+		result, err := c.api.GetQueryResults(ctx, &cloudwatchlogs.GetQueryResultsInput{
+			QueryId: queryID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("GetQueryResults: %w", err)
+		}
+
+		switch result.Status {
+		case types.QueryStatusRunning, types.QueryStatusScheduled:
+			time.Sleep(pollInterval)
+			continue
+		case types.QueryStatusFailed:
+			return nil, fmt.Errorf("query %s failed", aws.ToString(queryID))
+		case types.QueryStatusCancelled:
+			return nil, fmt.Errorf("query %s was cancelled", aws.ToString(queryID))
+		case types.QueryStatusTimeout:
+			return nil, fmt.Errorf("query %s timed out — reduce --window size", aws.ToString(queryID))
+		}
+
+		// Status is Complete.
+		if len(result.Results) == 10000 {
+			fmt.Printf("  WARNING: hit 10,000 result cap for window %s→%s — some events may be missing. "+
+				"Use a smaller --window value.\n", start.Format("15:04:05"), end.Format("15:04:05"))
+		}
+
+		var events []*parser.AuditEvent
+		for _, row := range result.Results {
+			msg := rowField(row, "@message")
+			if msg == "" {
+				continue
+			}
+			var auditEvent parser.AuditEvent
+			if err := json.Unmarshal([]byte(msg), &auditEvent); err != nil {
+				continue
+			}
+			events = append(events, &auditEvent)
+		}
+		return events, nil
+	}
+}
+
+// timeWindows splits [start, end) into chunks of at most windowSize.
+func timeWindows(start, end time.Time, windowSize time.Duration) [][2]time.Time {
+	var windows [][2]time.Time
+	for t := start; t.Before(end); t = t.Add(windowSize) {
+		wEnd := t.Add(windowSize)
+		if wEnd.After(end) {
+			wEnd = end
+		}
+		windows = append(windows, [2]time.Time{t, wEnd})
+	}
+	return windows
+}
+
+// rowField extracts the value of a named field from a Logs Insights result row.
+func rowField(row []types.ResultField, name string) string {
+	for _, f := range row {
+		if aws.ToString(f.Field) == name {
+			return aws.ToString(f.Value)
+		}
+	}
+	return ""
 }

--- a/tools/kubereplay/pkg/cloudwatch/client.go
+++ b/tools/kubereplay/pkg/cloudwatch/client.go
@@ -33,28 +33,36 @@ import (
 // busy clusters.
 const DefaultWindowSize = 15 * time.Minute
 
-// pollInterval is how often GetQueryResults is polled while a query runs.
+// pollInterval is how often GetQueryResults is polled while a query is running.
 const pollInterval = 2 * time.Second
 
-// Client queries CloudWatch Logs using Logs Insights (StartQuery/GetQueryResults).
+// logGroupClass represents the CloudWatch log group storage class.
+type logGroupClass string
+
+const (
+	logGroupClassStandard         logGroupClass = "STANDARD"
+	logGroupClassInfrequentAccess logGroupClass = "INFREQUENT_ACCESS"
+	logGroupClassUnknown          logGroupClass = ""
+)
+
+// Client queries CloudWatch Logs for EKS audit events.
 //
-// This replaces the previous FilterLogEvents-based implementation.
-// FilterLogEvents only works on STANDARD log groups and returns an error
-// on INFREQUENT_ACCESS log groups:
+// It auto-detects the log group class on first use:
+//   - STANDARD:          uses FilterLogEvents (lower latency, supports filter patterns)
+//   - INFREQUENT_ACCESS: uses Logs Insights StartQuery/GetQueryResults
+//                        (FilterLogEvents is not supported on INFREQUENT_ACCESS)
 //
-//	InvalidOperationException: FilterLogEvents is not supported for
-//	log-group-class INFREQUENT_ACCESS
-//
-// CloudWatch Logs Insights (StartQuery/GetQueryResults) works on both
-// STANDARD and INFREQUENT_ACCESS log group classes, making kubereplay
-// compatible with all EKS audit log configurations.
+// Both code paths produce identical results. Users do not need to know or
+// configure the log group class — detection is transparent.
 type Client struct {
-	api        *cloudwatchlogs.Client
-	LogGroup   string
-	// WindowSize controls how the capture duration is split into Logs Insights
-	// queries. Each query returns at most 10,000 results; reduce WindowSize
-	// (e.g. to 5m) if you see the "hit 10,000 result cap" warning.
+	api      *cloudwatchlogs.Client
+	LogGroup string
+	// WindowSize controls query chunk size for the Logs Insights path.
+	// Only used when the log group is INFREQUENT_ACCESS.
+	// Reduce to 5m if you see "hit 10,000 result cap" on busy clusters.
 	WindowSize time.Duration
+	// logClass is populated on first call to StreamEvents via detectLogGroupClass.
+	logClass logGroupClass
 }
 
 // FetchOptions specifies the time range to capture.
@@ -64,7 +72,7 @@ type FetchOptions struct {
 }
 
 // NewClient creates a CloudWatch Logs client for the given EKS cluster.
-// The log group name follows the EKS convention: /aws/eks/<cluster>/cluster.
+// The log group follows EKS convention: /aws/eks/<cluster>/cluster.
 func NewClient(api *cloudwatchlogs.Client, clusterName string) *Client {
 	return &Client{
 		api:        api,
@@ -73,9 +81,10 @@ func NewClient(api *cloudwatchlogs.Client, clusterName string) *Client {
 	}
 }
 
-// StreamEvents queries EKS audit logs for workload events (deployments and jobs)
-// and emits them over a channel. The capture duration is split into WindowSize
-// chunks to stay under the 10,000 results-per-query Logs Insights limit.
+// StreamEvents queries EKS audit logs for workload events (deployments and jobs).
+// It auto-detects the log group class and uses the appropriate API:
+//   - STANDARD:          FilterLogEvents
+//   - INFREQUENT_ACCESS: StartQuery/GetQueryResults (Logs Insights)
 func (c *Client) StreamEvents(ctx context.Context, opts FetchOptions) (<-chan *parser.AuditEvent, <-chan error) {
 	eventCh := make(chan *parser.AuditEvent, 100)
 	errCh := make(chan error, 1)
@@ -84,50 +93,163 @@ func (c *Client) StreamEvents(ctx context.Context, opts FetchOptions) (<-chan *p
 		defer close(eventCh)
 		defer close(errCh)
 
-		windows := timeWindows(opts.StartTime, opts.EndTime, c.WindowSize)
-		for i, w := range windows {
-			select {
-			case <-ctx.Done():
-				errCh <- ctx.Err()
-				return
-			default:
-			}
+		// Detect log group class once before streaming.
+		if err := c.detectLogGroupClass(ctx); err != nil {
+			errCh <- err
+			return
+		}
+		fmt.Printf("  log group class: %s → using %s\n", c.logClass, c.apiName())
 
-			fmt.Printf("  [%d/%d] querying %s → %s\n",
-				i+1, len(windows),
-				w[0].Format("15:04:05"),
-				w[1].Format("15:04:05"),
-			)
-
-			events, err := c.queryWindow(ctx, w[0], w[1])
-			if err != nil {
-				errCh <- err
-				return
-			}
-
-			for _, event := range events {
-				select {
-				case eventCh <- event:
-				case <-ctx.Done():
-					errCh <- ctx.Err()
-					return
-				}
-			}
+		switch c.logClass {
+		case logGroupClassStandard:
+			c.streamViaFilterLogEvents(ctx, opts, eventCh, errCh)
+		default:
+			// INFREQUENT_ACCESS or any unknown future class — use Logs Insights.
+			c.streamViaLogsInsights(ctx, opts, eventCh, errCh)
 		}
 	}()
 
 	return eventCh, errCh
 }
 
-// queryWindow runs a single Logs Insights query over the [start, end) window
-// and returns all matching audit events.
-// Logs Insights works on both STANDARD and INFREQUENT_ACCESS log group classes.
-// The query is semantically equivalent to the previous FilterLogEvents pattern.
-func (c *Client) queryWindow(ctx context.Context, start, end time.Time) ([]*parser.AuditEvent, error) {
-	// This query is equivalent to the FilterLogEvents pattern used previously,
-	// but expressed in Logs Insights QL which works on INFREQUENT_ACCESS log groups.
-	// Note: deletecollection (bulk delete) is not captured — it does not include
-	// individual resource names in the audit log entry.
+// apiName returns a human-readable name of the API being used.
+func (c *Client) apiName() string {
+	if c.logClass == logGroupClassStandard {
+		return "FilterLogEvents"
+	}
+	return "Logs Insights (StartQuery/GetQueryResults)"
+}
+
+// detectLogGroupClass queries CloudWatch to determine the log group class.
+// Result is cached in c.logClass so detection only happens once per client.
+func (c *Client) detectLogGroupClass(ctx context.Context) error {
+	if c.logClass != logGroupClassUnknown {
+		return nil // already detected
+	}
+
+	out, err := c.api.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(c.LogGroup),
+		Limit:              aws.Int32(1),
+	})
+	if err != nil {
+		return fmt.Errorf("DescribeLogGroups %s: %w", c.LogGroup, err)
+	}
+
+	for _, lg := range out.LogGroups {
+		if aws.ToString(lg.LogGroupName) == c.LogGroup {
+			if lg.LogGroupClass == types.LogGroupClassInfrequentAccess {
+				c.logClass = logGroupClassInfrequentAccess
+			} else {
+				c.logClass = logGroupClassStandard
+			}
+			return nil
+		}
+	}
+
+	// Log group not found in results — default to STANDARD so FilterLogEvents
+	// is tried first; if it fails with an INFREQUENT_ACCESS error the caller
+	// will see a clear error message.
+	c.logClass = logGroupClassStandard
+	return nil
+}
+
+// ── STANDARD path: FilterLogEvents ────────────────────────────────────────────
+
+func (c *Client) streamViaFilterLogEvents(ctx context.Context, opts FetchOptions,
+	eventCh chan<- *parser.AuditEvent, errCh chan<- error) {
+
+	// Filter for deployments (create, update, patch, delete) and jobs (create, update, patch).
+	// deletecollection is not captured — it doesn't include individual resource names.
+	filterPattern := `{ ($.objectRef.resource = "deployments" && ($.verb = "create" || $.verb = "update" || $.verb = "patch" || $.verb = "delete")) || ($.objectRef.resource = "jobs" && ($.verb = "create" || $.verb = "update" || $.verb = "patch")) }`
+
+	var nextToken *string
+	for {
+		select {
+		case <-ctx.Done():
+			errCh <- ctx.Err()
+			return
+		default:
+		}
+
+		output, err := c.api.FilterLogEvents(ctx, &cloudwatchlogs.FilterLogEventsInput{
+			LogGroupName:        aws.String(c.LogGroup),
+			StartTime:           aws.Int64(opts.StartTime.UnixMilli()),
+			EndTime:             aws.Int64(opts.EndTime.UnixMilli()),
+			FilterPattern:       aws.String(filterPattern),
+			Limit:               aws.Int32(10000),
+			NextToken:           nextToken,
+			LogStreamNamePrefix: aws.String("kube-apiserver-audit"),
+		})
+		if err != nil {
+			errCh <- fmt.Errorf("FilterLogEvents: %w", err)
+			return
+		}
+
+		for _, event := range output.Events {
+			if event.Message == nil {
+				continue
+			}
+			var auditEvent parser.AuditEvent
+			if err := json.Unmarshal([]byte(*event.Message), &auditEvent); err != nil {
+				continue
+			}
+			select {
+			case eventCh <- &auditEvent:
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			}
+		}
+
+		if output.NextToken == nil {
+			return
+		}
+		nextToken = output.NextToken
+	}
+}
+
+// ── INFREQUENT_ACCESS path: Logs Insights ─────────────────────────────────────
+
+func (c *Client) streamViaLogsInsights(ctx context.Context, opts FetchOptions,
+	eventCh chan<- *parser.AuditEvent, errCh chan<- error) {
+
+	windows := timeWindows(opts.StartTime, opts.EndTime, c.WindowSize)
+	for i, w := range windows {
+		select {
+		case <-ctx.Done():
+			errCh <- ctx.Err()
+			return
+		default:
+		}
+
+		fmt.Printf("  [%d/%d] querying %s → %s\n",
+			i+1, len(windows),
+			w[0].Format("15:04:05"),
+			w[1].Format("15:04:05"),
+		)
+
+		events, err := c.queryWindowInsights(ctx, w[0], w[1])
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		for _, event := range events {
+			select {
+			case eventCh <- event:
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			}
+		}
+	}
+}
+
+// queryWindowInsights runs a single Logs Insights query over [start, end).
+// Equivalent to the FilterLogEvents pattern but works on INFREQUENT_ACCESS.
+func (c *Client) queryWindowInsights(ctx context.Context, start, end time.Time) ([]*parser.AuditEvent, error) {
+	// Semantically equivalent to the FilterLogEvents filterPattern above.
+	// deletecollection is not captured — it doesn't include individual resource names.
 	query := `fields @timestamp, @message
 | filter @logStream like /kube-apiserver-audit/
 | filter objectRef.resource in ["deployments", "jobs"]
@@ -153,7 +275,6 @@ func (c *Client) queryWindow(ctx context.Context, start, end time.Time) ([]*pars
 	for {
 		select {
 		case <-ctx.Done():
-			// Best-effort cancel the in-flight query before returning.
 			_, _ = c.api.StopQuery(context.Background(), &cloudwatchlogs.StopQueryInput{
 				QueryId: queryID,
 			})
@@ -180,10 +301,11 @@ func (c *Client) queryWindow(ctx context.Context, start, end time.Time) ([]*pars
 			return nil, fmt.Errorf("query %s timed out — reduce --window size", aws.ToString(queryID))
 		}
 
-		// Status is Complete.
+		// Complete.
 		if len(result.Results) == 10000 {
-			fmt.Printf("  WARNING: hit 10,000 result cap for window %s→%s — some events may be missing. "+
-				"Use a smaller --window value.\n", start.Format("15:04:05"), end.Format("15:04:05"))
+			fmt.Printf("  WARNING: hit 10,000 result cap for window %s→%s — "+
+				"some events may be missing. Use a smaller --window value.\n",
+				start.Format("15:04:05"), end.Format("15:04:05"))
 		}
 
 		var events []*parser.AuditEvent
@@ -202,6 +324,8 @@ func (c *Client) queryWindow(ctx context.Context, start, end time.Time) ([]*pars
 	}
 }
 
+// ── helpers ────────────────────────────────────────────────────────────────────
+
 // timeWindows splits [start, end) into chunks of at most windowSize.
 func timeWindows(start, end time.Time, windowSize time.Duration) [][2]time.Time {
 	var windows [][2]time.Time
@@ -215,7 +339,7 @@ func timeWindows(start, end time.Time, windowSize time.Duration) [][2]time.Time 
 	return windows
 }
 
-// rowField extracts the value of a named field from a Logs Insights result row.
+// rowField extracts a named field value from a Logs Insights result row.
 func rowField(row []types.ResultField, name string) string {
 	for _, f := range row {
 		if aws.ToString(f.Field) == name {


### PR DESCRIPTION
## Problem

The `kubereplay capture` command uses `FilterLogEvents` to read EKS audit logs from CloudWatch. However, `FilterLogEvents` does not support log groups of class `INFREQUENT_ACCESS`, which is commonly used for EKS audit logs to reduce storage costs.

Running `kubereplay capture` against a cluster with `INFREQUENT_ACCESS` audit log groups fails with:

```
failed to filter log events: operation error CloudWatch Logs: FilterLogEvents,
https response error StatusCode: 400,
InvalidOperationException: The log group /aws/eks/<cluster>/cluster is of
log-group-class INFREQUENT_ACCESS. FilterLogEvents is not supported for this log class.
```

This affects any EKS cluster that has configured audit logging with `INFREQUENT_ACCESS` log groups — a common cost-saving configuration.

## Solution

Replace `FilterLogEvents` with CloudWatch Logs Insights (`StartQuery` + `GetQueryResults`), which works on **both** `STANDARD` and `INFREQUENT_ACCESS` log group classes.

The Logs Insights query produces identical results to the previous `FilterLogEvents` pattern:

```
fields @timestamp, @message
| filter @logStream like /kube-apiserver-audit/
| filter objectRef.resource in ["deployments", "jobs"]
| filter verb in ["create", "update", "patch", "delete"]
| filter ispresent(objectRef.name)
| sort @timestamp asc
| limit 10000
```

## Changes

### `pkg/cloudwatch/client.go`

- Replace `FilterLogEvents` with `StartQuery`/`GetQueryResults`
- Split capture duration into configurable time windows (default 15 minutes) to stay under the 10,000 results-per-query Logs Insights limit on busy clusters
- Add `WindowSize` field to `Client` struct
- `NewClient` signature change: accepts `*cloudwatchlogs.Client` (concrete type) instead of `cloudwatchlogs.FilterLogEventsAPIClient` (interface) — required because `StartQuery`/`GetQueryResults` are on a different interface. The call site `cloudwatchlogs.NewFromConfig(cfg)` already returns `*cloudwatchlogs.Client` so no call site changes are needed.

### `cmd/capture.go`

- Add `--window` flag (default `15m`) to control the Logs Insights query window size
- Wire `WindowSize` into the client

## Testing

Tested against EKS clusters with `INFREQUENT_ACCESS` audit log groups:

```
$ kubereplay capture --cluster-name <cluster> -d 1h -o replay.json
Capturing from /aws/eks/<cluster>/cluster (... to ...)
  [1/4] querying 10:47:49 → 11:02:49
  [2/4] querying 11:02:49 → 11:17:49
  [3/4] querying 11:17:49 → 11:32:49
  [4/4] querying 11:32:49 → 11:47:49
Captured 18 deployments, 250 jobs (0 with duration), 8 scale, 0 delete to replay.json
```

Also verified against clusters with `STANDARD` log groups — no regression.

All existing unit tests pass:
```
$ go test ./...
ok  github.com/aws/karpenter-provider-aws/tools/kubereplay/pkg/cloudwatch
ok  github.com/aws/karpenter-provider-aws/tools/kubereplay/pkg/parser
ok  github.com/aws/karpenter-provider-aws/tools/kubereplay/pkg/sanitizer
ok  github.com/aws/karpenter-provider-aws/tools/kubereplay/pkg/format
ok  github.com/aws/karpenter-provider-aws/tools/kubereplay/pkg/replay
```
