### PR TITLE
feat(chart): add podDisruptionBudget.unhealthyPodEvictionPolicy

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -75,6 +75,7 @@ cosign verify public.ecr.aws/karpenter/karpenter:1.14.1 \
 | podAnnotations | object | `{}` | Additional annotations for the pod. |
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podDisruptionBudget.name | string | `"karpenter"` |  |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Unhealthy pod eviction policy for the PodDisruptionBudget (`IfHealthyBudget` or `AlwaysAllow`). `AlwaysAllow` lets non-Ready pods (e.g. stuck on an unreachable node) be evicted regardless of the budget. Requires Kubernetes 1.27+; ignored on older clusters. Empty keeps the Kubernetes default (`IfHealthyBudget`). |
 | podLabels | object | `{}` | Additional labels for the pod. |
 | podSecurityContext | object | `{"fsGroup":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext for the pod. |
 | priorityClassName | string | `"system-cluster-critical"` | PriorityClass name for the pod. |

--- a/charts/karpenter/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter/templates/poddisruptionbudget.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if and .Values.podDisruptionBudget.unhealthyPodEvictionPolicy (semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version) }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
   selector:
     matchLabels:
     {{- include "karpenter.selectorLabels" . | nindent 6 }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -60,6 +60,10 @@ podAnnotations: {}
 podDisruptionBudget:
   name: karpenter
   maxUnavailable: 1
+  # -- Unhealthy pod eviction policy for the PodDisruptionBudget (`IfHealthyBudget` or `AlwaysAllow`).
+  # `AlwaysAllow` lets non-Ready pods (e.g. stuck on an unreachable node) be evicted regardless of the budget.
+  # Requires Kubernetes 1.27+; ignored on older clusters. Empty keeps the Kubernetes default (`IfHealthyBudget`).
+  unhealthyPodEvictionPolicy: ""
 # -- SecurityContext for the pod.
 podSecurityContext:
   fsGroup: 65532


### PR DESCRIPTION
Fixes #N/A (relates to #7025; revives #7037, which went stale after the review feedback had been addressed)

**Description**

Adds an optional `podDisruptionBudget.unhealthyPodEvictionPolicy` value to the Karpenter chart and renders it as `spec.unhealthyPodEvictionPolicy` on the PodDisruptionBudget.

Motivation: with the Kubernetes default (`IfHealthyBudget`), a PDB also protects pods that are not Ready. When a node becomes unreachable and its Karpenter pod goes to Terminating/Unknown, the eviction API refuses to evict it as long as the budget would be violated, which blocks node drain and the node lifecycle controller. Setting the policy to `AlwaysAllow` lets non-Ready pods be evicted regardless of the budget, which is the recommended setting for controllers like Karpenter that should never be kept "protected" while unhealthy.

Behavior:

- The field is rendered only when the value is non-empty **and** `.Capabilities.KubeVersion` is 1.27 or newer (the field became beta and enabled by default in 1.27). Older clusters silently keep the previous manifest.
- The default is `""`, so existing installations render exactly the same PDB as before. Users opt in with `--set podDisruptionBudget.unhealthyPodEvictionPolicy=AlwaysAllow`.
- `charts/karpenter/README.md` regenerated with `helm-docs` v1.14.2, matching `hack/docgen.sh`.

**How was this change tested?**

`helm template` against the chart with three inputs:

```
# default values                      -> spec has only maxUnavailable and selector (unchanged)
# --set podDisruptionBudget.unhealthyPodEvictionPolicy=AlwaysAllow
                                      -> spec.unhealthyPodEvictionPolicy: AlwaysAllow
# same, with --kube-version 1.26.0    -> field omitted
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No (chart README is regenerated from `values.yaml` comments)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
