### PR TITLE
docs: add kubectl examples to inspect NodePools, EC2NodeClasses, and NodeClaims

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/_index.md
@@ -154,6 +154,19 @@ Note: This NodePool will create capacity as long as the sum of all created capac
 
 Karpenter is now active and ready to begin provisioning nodes.
 
+{{% alert title="Note" color="primary" %}}
+NodePools, EC2NodeClasses, and NodeClaims are standard Kubernetes custom resources. You can list and inspect them with `kubectl` the same way you would any other cluster resource:
+
+```bash
+kubectl get nodepools
+kubectl describe nodepool default
+kubectl get ec2nodeclasses
+kubectl describe ec2nodeclass default
+kubectl get nodeclaims
+kubectl describe nodeclaim <nodeclaim-name>
+```
+{{% /alert %}}
+
 ### 6. Scale up deployment
 
 This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-pause-container) and starts with zero replicas.

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -154,6 +154,19 @@ Note: This NodePool will create capacity as long as the sum of all created capac
 
 Karpenter is now active and ready to begin provisioning nodes.
 
+{{% alert title="Note" color="primary" %}}
+NodePools, EC2NodeClasses, and NodeClaims are standard Kubernetes custom resources. You can list and inspect them with `kubectl` the same way you would any other cluster resource:
+
+```bash
+kubectl get nodepools
+kubectl describe nodepool default
+kubectl get ec2nodeclasses
+kubectl describe ec2nodeclass default
+kubectl get nodeclaims
+kubectl describe nodeclaim <nodeclaim-name>
+```
+{{% /alert %}}
+
 ### 6. Scale up deployment
 
 This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-pause-container) and starts with zero replicas.

--- a/website/content/en/v1.0/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.0/getting-started/getting-started-with-karpenter/_index.md
@@ -162,6 +162,19 @@ Note: This NodePool will create capacity as long as the sum of all created capac
 
 Karpenter is now active and ready to begin provisioning nodes.
 
+{{% alert title="Note" color="primary" %}}
+NodePools, EC2NodeClasses, and NodeClaims are standard Kubernetes custom resources. You can list and inspect them with `kubectl` the same way you would any other cluster resource:
+
+```bash
+kubectl get nodepools
+kubectl describe nodepool default
+kubectl get ec2nodeclasses
+kubectl describe ec2nodeclass default
+kubectl get nodeclaims
+kubectl describe nodeclaim <nodeclaim-name>
+```
+{{% /alert %}}
+
 ### 6. Scale up deployment
 
 This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-pause-container) and starts with zero replicas.

--- a/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.12/getting-started/getting-started-with-karpenter/_index.md
@@ -154,6 +154,19 @@ Note: This NodePool will create capacity as long as the sum of all created capac
 
 Karpenter is now active and ready to begin provisioning nodes.
 
+{{% alert title="Note" color="primary" %}}
+NodePools, EC2NodeClasses, and NodeClaims are standard Kubernetes custom resources. You can list and inspect them with `kubectl` the same way you would any other cluster resource:
+
+```bash
+kubectl get nodepools
+kubectl describe nodepool default
+kubectl get ec2nodeclasses
+kubectl describe ec2nodeclass default
+kubectl get nodeclaims
+kubectl describe nodeclaim <nodeclaim-name>
+```
+{{% /alert %}}
+
 ### 6. Scale up deployment
 
 This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-pause-container) and starts with zero replicas.

--- a/website/content/en/v1.13/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.13/getting-started/getting-started-with-karpenter/_index.md
@@ -154,6 +154,19 @@ Note: This NodePool will create capacity as long as the sum of all created capac
 
 Karpenter is now active and ready to begin provisioning nodes.
 
+{{% alert title="Note" color="primary" %}}
+NodePools, EC2NodeClasses, and NodeClaims are standard Kubernetes custom resources. You can list and inspect them with `kubectl` the same way you would any other cluster resource:
+
+```bash
+kubectl get nodepools
+kubectl describe nodepool default
+kubectl get ec2nodeclasses
+kubectl describe ec2nodeclass default
+kubectl get nodeclaims
+kubectl describe nodeclaim <nodeclaim-name>
+```
+{{% /alert %}}
+
 ### 6. Scale up deployment
 
 This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-pause-container) and starts with zero replicas.

--- a/website/content/en/v1.14/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/v1.14/getting-started/getting-started-with-karpenter/_index.md
@@ -154,6 +154,19 @@ Note: This NodePool will create capacity as long as the sum of all created capac
 
 Karpenter is now active and ready to begin provisioning nodes.
 
+{{% alert title="Note" color="primary" %}}
+NodePools, EC2NodeClasses, and NodeClaims are standard Kubernetes custom resources. You can list and inspect them with `kubectl` the same way you would any other cluster resource:
+
+```bash
+kubectl get nodepools
+kubectl describe nodepool default
+kubectl get ec2nodeclasses
+kubectl describe ec2nodeclass default
+kubectl get nodeclaims
+kubectl describe nodeclaim <nodeclaim-name>
+```
+{{% /alert %}}
+
 ### 6. Scale up deployment
 
 This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-pause-container) and starts with zero replicas.


### PR DESCRIPTION
## Description

Fixes #5543

Users following Getting Started had no documented way to list/inspect the NodePools / EC2NodeClasses / NodeClaims they applied. As noted by @jmdeal, these are standard Kubernetes custom resources.

This adds a short Note callout immediately after the default NodePool/EC2NodeClass is applied in Getting Started, with `kubectl get` / `kubectl describe` examples for:

- NodePools
- EC2NodeClasses
- NodeClaims (Getting Started already had a `kubectl get nodeclaims` example in the optional Zonal Shift section; this makes NodePools and EC2NodeClasses explicit in the main flow too)

Applied to `website/content/en/docs/` (live site), `preview/`, and versioned docs (`v1.14`, `v1.13`, `v1.12`, `v1.0`) per the documentation contribution guide.

## How was this change tested?

- Docs-only change; verified the callout is inserted after "Create NodePool" and before "Scale up deployment" in each versioned Getting Started guide.
- Spot-checked existing NodeClaims coverage in concepts docs and the Zonal Shift section; this change complements that with NodePool/EC2NodeClass examples in the primary onboarding path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.