### PR TITLE
ci: harden website preview workflow's artifact handling

### DIFF
--- a/.github/actions/deploy-website/action.yaml
+++ b/.github/actions/deploy-website/action.yaml
@@ -60,7 +60,7 @@ runs:
       shell: bash
       run: |
         S3_PATH="s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}"
-        aws s3 sync ${{ inputs.site-path }}/ "$S3_PATH" --delete
+        aws s3 sync ${{ inputs.site-path }}/ "$S3_PATH" --delete --no-follow-symlinks
     - name: Create Amplify branch (if preview and doesn't exist)
       shell: bash
       if: github.event_name == 'workflow_run'

--- a/.github/actions/download-artifact/action.yaml
+++ b/.github/actions/download-artifact/action.yaml
@@ -25,6 +25,13 @@ runs:
     - run: |
         mkdir -p /tmp/artifacts
         unzip /tmp/artifacts.zip -d /tmp/artifacts
+        # The artifact comes from the untrusted fork build so treat its contents as hostile. Symlink or other
+        # non-regular entries can point at credential files. Fail closed on anything but dirs/regular files.
+        if [ -n "$(find /tmp/artifacts -not -type d -not -type f -print -quit)" ]; then
+          echo "::error::Refusing artifact: it contains non-regular files (symlinks/devices/fifos)."
+          find /tmp/artifacts -not -type d -not -type f -ls
+          exit 1
+        fi
       shell: bash
     - run: |
         echo "Downloaded artifacts:"

--- a/.github/workflows/website-preview.yaml
+++ b/.github/workflows/website-preview.yaml
@@ -11,6 +11,8 @@ jobs:
     # A failed trigger means the PR's site never built, so there is nothing to ship and the
     # error already surfaced on the PR's own check
     if: github.event.workflow_run.conclusion == 'success'
+    # Gate the credentialed deploy behind an Environment protection rule. See .github/security-notice.md.
+    environment: website-preview
     permissions:
       id-token: write
       contents: read
@@ -19,6 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not persist GITHUB_TOKEN into .git/config: this privileged job
+          # extracts an artifact from the untrusted fork build, and a symlink to
+          # .git/config would otherwise leak the token. API calls here use the
+          # actions' github-token input (octokit), not the git CLI, so this is safe.
+          persist-credentials: false
       - uses: ./.github/actions/download-artifact
       # WebsitePreviewTrigger builds the PR's own site, so the PR can run arbitrary code there and
       # rewrite the metadata artifact after it is written. Take the commit from the event payload,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

The website-preview deploy pipeline builds a PR's site in an unprivileged pull_request job and ships the resulting artifact from a privileged workflow_run job that holds the preview OIDC role and a write GITHUB_TOKEN. Because the producer runs from the PR head, its uploaded artifact must be treated as fully untrusted by the consumer.

Today the consumer extracts that artifact with plain unzip (which restores symlink entries as live symlinks) and then runs `aws s3 sync` without `--no-follow-symlinks`, so a crafted artifact containing symlinks can cause the deploy step to read through those links and publish their targets to the public preview URL. The privileged checkout also persists the token to `.git/config`, and the deploy job has no environment gate. This PR closes these gaps.


**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.