### PR TITLE
feat: validate shutdownGracePeriod and shutdownGracePeriodCriticalPods semantics

### DIFF
--- a/pkg/apis/v1/kubeletconfiguration_validation.go
+++ b/pkg/apis/v1/kubeletconfiguration_validation.go
@@ -247,6 +247,21 @@ func validateKubeletSemantics(kc KubeletConfiguration) []error {
 		errs = append(errs, fmt.Errorf("spec.kubelet: imageGCHighThresholdPercent (%d) must be greater than imageGCLowThresholdPercent (%d)", high, low))
 	}
 
+	// shutdownGracePeriodCriticalPods must not exceed shutdownGracePeriod. The kubelet evicts
+	// non-critical pods first and then switches to the critical-pod budget; a budget larger than
+	// the overall window means critical pods always get zero time.
+	sgp, sgpOK := decodeDuration(kc, "shutdownGracePeriod")
+	sgpcp, sgpcpOK := decodeDuration(kc, "shutdownGracePeriodCriticalPods")
+	if sgpOK && sgp < 0 {
+		errs = append(errs, fmt.Errorf("spec.kubelet.shutdownGracePeriod: %v can't be negative", sgp))
+	}
+	if sgpcpOK && sgpcp < 0 {
+		errs = append(errs, fmt.Errorf("spec.kubelet.shutdownGracePeriodCriticalPods: %v can't be negative", sgpcp))
+	}
+	if sgpOK && sgpcpOK && sgp >= 0 && sgpcp > sgp {
+		errs = append(errs, fmt.Errorf("spec.kubelet: shutdownGracePeriodCriticalPods (%v) must not exceed shutdownGracePeriod (%v)", sgpcp, sgp))
+	}
+
 	return errs
 }
 
@@ -277,6 +292,25 @@ func decodeInt(kc KubeletConfiguration, field string) (int64, bool) {
 		return 0, false
 	}
 	return out, true
+}
+
+// decodeDuration reads a metav1.Duration field (JSON string, e.g. "30s"), reporting false if
+// it's absent or can't be parsed. As with decodeInt, a wrong type is left to
+// validateAgainstUpstreamType to report.
+func decodeDuration(kc KubeletConfiguration, field string) (time.Duration, bool) {
+	raw, ok := kc[field]
+	if !ok {
+		return 0, false
+	}
+	var s string
+	if err := json.Unmarshal(raw.Raw, &s); err != nil {
+		return 0, false
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, false
+	}
+	return d, true
 }
 
 // isJSONString reports whether a raw JSON value is a string.

--- a/pkg/apis/v1/kubeletconfiguration_validation_test.go
+++ b/pkg/apis/v1/kubeletconfiguration_validation_test.go
@@ -64,6 +64,10 @@ var _ = Describe("ValidateKubeletConfig", func() {
 			"imageGCHighThresholdPercent": v1.JSONValue(80),
 			"imageGCLowThresholdPercent":  v1.JSONValue(60),
 		}),
+		Entry("shutdown grace periods with criticalPods within the overall window", v1.KubeletConfiguration{
+			"shutdownGracePeriod":             v1.JSONValue("3590s"),
+			"shutdownGracePeriodCriticalPods": v1.JSONValue("120s"),
+		}),
 		Entry("zero-valued fields", v1.KubeletConfiguration{
 			"maxPods":                   v1.JSONValue(0),
 			"podsPerCore":               v1.JSONValue(0),
@@ -220,6 +224,47 @@ var _ = Describe("ValidateKubeletConfig", func() {
 		Expect(v1.ValidateKubeletConfig(v1.KubeletConfiguration{
 			"imageGCHighThresholdPercent": v1.JSONValue(70),
 			"imageGCLowThresholdPercent":  v1.JSONValue(70),
+		})).ToNot(BeEmpty())
+	})
+	It("should accept valid shutdown grace periods", func() {
+		// Both set with criticalPods < gracePeriod.
+		Expect(v1.ValidateKubeletConfig(v1.KubeletConfiguration{
+			"shutdownGracePeriod":             v1.JSONValue("3590s"),
+			"shutdownGracePeriodCriticalPods": v1.JSONValue("120s"),
+		})).To(BeEmpty())
+		// Equal values are allowed: all shutdown time is allocated to critical pods.
+		Expect(v1.ValidateKubeletConfig(v1.KubeletConfiguration{
+			"shutdownGracePeriod":             v1.JSONValue("120s"),
+			"shutdownGracePeriodCriticalPods": v1.JSONValue("120s"),
+		})).To(BeEmpty())
+		// Zero disables graceful shutdown; setting only one field is valid.
+		Expect(v1.ValidateKubeletConfig(v1.KubeletConfiguration{
+			"shutdownGracePeriod": v1.JSONValue("0s"),
+		})).To(BeEmpty())
+		Expect(v1.ValidateKubeletConfig(v1.KubeletConfiguration{
+			"shutdownGracePeriodCriticalPods": v1.JSONValue("30s"),
+		})).To(BeEmpty())
+	})
+	It("should reject shutdownGracePeriodCriticalPods exceeding shutdownGracePeriod", func() {
+		// The kubelet evicts non-critical pods in (gracePeriod - criticalPods) and then runs
+		// critical pods for criticalPods seconds. A budget larger than the window means
+		// non-critical pods get zero time (criticalPods > gracePeriod) or worse.
+		errs := v1.ValidateKubeletConfig(v1.KubeletConfiguration{
+			"shutdownGracePeriod":             v1.JSONValue("60s"),
+			"shutdownGracePeriodCriticalPods": v1.JSONValue("90s"),
+		})
+		Expect(errs).ToNot(BeEmpty())
+		Expect(errs[0].Error()).To(ContainSubstring("shutdownGracePeriodCriticalPods"))
+		Expect(errs[0].Error()).To(ContainSubstring("shutdownGracePeriod"))
+	})
+	It("should reject a negative shutdownGracePeriod", func() {
+		Expect(v1.ValidateKubeletConfig(v1.KubeletConfiguration{
+			"shutdownGracePeriod": v1.JSONValue("-1s"),
+		})).ToNot(BeEmpty())
+	})
+	It("should reject a negative shutdownGracePeriodCriticalPods", func() {
+		Expect(v1.ValidateKubeletConfig(v1.KubeletConfiguration{
+			"shutdownGracePeriodCriticalPods": v1.JSONValue("-30s"),
 		})).ToNot(BeEmpty())
 	})
 	// registerWithTaints is a legitimate kubelet field, so the decode against the upstream type


### PR DESCRIPTION
## Summary

Adds semantic validation for `shutdownGracePeriod` and `shutdownGracePeriodCriticalPods`
in `EC2NodeClass.spec.kubelet`.

Both fields already pass through to the node via `generateInlineKubeletConfiguration()`
on AL2023. This PR adds the validation rules their open-map type cannot express:

- Both values must be non-negative durations
- `shutdownGracePeriodCriticalPods` must not exceed `shutdownGracePeriod` — if it does,
  the kubelet silently gives critical pods zero time during shutdown

The cross-field check matches the pattern already in `validateKubeletSemantics` for
`imageGCHighThresholdPercent > imageGCLowThresholdPercent` and the evictionSoft /
evictionSoftGracePeriod key-pairing check.

## Changes

- `pkg/apis/v1/kubeletconfiguration_validation.go` — adds `decodeDuration` helper and
  three new checks in `validateKubeletSemantics`
- `pkg/apis/v1/kubeletconfiguration_validation_test.go` — table-driven tests covering
  negative durations, the cross-field violation, and valid combinations

## Testing

```
go test ./pkg/apis/v1/... -run TestKubelet
```